### PR TITLE
Fix broken nightly: Const fn union workaround

### DIFF
--- a/src/__core.rs
+++ b/src/__core.rs
@@ -1,18 +1,20 @@
 /// Temporary fork of some stuff in `core` that's doesn't have a `const fn` API
 
 pub mod mem {
-    pub use core::mem::{replace, zeroed, ManuallyDrop};
+    pub use core::mem::{replace, zeroed, ManuallyDrop, uninitialized};
     use core::ops::{Deref, DerefMut};
 
 
     /// extremely unsafe uniniatilized memory
     /// only use with ManuallyDrop
     #[allow(unions_with_drop_fields)]
+    #[cfg(feature = "const-fn")]
     pub(crate) union Uninit<T> {
         uninit: (),
         init: T,
     }
 
+    #[cfg(feature = "const-fn")]
     impl<T> Uninit<T> {
         const_fn!(
             pub const unsafe fn new() -> Self {
@@ -23,6 +25,7 @@ pub mod mem {
         );
     }
 
+    #[cfg(feature = "const-fn")]
     impl<T> Deref for Uninit<T> {
         type Target = T;
         fn deref(&self) -> &T {
@@ -30,11 +33,40 @@ pub mod mem {
         }
     }
 
+    #[cfg(feature = "const-fn")]
     impl<T> DerefMut for Uninit<T> {
         fn deref_mut(&mut self) -> &mut T {
             unsafe { &mut self.init }
         }
     }
+
+    /// extremely unsafe uniniatilized memory
+    /// only use with ManuallyDrop
+    #[cfg(not(feature = "const-fn"))]
+    pub(crate) struct Uninit<T>(T);
+
+    #[cfg(not(feature = "const-fn"))]
+    impl<T> Uninit<T> {
+        pub unsafe fn new() -> Self {
+            Uninit(uninitialized())
+        }
+    }
+
+    #[cfg(not(feature = "const-fn"))]
+    impl<T> Deref for Uninit<T> {
+        type Target = T;
+        fn deref(&self) -> &T {
+            &self.0
+        }
+    }
+
+    #[cfg(not(feature = "const-fn"))]
+    impl<T> DerefMut for Uninit<T> {
+        fn deref_mut(&mut self) -> &mut T {
+            &mut self.0
+        }
+    }
+
 
 }
 

--- a/src/__core.rs
+++ b/src/__core.rs
@@ -8,7 +8,6 @@ pub mod mem {
     /// extremely unsafe uniniatilized memory
     /// only use with ManuallyDrop
     #[allow(unions_with_drop_fields)]
-    #[cfg(feature = "const-fn")]
     pub(crate) union Uninit<T> {
         uninit: (),
         init: T,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,7 @@
 #![cfg_attr(feature = "const-fn", feature(const_fn))]
 #![cfg_attr(feature = "const-fn", feature(const_manually_drop_new))]
 #![cfg_attr(feature = "const-fn", feature(untagged_unions))]
+#![cfg_attr(feature = "const-fn", feature(const_fn_union))]
 #![cfg_attr(feature = "smaller-atomics", feature(core_intrinsics))]
 #![no_std]
 

--- a/src/ring_buffer/mod.rs
+++ b/src/ring_buffer/mod.rs
@@ -7,12 +7,13 @@ use core::ops::Add;
 use core::ptr;
 #[cfg(not(feature = "smaller-atomics"))]
 use core::sync::atomic::{AtomicUsize, Ordering};
+use __core::mem::Uninit;
 
 use generic_array::typenum::{Sum, U1, Unsigned};
 use generic_array::{ArrayLength, GenericArray};
 
 pub use self::spsc::{Consumer, Producer};
-use __core::mem::{self, ManuallyDrop};
+use __core::mem::{ManuallyDrop};
 
 mod spsc;
 
@@ -230,7 +231,7 @@ where
     // this is where we enqueue new items
     tail: Atomic<U>,
 
-    buffer: ManuallyDrop<GenericArray<T, Sum<N, U1>>>,
+    buffer: ManuallyDrop<Uninit<GenericArray<T, Sum<N, U1>>>>,
 }
 
 impl<T, N, U> RingBuffer<T, N, U>
@@ -334,7 +335,7 @@ macro_rules! impl_ {
                 /// Creates an empty ring buffer with a fixed capacity of `N`
                 pub const fn $uxx() -> Self {
                     RingBuffer {
-                        buffer: ManuallyDrop::new(unsafe { mem::uninitialized() }),
+                        buffer: ManuallyDrop::new(unsafe { Uninit::new() }),
                         head: Atomic::new(0),
                         tail: Atomic::new(0),
                     }

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -2,7 +2,7 @@ use core::{fmt, ops, ptr, slice};
 
 use generic_array::{ArrayLength, GenericArray};
 
-use __core::mem::{self, ManuallyDrop};
+use __core::mem::{ManuallyDrop, Uninit};
 
 use core::iter::FromIterator;
 
@@ -39,7 +39,7 @@ pub struct Vec<T, N>
 where
     N: ArrayLength<T>,
 {
-    buffer: ManuallyDrop<GenericArray<T, N>>,
+    buffer: ManuallyDrop<Uninit<GenericArray<T, N>>>,
     len: usize,
 }
 
@@ -52,7 +52,7 @@ where
         /// Constructs a new, empty vector with a fixed capacity of `N`
         pub const fn new() -> Self {
             Vec {
-                buffer: ManuallyDrop::new(unsafe { mem::uninitialized() }),
+                buffer: ManuallyDrop::new(unsafe { Uninit::new() }),
                 len: 0,
             }
         }


### PR DESCRIPTION
This PR fixes the latest issues with the nightly build.
It is a follow up to #51 

Instead of using a const fn version of `mem::uninitialized`, an `ManuallyDrop<Uninit<T>>` wrapper is used.
The Uninit struct implements Deref T. This code is extreme unsafe, beware of dragons.

However the tests seem to pass, so at least the workaround seems to work.
