### PR TITLE
Put all const functions behind a const-fn feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ repository = "https://github.com/japaric/heapless"
 version = "0.3.6"
 
 [features]
+default = ["const-fn"]
 const-fn = []
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,9 @@ name = "heapless"
 repository = "https://github.com/japaric/heapless"
 version = "0.3.6"
 
+[features]
+const-fn = []
+
 [dev-dependencies]
 scoped_threadpool = "0.1.8"
 

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -5,18 +5,18 @@ main() {
 
     if [ $TARGET = x86_64-unknown-linux-gnu ]; then
         cargo test --target $TARGET
-        cargo test --target $TARGET --all-features
+        cargo test --target $TARGET --no-default-features
         cargo test --target $TARGET --release
-        cargo test --target $TARGET --release --all-features
+        cargo test --target $TARGET --release --no-default-features
 
         export RUSTFLAGS="-Z sanitizer=thread"
         export RUST_TEST_THREADS=1
         export TSAN_OPTIONS="suppressions=$(pwd)/blacklist.txt"
 
         cargo test --test tsan --target $TARGET
-        cargo test --test tsan --target $TARGET --all-features
+        cargo test --test tsan --target $TARGET --no-default-features
         cargo test --test tsan --target $TARGET --release
-        cargo test --test tsan --target $TARGET --release --all-features
+        cargo test --test tsan --target $TARGET --release --no-default-features
     fi
 }
 

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -5,14 +5,18 @@ main() {
 
     if [ $TARGET = x86_64-unknown-linux-gnu ]; then
         cargo test --target $TARGET
+        cargo test --target $TARGET --all-features
         cargo test --target $TARGET --release
+        cargo test --target $TARGET --release --all-features
 
         export RUSTFLAGS="-Z sanitizer=thread"
         export RUST_TEST_THREADS=1
         export TSAN_OPTIONS="suppressions=$(pwd)/blacklist.txt"
 
         cargo test --test tsan --target $TARGET
+        cargo test --test tsan --target $TARGET --all-features
         cargo test --test tsan --target $TARGET --release
+        cargo test --test tsan --target $TARGET --release --all-features
     fi
 }
 

--- a/src/__core.rs
+++ b/src/__core.rs
@@ -47,3 +47,30 @@ pub mod mem {
         }
     );
 }
+
+#[cfg(feature = "const-fn")] // Remove this if there are more tests
+#[cfg(test)]
+mod test {
+    use __core;
+    use __core::mem::ManuallyDrop;
+    use core;
+
+    #[cfg(feature = "const-fn")]
+    #[test]
+    fn static_uninitzialized() {
+        static mut I: i32 = unsafe { __core::mem::uninitialized() };
+        // Initialize before drop
+        unsafe { core::ptr::write(&mut I as *mut i32, 42) };
+        unsafe{ assert_eq!(I, 42) };
+    }
+
+    #[cfg(feature = "const-fn")]
+    #[test]
+    fn static_new_manually_drop() {
+        static mut M: ManuallyDrop<i32> = ManuallyDrop::new(42);
+        unsafe { assert_eq!(*M, 42); }
+        // Drop before deinitialization
+        unsafe { core::ptr::drop_in_place(&mut M as &mut i32 as *mut i32) };
+    }
+
+}

--- a/src/__core.rs
+++ b/src/__core.rs
@@ -12,9 +12,11 @@ pub mod mem {
 
     impl<T> ManuallyDrop<T> {
         #[inline]
-        pub const fn new(value: T) -> ManuallyDrop<T> {
-            ManuallyDrop { value: value }
-        }
+        const_fn!(
+            pub const fn new(value: T) -> ManuallyDrop<T> {
+                ManuallyDrop { value: value }
+            }
+        );
     }
 
     impl<T> Deref for ManuallyDrop<T> {
@@ -33,13 +35,15 @@ pub mod mem {
         }
     }
 
-    pub const unsafe fn uninitialized<T>() -> T {
-        #[allow(unions_with_drop_fields)]
-        union U<T> {
-            none: (),
-            some: T,
-        }
+    const_fn!(
+        pub const unsafe fn uninitialized<T>() -> T {
+            #[allow(unions_with_drop_fields)]
+            union U<T> {
+                none: (),
+                some: T,
+            }
 
-        U { none: () }.some
-    }
+            U { none: () }.some
+        }
+    );
 }

--- a/src/binary_heap.rs
+++ b/src/binary_heap.rs
@@ -116,12 +116,14 @@ where
     /// let mut heap: BinaryHeap<_, U8, Max> = BinaryHeap::new();
     /// heap.push(4).unwrap();
     /// ```
-    pub const fn new() -> Self {
-        BinaryHeap {
-            _kind: PhantomData,
-            data: Vec::new(),
+    const_fn!(
+        pub const fn new() -> Self {
+            BinaryHeap {
+                _kind: PhantomData,
+                data: Vec::new(),
+            }
         }
-    }
+    );
 
     /* Public API */
     /// Returns the capacity of the binary heap.

--- a/src/binary_heap.rs
+++ b/src/binary_heap.rs
@@ -107,16 +107,17 @@ where
     K: Kind,
 {
     /* Constructors */
-    /// Creates an empty BinaryHeap as a $K-heap.
-    ///
-    /// ```
-    /// use heapless::binary_heap::{BinaryHeap, Max};
-    /// use heapless::consts::*;
-    ///
-    /// let mut heap: BinaryHeap<_, U8, Max> = BinaryHeap::new();
-    /// heap.push(4).unwrap();
-    /// ```
+
     const_fn!(
+        /// Creates an empty BinaryHeap as a $K-heap.
+        ///
+        /// ```
+        /// use heapless::binary_heap::{BinaryHeap, Max};
+        /// use heapless::consts::*;
+        ///
+        /// let mut heap: BinaryHeap<_, U8, Max> = BinaryHeap::new();
+        /// heap.push(4).unwrap();
+        /// ```
         pub const fn new() -> Self {
             BinaryHeap {
                 _kind: PhantomData,

--- a/src/binary_heap.rs
+++ b/src/binary_heap.rs
@@ -433,6 +433,12 @@ mod tests {
     use binary_heap::{self, BinaryHeap, Min};
     use consts::*;
 
+    #[cfg(feature = "const-fn")]
+    #[test]
+    fn static_new() {
+        static mut _B: BinaryHeap<i32, U16, Min> = BinaryHeap::new();
+    }
+
     #[test]
     fn min() {
         let mut heap = BinaryHeap::<_, U16, Min>::new();

--- a/src/const_fn.rs
+++ b/src/const_fn.rs
@@ -1,0 +1,32 @@
+#![allow(missing_docs)]
+macro_rules! const_fn {
+    ($(#[$attr:meta])* pub const unsafe fn $($f:tt)*) => (
+
+        $(#[$attr])*
+        #[cfg(feature = "const-fn")]
+        pub const unsafe fn $($f)*
+
+        $(#[$attr])*
+        #[cfg(not(feature = "const-fn"))]
+        pub unsafe fn $($f)*
+    );
+    ($(#[$attr:meta])* pub const fn $($f:tt)*) => (
+
+        $(#[$attr])*
+        #[cfg(feature = "const-fn")]
+        pub const fn $($f)*
+
+        $(#[$attr])*
+        #[cfg(not(feature = "const-fn"))]
+        pub fn $($f)*
+    );
+    ($(#[$attr:meta])* const fn $($f:tt)*) => (
+        $(#[$attr])*
+        #[cfg(feature = "const-fn")]
+        const fn $($f)*
+
+        $(#[$attr])*
+        #[cfg(not(feature = "const-fn"))]
+        fn $($f)*
+    );
+}

--- a/src/const_fn.rs
+++ b/src/const_fn.rs
@@ -1,4 +1,7 @@
-
+// Make functions `const` if the `const-fn` feature is active.
+// The meta attributes are in place to keep doc comments with the functions.
+// The function definition incl. annotations and doc comments must be enclodes
+// by the marco invocation.
 macro_rules! const_fn {
     ($(#[$attr:meta])* pub const unsafe fn $($f:tt)*) => (
 

--- a/src/const_fn.rs
+++ b/src/const_fn.rs
@@ -1,4 +1,4 @@
-#![allow(missing_docs)]
+
 macro_rules! const_fn {
     ($(#[$attr:meta])* pub const unsafe fn $($f:tt)*) => (
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@
 //! - [`Vec`](struct.Vec.html)
 
 #![allow(warnings)]
-//#![deny(missing_docs)]
+#![deny(missing_docs)]
 #![deny(warnings)]
 #![cfg_attr(feature = "const-fn", feature(const_fn))]
 #![feature(core_intrinsics)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,9 +49,9 @@
 //! - [`Vec`](struct.Vec.html)
 
 #![allow(warnings)]
-#![deny(missing_docs)]
+//#![deny(missing_docs)]
 #![deny(warnings)]
-#![feature(const_fn)]
+#![cfg_attr(feature = "const-fn", feature(const_fn))]
 #![feature(core_intrinsics)]
 #![feature(nonzero)]
 #![feature(untagged_unions)]
@@ -61,6 +61,9 @@ extern crate generic_array;
 extern crate hash32;
 #[cfg(test)]
 extern crate std;
+
+#[macro_use]
+mod const_fn;
 
 pub use binary_heap::BinaryHeap;
 pub use generic_array::typenum::consts;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,21 +8,6 @@
 //! via their type parameter `N`. This means that you can instantiate a `heapless` data structure on
 //! the stack, in a `static` variable, or even in the heap.
 //!
-//! There is a feature gate `const-fn` which enables the nightly `const_fn` feature.
-//! You can enable it in `Cargo.toml`.
-//!
-//! ```text
-//! # Cargo.toml
-//! ...
-//! [dependencies]
-//! heapless = { version = "0.4.0", features = ["const-fn"] }
-//! ...
-//!
-//! ```
-//! When enabled, you can use most `new` methods to initialize `static`
-//! variables at compile time.
-//!
-//!
 //! ```
 //! use heapless::Vec; // fixed capacity `std::Vec`
 //! use heapless::consts::U8; // type level integer used to specify capacity
@@ -38,9 +23,10 @@
 //! // work around
 //! static mut XS: Option<Vec<u8, U8>> = None;
 //! unsafe { XS = Some(Vec::new()) };
+//! let xs = unsafe { XS.as_mut().unwrap() };
 //!
-//! unsafe { XS.as_mut().unwrap().push(42) };
-//! unsafe { assert_eq!(XS.as_mut().unwrap().pop(), Some(42)) };
+//! xs.push(42);
+//! assert_eq!(xs.pop(), Some(42));
 //!
 //! // in the heap (though kind of pointless because no reallocation)
 //! let mut ys: Box<Vec<u8, U8>> = Box::new(Vec::new());
@@ -69,6 +55,29 @@
 //! queue
 //! - [`String`](struct.String.html)
 //! - [`Vec`](struct.Vec.html)
+//!
+//!
+//! In order to target the Rust stable toolchain, there are some feature gates.
+//! The features need to be enabled in `Cargo.toml` in order to use them.
+//! Once the underlaying features in Rust are stable,
+//! these feature gates might be activated by default.
+//!
+//! Example of `Cargo.toml`:
+//!
+//! ```text
+//! ...
+//! [dependencies]
+//! heapless = { version = "0.4.0", features = ["const-fn"] }
+//! ...
+//!
+//! ```
+//!
+//! Currently the following features are availbale and not active by default:
+//!
+//! - `"const-fn"` -- Enable the nightly `const_fn` feature and make most `new` methods `const`.
+//!      This way they can be used to initialize static memory at compile time.
+//!
+
 
 #![allow(warnings)]
 #![deny(missing_docs)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,21 @@
 //! via their type parameter `N`. This means that you can instantiate a `heapless` data structure on
 //! the stack, in a `static` variable, or even in the heap.
 //!
+//! There is a feature gate `const-fn` which enables the nightly `const_fn` feature.
+//! You can enable it in `Cargo.toml`.
+//!
+//! ```text
+//! # Cargo.toml
+//! ...
+//! [dependencies]
+//! heapless = { version = "0.4.0", features = ["const-fn"] }
+//! ...
+//!
+//! ```
+//! When enabled, you can use most `new` methods to initialize `static`
+//! variables at compile time.
+//!
+//!
 //! ```
 //! use heapless::Vec; // fixed capacity `std::Vec`
 //! use heapless::consts::U8; // type level integer used to specify capacity
@@ -18,7 +33,14 @@
 //! assert_eq!(xs.pop(), Some(42));
 //!
 //! // in a `static` variable
-//! static mut XS: Vec<u8, U8> = Vec::new();
+//! // static mut XS: Vec<u8, U8> = Vec::new(); // requires feature `const-fn`
+//!
+//! // work around
+//! static mut XS: Option<Vec<u8, U8>> = None;
+//! unsafe { XS = Some(Vec::new()) };
+//!
+//! unsafe { XS.as_mut().unwrap().push(42) };
+//! unsafe { assert_eq!(XS.as_mut().unwrap().pop(), Some(42)) };
 //!
 //! // in the heap (though kind of pointless because no reallocation)
 //! let mut ys: Box<Vec<u8, U8>> = Box::new(Vec::new());

--- a/src/linear_map.rs
+++ b/src/linear_map.rs
@@ -442,3 +442,18 @@ where
         self.iter.next().map(|&mut (ref k, ref mut v)| (k, v))
     }
 }
+
+
+#[cfg(feature = "const-fn")] // Remove this if there are more tests
+#[cfg(test)]
+mod test {
+    use consts::*;
+    use LinearMap;
+
+    #[cfg(feature = "const-fn")]
+    #[test]
+    fn static_new() {
+        static mut _L: LinearMap<i32, i32, U8>= LinearMap::new();
+    }
+
+}

--- a/src/linear_map.rs
+++ b/src/linear_map.rs
@@ -31,9 +31,11 @@ where
     ///
     /// let mut map: LinearMap<&str, isize, U8> = LinearMap::new();
     /// ```
-    pub const fn new() -> Self {
-        LinearMap { buffer: Vec::new() }
-    }
+    const_fn!(
+        pub const fn new() -> Self {
+            LinearMap { buffer: Vec::new() }
+        }
+    );
 
     /// Returns the number of elements that the map can hold
     ///

--- a/src/linear_map.rs
+++ b/src/linear_map.rs
@@ -21,17 +21,18 @@ where
     N: ArrayLength<(K, V)>,
     K: Eq,
 {
-    /// Creates an empty `LinearMap`
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use heapless::LinearMap;
-    /// use heapless::consts::*;
-    ///
-    /// let mut map: LinearMap<&str, isize, U8> = LinearMap::new();
-    /// ```
+
     const_fn!(
+        /// Creates an empty `LinearMap`
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use heapless::LinearMap;
+        /// use heapless::consts::*;
+        ///
+        /// let mut map: LinearMap<&str, isize, U8> = LinearMap::new();
+        /// ```
         pub const fn new() -> Self {
             LinearMap { buffer: Vec::new() }
         }

--- a/src/ring_buffer/mod.rs
+++ b/src/ring_buffer/mod.rs
@@ -61,11 +61,13 @@ impl<U> Atomic<U>
 where
     U: Uxx,
 {
-    const fn new(v: U) -> Atomic<U> {
-        Atomic {
-            v: UnsafeCell::new(v),
+    const_fn!(
+        const fn new(v: U) -> Atomic<U> {
+            Atomic {
+                v: UnsafeCell::new(v),
+            }
         }
-    }
+    );
 
     fn get_mut(&mut self) -> &mut U {
         unsafe { &mut *self.v.get() }
@@ -265,13 +267,15 @@ macro_rules! impl_ {
             Sum<N, U1>: ArrayLength<T>,
         {
             /// Creates an empty ring buffer with a fixed capacity of `N`
-            pub const fn $uxx() -> Self {
-                RingBuffer {
-                    buffer: ManuallyDrop::new(unsafe { mem::uninitialized() }),
-                    head: Atomic::new(0),
-                    tail: Atomic::new(0),
+            const_fn!(
+                pub const fn $uxx() -> Self {
+                    RingBuffer {
+                        buffer: ManuallyDrop::new(unsafe { mem::uninitialized() }),
+                        head: Atomic::new(0),
+                        tail: Atomic::new(0),
+                    }
                 }
-            }
+            );
 
             /// Returns the item in the front of the queue, or `None` if the queue is empty
             pub fn dequeue(&mut self) -> Option<T> {
@@ -350,9 +354,11 @@ where
     Sum<N, U1>: ArrayLength<T>,
 {
     /// Alias for [`RingBuffer::usize`](struct.RingBuffer.html#method.usize)
-    pub const fn new() -> Self {
-        RingBuffer::usize()
-    }
+    const_fn!(
+        pub const fn new() -> Self {
+            RingBuffer::usize()
+        }
+    );
 }
 
 impl_!(u8);

--- a/src/ring_buffer/mod.rs
+++ b/src/ring_buffer/mod.rs
@@ -445,6 +445,12 @@ mod tests {
     use consts::*;
     use RingBuffer;
 
+    #[cfg(feature = "const-fn")]
+    #[test]
+    fn static_new() {
+        static mut _R: RingBuffer<i32, U4> = RingBuffer::new();
+    }
+
     #[test]
     fn drop() {
         struct Droppable;

--- a/src/ring_buffer/mod.rs
+++ b/src/ring_buffer/mod.rs
@@ -118,13 +118,16 @@ where
 /// use heapless::RingBuffer;
 /// use heapless::consts::*;
 ///
-/// static mut RB: RingBuffer<Event, U4> = RingBuffer::new();
+/// // static mut RB: RingBuffer<Event, U4> = RingBuffer::new(); // requires feature `const-fn`
+///
+/// static mut RB: Option<RingBuffer<Event, U4>>  = None;
 ///
 /// enum Event { A, B }
 ///
 /// fn main() {
+///     unsafe { RB = Some(RingBuffer::new()) };
 ///     // NOTE(unsafe) beware of aliasing the `consumer` end point
-///     let mut consumer = unsafe { RB.split().1 };
+///     let mut consumer = unsafe { RB.as_mut().unwrap().split().1 };
 ///
 ///     loop {
 ///         // `dequeue` is a lockless operation
@@ -140,7 +143,7 @@ where
 /// // this is a different execution context that can preempt `main`
 /// fn interrupt_handler() {
 ///     // NOTE(unsafe) beware of aliasing the `producer` end point
-///     let mut producer = unsafe { RB.split().0 };
+///     let mut producer = unsafe { RB.as_mut().unwrap().split().0 };
 /// #   let condition = true;
 ///
 ///     // ..

--- a/src/ring_buffer/mod.rs
+++ b/src/ring_buffer/mod.rs
@@ -266,8 +266,9 @@ macro_rules! impl_ {
             N: Add<U1> + Unsigned,
             Sum<N, U1>: ArrayLength<T>,
         {
-            /// Creates an empty ring buffer with a fixed capacity of `N`
+
             const_fn!(
+                /// Creates an empty ring buffer with a fixed capacity of `N`
                 pub const fn $uxx() -> Self {
                     RingBuffer {
                         buffer: ManuallyDrop::new(unsafe { mem::uninitialized() }),
@@ -353,8 +354,9 @@ where
     N: Add<U1> + Unsigned,
     Sum<N, U1>: ArrayLength<T>,
 {
-    /// Alias for [`RingBuffer::usize`](struct.RingBuffer.html#method.usize)
+
     const_fn!(
+        /// Alias for [`RingBuffer::usize`](struct.RingBuffer.html#method.usize)
         pub const fn new() -> Self {
             RingBuffer::usize()
         }

--- a/src/ring_buffer/spsc.rs
+++ b/src/ring_buffer/spsc.rs
@@ -184,9 +184,9 @@ mod tests {
 
     #[test]
     fn sanity() {
-        static mut RB: RingBuffer<i32, U2> = RingBuffer::new();
+        let mut rb: RingBuffer<i32, U2> = RingBuffer::new();
 
-        let (mut p, mut c) = unsafe { RB.split() };
+        let (mut p, mut c) = rb.split();
 
         assert_eq!(c.dequeue(), None);
 

--- a/src/string.rs
+++ b/src/string.rs
@@ -17,20 +17,21 @@ impl<N> String<N>
 where
     N: ArrayLength<u8>,
 {
-    /// Constructs a new, empty `String` with a fixed capacity of `N`
-    ///
-    /// # Examples
-    ///
-    /// Basic usage:
-    ///
-    /// ```
-    /// use heapless::String;
-    /// use heapless::consts::*;
-    ///
-    /// let mut s: String<U4> = String::new();
-    /// ```
+
     #[inline]
     const_fn!(
+        /// Constructs a new, empty `String` with a fixed capacity of `N`
+        ///
+        /// # Examples
+        ///
+        /// Basic usage:
+        ///
+        /// ```
+        /// use heapless::String;
+        /// use heapless::consts::*;
+        ///
+        /// let mut s: String<U4> = String::new();
+        /// ```
         pub const fn new() -> Self {
             String { vec: Vec::new() }
         }

--- a/src/string.rs
+++ b/src/string.rs
@@ -30,9 +30,11 @@ where
     /// let mut s: String<U4> = String::new();
     /// ```
     #[inline]
-    pub const fn new() -> Self {
-        String { vec: Vec::new() }
-    }
+    const_fn!(
+        pub const fn new() -> Self {
+            String { vec: Vec::new() }
+        }
+    );
 
     /// Converts a vector of bytes into a `String`.
     ///

--- a/src/string.rs
+++ b/src/string.rs
@@ -524,6 +524,12 @@ mod tests {
     use consts::*;
     use {String, Vec};
 
+    #[cfg(feature = "const-fn")]
+    #[test]
+    fn static_new() {
+        static mut _S: String<U8> = String::new();
+    }
+
     #[test]
     fn debug() {
         extern crate std;

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -514,6 +514,12 @@ mod tests {
     use consts::*;
     use Vec;
 
+    #[cfg(feature = "const-fn")]
+    #[test]
+    fn static_new() {
+        static mut _V: Vec<i32, U4> = Vec::new();
+    }
+
     macro_rules! droppable {
         () => (
             struct Droppable;

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -49,12 +49,14 @@ where
 {
     /* Constructors */
     /// Constructs a new, empty vector with a fixed capacity of `N`
-    pub const fn new() -> Self {
-        Vec {
-            buffer: ManuallyDrop::new(unsafe { mem::uninitialized() }),
-            len: 0,
+    const_fn!(
+        pub const fn new() -> Self {
+            Vec {
+                buffer: ManuallyDrop::new(unsafe { mem::uninitialized() }),
+                len: 0,
+            }
         }
-    }
+    );
 
     /* Public API */
     /// Returns the maximum number of elements the vector can hold

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -48,8 +48,8 @@ where
     N: ArrayLength<T>,
 {
     /* Constructors */
-    /// Constructs a new, empty vector with a fixed capacity of `N`
     const_fn!(
+        /// Constructs a new, empty vector with a fixed capacity of `N`
         pub const fn new() -> Self {
             Vec {
                 buffer: ManuallyDrop::new(unsafe { mem::uninitialized() }),

--- a/tests/tsan.rs
+++ b/tests/tsan.rs
@@ -4,6 +4,7 @@ extern crate generic_array;
 extern crate heapless;
 extern crate scoped_threadpool;
 
+#[cfg(feature = "const-fn")]
 use std::thread;
 
 use generic_array::typenum::Unsigned;

--- a/tests/tsan.rs
+++ b/tests/tsan.rs
@@ -4,7 +4,6 @@ extern crate generic_array;
 extern crate heapless;
 extern crate scoped_threadpool;
 
-#[cfg(feature = "const-fn")]
 use std::thread;
 
 use generic_array::typenum::Unsigned;
@@ -12,12 +11,12 @@ use heapless::consts::*;
 use heapless::RingBuffer;
 use scoped_threadpool::Pool;
 
-#[cfg(feature = "const-fn")]
 #[test]
 fn once() {
-    static mut RB: RingBuffer<i32, U4> = RingBuffer::new();
+    static mut RB: Option<RingBuffer<i32, U4>> = None;
+    unsafe{ RB = Some(RingBuffer::new()) };
 
-    let rb = unsafe { &mut RB };
+    let rb = unsafe { RB.as_mut().unwrap() };
 
     rb.enqueue(0).unwrap();
 
@@ -34,12 +33,12 @@ fn once() {
     });
 }
 
-#[cfg(feature = "const-fn")]
 #[test]
 fn twice() {
-    static mut RB: RingBuffer<i32, U8> = RingBuffer::new();
+    static mut RB: Option<RingBuffer<i32, U4>> = None;
+    unsafe{ RB = Some(RingBuffer::new()) };
 
-    let rb = unsafe { &mut RB };
+    let rb = unsafe { RB.as_mut().unwrap() };
 
     rb.enqueue(0).unwrap();
     rb.enqueue(1).unwrap();

--- a/tests/tsan.rs
+++ b/tests/tsan.rs
@@ -11,6 +11,7 @@ use heapless::consts::*;
 use heapless::RingBuffer;
 use scoped_threadpool::Pool;
 
+#[cfg(feature = "const-fn")]
 #[test]
 fn once() {
     static mut RB: RingBuffer<i32, U4> = RingBuffer::new();
@@ -32,6 +33,7 @@ fn once() {
     });
 }
 
+#[cfg(feature = "const-fn")]
 #[test]
 fn twice() {
     static mut RB: RingBuffer<i32, U8> = RingBuffer::new();


### PR DESCRIPTION
## Purpose
This PR introduces the `const-fn` feature gate, which when enabled makes most `new` methods `const` 
and therefore usable for initializing `static` variables.
The idea was introduced in #40 with the purpose to come closer to targeting stable rust.
`const` functions are currently only available on rust nightly (tracking issue: [const fn tracking issue (RFC 911)](https://github.com/rust-lang/rust/issues/24111)).
In order to target stable rust this feature is made opt-in.

This feature is a **breaking change** as users of the library now need to explicitly enable it by changing their `Cargo.toml`:
```
...
[dependencies]
heapless = { version = "0.4.0", features = ["const-fn"] }
...
```



## Approach
The implementation of the feature mainly consist of the `const_fn!` macro, which takes a function with `const` modifier
and removes the modifier if the feature gate is not activated.
For the `const` functions a test is intoduced that checks if `static` variables can be initialized.
These tests are only active if the feature is active.
I have not found a way to make doc-test depend on a feature. Therefore some doc-tests are adapted, so that no static initialization is necessary.
The `ci/script.sh` is adapted to also tests with the `--all-feature` flag

## Future
When in the future the `const_fn` rust feature becomes stable, this feature gate **might become active by default**.


Closes #41 .