### PR TITLE
Implement FromIterator for Vec

### DIFF
--- a/src/vec.rs
+++ b/src/vec.rs
@@ -323,7 +323,7 @@ where
     {
         let mut vec = Vec::new();
         for i in iter {
-            vec.push(i).expect("Vec::from_iter overflow");
+            vec.push(i).ok().expect("Vec::from_iter overflow");
         }
         vec
     }

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -4,6 +4,8 @@ use generic_array::{ArrayLength, GenericArray};
 
 use __core::mem::{self, ManuallyDrop};
 
+use core::iter::FromIterator;
+
 /// A fixed capacity [`Vec`](https://doc.rust-lang.org/std/vec/struct.Vec.html)
 ///
 /// # Examples
@@ -310,6 +312,23 @@ where
     }
 }
 
+impl<T, N> FromIterator<T> for Vec<T, N>
+where
+    N: ArrayLength<T>,
+    T: fmt::Debug,
+{
+    fn from_iter<I>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = T>,
+    {
+        let mut vec = Vec::new();
+        for i in iter {
+            vec.push(i).unwrap();
+        }
+        vec
+    }
+}
+
 impl<A, B, N1, N2> PartialEq<Vec<B, N2>> for Vec<A, N1>
 where
     N1: ArrayLength<A>,
@@ -531,6 +550,20 @@ mod tests {
         assert_eq!(items.next(), Some(&mut 2));
         assert_eq!(items.next(), Some(&mut 3));
         assert_eq!(items.next(), None);
+    }
+
+    #[test]
+    fn collect_from_iter() {
+        let slice = &[1, 2, 3];
+        let vec = slice.iter().cloned().collect::<Vec<_, U4>>();
+        assert_eq!(vec, slice);
+    }
+
+    #[test]
+    #[should_panic]
+    fn collect_from_iter_overfull() {
+        let slice = &[1, 2, 3];
+        let _vec = slice.iter().cloned().collect::<Vec<_, U2>>();
     }
 
     #[test]

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -620,7 +620,6 @@ mod tests {
     }
 
     #[test]
-
     fn collect_from_iter() {
         let slice = &[1, 2, 3];
         let vec = slice.iter().cloned().collect::<Vec<_, U4>>();
@@ -634,6 +633,7 @@ mod tests {
         let _vec = slice.iter().cloned().collect::<Vec<_, U2>>();
     }
 
+    #[test]
     fn iter_move() {
         let mut v: Vec<i32, U4> = Vec::new();
         v.push(0).unwrap();

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -315,7 +315,6 @@ where
 impl<T, N> FromIterator<T> for Vec<T, N>
 where
     N: ArrayLength<T>,
-    T: fmt::Debug,
 {
     fn from_iter<I>(iter: I) -> Self
     where
@@ -323,7 +322,10 @@ where
     {
         let mut vec = Vec::new();
         for i in iter {
-            vec.push(i).unwrap();
+            match vec.push(i) {
+                Ok(()) => {},
+                Err(_) => panic!("Vec::from_iter overflow")
+            }
         }
         vec
     }

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -322,10 +322,7 @@ where
     {
         let mut vec = Vec::new();
         for i in iter {
-            match vec.push(i) {
-                Ok(()) => {},
-                Err(_) => panic!("Vec::from_iter overflow")
-            }
+            vec.push(i).expect("Vec::from_iter overflow");
         }
         vec
     }


### PR DESCRIPTION
As discussed in #36 

Panics when the vector can not hold all values supplied by the iterator.
Calling `unwrap` on the result might not be the best choice here.
It might be better to match the result and have a custom panic message.
Is this the best possible behavior?