### PR TITLE
Implement Debug for `Queue`, `LinearMap` and `BinaryHeap`

### DIFF
--- a/src/binary_heap.rs
+++ b/src/binary_heap.rs
@@ -11,7 +11,7 @@
 use core::cmp::Ordering;
 use core::marker::PhantomData;
 use core::mem::ManuallyDrop;
-use core::{mem, ptr, slice};
+use core::{mem, ptr, slice, fmt};
 
 use generic_array::ArrayLength;
 
@@ -409,6 +409,17 @@ impl<'a, T> Drop for Hole<'a, T> {
             let pos = self.pos;
             ptr::write(self.data.get_unchecked_mut(pos), ptr::read(&*self.elt));
         }
+    }
+}
+
+impl<T, N, K> fmt::Debug for BinaryHeap<T, N, K>
+where
+    N: ArrayLength<T>,
+    K: Kind,
+    T: Ord + fmt::Debug
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_list().entries(self.iter()).finish()
     }
 }
 

--- a/src/linear_map.rs
+++ b/src/linear_map.rs
@@ -1,5 +1,5 @@
 use core::borrow::Borrow;
-use core::{mem, ops, slice};
+use core::{mem, ops, slice, fmt};
 
 use generic_array::ArrayLength;
 
@@ -387,6 +387,17 @@ where
 {
     fn index_mut(&mut self, key: &Q) -> &mut V {
         self.get_mut(key).expect("no entry found for key")
+    }
+}
+
+impl<K, V, N> fmt::Debug for LinearMap<K, V, N>
+where
+    N: ArrayLength<(K, V)>,
+    K: Eq + fmt::Debug,
+    V: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_map().entries(self.iter()).finish()
     }
 }
 

--- a/src/spsc/mod.rs
+++ b/src/spsc/mod.rs
@@ -2,7 +2,7 @@
 
 use core::cell::UnsafeCell;
 use core::marker::PhantomData;
-use core::ptr;
+use core::{ptr, fmt};
 
 use generic_array::{ArrayLength, GenericArray};
 
@@ -213,6 +213,18 @@ where
                 ptr::drop_in_place(item);
             }
         }
+    }
+}
+
+impl<T, N, U, C> fmt::Debug for Queue<T, N, U, C>
+where
+    N: ArrayLength<T>,
+    T: fmt::Debug,
+    U: sealed::Uxx,
+    C: sealed::XCore,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_list().entries(self.iter()).finish()
     }
 }
 


### PR DESCRIPTION

# Description
As pointed out in #56 the `fmt::Debug` implementation for those types is missing.
This PR implements them by passing their respective `Iterator` to the formatter.

# Open Questions
- Should `Debug` also be implemented for `spsc::Consumer` and `spsc::Producer`?
- Should the implementation for `BinaryHeap` respect the priority of the items in the heap?
