### PR TITLE
[WIP] Implement serde::Deserialize for Vec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ version = "0.4.0"
 [features]
 const-fn = []
 smaller-atomics = []
+with-serde = ["serde"]
 
 [dev-dependencies]
 scoped_threadpool = "0.1.8"
@@ -28,3 +29,5 @@ scoped_threadpool = "0.1.8"
 [dependencies]
 generic-array = "0.11.0"
 hash32 = "0.1.0"
+
+serde = { version = "1", optional = true, default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,9 @@ extern crate hash32;
 #[cfg(test)]
 extern crate std;
 
+#[cfg(feature = "with-serde")]
+extern crate serde;
+
 #[macro_use]
 mod const_fn;
 


### PR DESCRIPTION
This is a first working branch that implements serde's Deserialize for `heapless::Vec`, and would (if completed) close https://github.com/japaric/heapless/issues/58.

I'm unsure when I'll find the time to complete this (a full solution would at least include tests, implementations of Serialize and Deserialize for Vec and String; in-place would be nice too). It is still published at this early stage in the hope that anyone joining this effort (@sanmai-NL?) might find it a useful starting point.