### PR TITLE
Added Consumer::ready and Producer::ready indicating if it is ready t…

### DIFF
--- a/src/ring_buffer/mod.rs
+++ b/src/ring_buffer/mod.rs
@@ -556,4 +556,32 @@ mod tests {
 
         assert_eq!(rb.len(), 2);
     }
+
+    #[test]
+    fn ready_flag() {
+        let mut rb: RingBuffer<i32, U2> = RingBuffer::new();
+        let (mut p, mut c) = rb.split();
+        assert_eq!(c.ready(), false);
+        assert_eq!(p.ready(), true);
+
+        p.enqueue(0).unwrap();
+
+        assert_eq!(c.ready(), true);
+        assert_eq!(p.ready(), true);
+
+        p.enqueue(1).unwrap();
+
+        assert_eq!(c.ready(), true);
+        assert_eq!(p.ready(), false);
+
+        c.dequeue().unwrap();
+
+        assert_eq!(c.ready(), true);
+        assert_eq!(p.ready(), true);
+
+        c.dequeue().unwrap();
+
+        assert_eq!(c.ready(), false);
+        assert_eq!(p.ready(), true);
+    }
 }


### PR DESCRIPTION
…o enqueue/dequeue.

I needed this to use it with a serial library. e.g. without it:
```
if let Some(x) = serial.read() {
if let Err(x) = producer.enqueue(x) {
// Now what ?
}
}
```
With the ready flag:
```
if producer.ready() {
if let Some(x) = serial.read() {
producer.enqueue(x).unwrap();
}
}
```