### PR TITLE
RingBuffer: put smaller atomic indices behind a Cargo feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,9 @@ repository = "https://github.com/japaric/heapless"
 version = "0.3.6"
 
 [features]
-default = ["const-fn"]
+default = ["const-fn", "smaller-atomics"]
 const-fn = []
+smaller-atomics = []
 
 [dev-dependencies]
 scoped_threadpool = "0.1.8"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@
 #![deny(missing_docs)]
 #![deny(warnings)]
 #![cfg_attr(feature = "const-fn", feature(const_fn))]
-#![feature(core_intrinsics)]
+#![cfg_attr(feature = "smaller-atomics", feature(core_intrinsics))]
 #![feature(untagged_unions)]
 #![no_std]
 

--- a/src/ring_buffer/mod.rs
+++ b/src/ring_buffer/mod.rs
@@ -19,7 +19,7 @@ mod spsc;
 /// Types that can be used as `RingBuffer` indices: `u8`, `u16` and `usize
 ///
 /// This trait is sealed and cannot be implemented outside of `heapless`.
-pub unsafe trait Uxx: Into<usize> + Send {
+pub unsafe trait Uxx: Into<usize> + Send + private::Sealed {
     #[doc(hidden)]
     fn truncate(x: usize) -> Self;
 
@@ -52,6 +52,16 @@ pub unsafe trait Uxx: Into<usize> + Send {
     #[cfg(not(feature = "smaller-atomics"))]
     #[doc(hidden)]
     fn store_release(x: *mut Self, val: Self);
+}
+
+mod private {
+    pub trait Sealed {}
+
+    impl Sealed for usize {}
+    #[cfg(feature = "smaller-atomics")]
+    impl Sealed for u8 {}
+    #[cfg(feature = "smaller-atomics")]
+    impl Sealed for u16 {}
 }
 
 #[cfg(feature = "smaller-atomics")]

--- a/src/ring_buffer/spsc.rs
+++ b/src/ring_buffer/spsc.rs
@@ -196,7 +196,9 @@ macro_rules! impl_ {
     };
 }
 
+#[cfg(feature = "smaller-atomics")]
 impl_!(u8);
+#[cfg(feature = "smaller-atomics")]
 impl_!(u16);
 impl_!(usize);
 


### PR DESCRIPTION
cc #40