### PR TITLE
Fix buffer capacity off by one error

### DIFF
--- a/src/ring_buffer/mod.rs
+++ b/src/ring_buffer/mod.rs
@@ -76,7 +76,7 @@ where
     /// Returns the maximum number of elements the ring buffer can hold
     pub fn capacity(&self) -> usize {
         let buffer: &[T] = unsafe { self.buffer.as_ref() };
-        buffer.len() - 1
+        buffer.len()
     }
 
     /// Returns the item in the front of the queue, or `None` if the queue is empty


### PR DESCRIPTION
I was looking to implement a UART input buffer as a `RingBuffer`, and I ran into a surprising `panic` while stress testing the driver.

#### Here's a minimal reproduction of the `panic`:

```rust
use heapless::RingBuffer;

let mut test: RingBuffer<u8, [u8; 2]> = RingBuffer::new();

println!("Capacity = {}", test.capacity());

test.enqueue(1);
test.enqueue(2);

test.dequeue().expect("Expected data");
test.dequeue().expect("Expected data");
test.dequeue().expect("This is expected to panic");
```

The problem is that the `capacity()` method returns one less than it should.  The fix is pretty simple.

```diff
-        buffer.len() - 1
+        buffer.len()
```

#### Error

```
Capacity = 1

PANIC in [snip]
    Expected data
```

#### Here's the output with fix

```
Capacity = 2

PANIC in [snip]
    This is expected to panic
```