### PR TITLE
Draft: CapacityError with failure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,8 @@ hash32 = "0.1.0"
 version = "1"
 optional = true
 default-features = false
+
+[dependencies.failure]
+version = "0.1.5"
+default-features = false
+features = ["derive"]

--- a/src/binary_heap.rs
+++ b/src/binary_heap.rs
@@ -16,6 +16,7 @@ use core::{mem, ptr, slice, fmt};
 use generic_array::ArrayLength;
 
 use Vec;
+use errors::CapacityError;
 
 /// Min-heap
 pub enum Min {}
@@ -286,9 +287,13 @@ where
     /// assert_eq!(heap.len(), 3);
     /// assert_eq!(heap.peek(), Some(&5));
     /// ```
-    pub fn push(&mut self, item: T) -> Result<(), T> {
+    pub fn push(&mut self, item: T) -> Result<(), (T, CapacityError)> {
         if self.data.is_full() {
-            return Err(item);
+            let err = (item, CapacityError {
+                maximum: self.capacity(),
+                encountered: self.capacity() + 1
+            });
+            return Err(err);
         }
 
         unsafe { self.push_unchecked(item) }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,31 +1,10 @@
-use core::fmt;
-#[cfg(feature = "std")]
-use std::error::Error;
-
-const CAPERROR: &'static str = "insufficient capacity";
-
 /// Capacity error returned when container's capacity is not enough to complete the operation
-#[derive(Debug, PartialEq)]
-pub struct CapacityError {
+#[derive(Fail, Debug, PartialEq, Eq)]
+#[fail(display= "Insufficient capacity: maximum {}, encountered {}", maximum, encountered)]
+pub struct CapacityError
+{
     /// Maximum characters allowed
     pub maximum: usize,
     /// Encountered number of characters
     pub encountered: usize,
-}
-
-#[cfg(feature = "std")]
-impl Error for CapacityError {
-    fn description(&self) -> &str {
-        CAPERROR
-    }
-}
-
-impl fmt::Display for CapacityError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "{}: maximum {}, encountered {}",
-            CAPERROR, self.maximum, self.encountered
-        )
-    }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,31 @@
+use core::fmt;
+#[cfg(feature = "std")]
+use std::error::Error;
+
+const CAPERROR: &'static str = "insufficient capacity";
+
+/// Capacity error returned when container's capacity is not enough to complete the operation
+#[derive(Debug, PartialEq)]
+pub struct CapacityError {
+    /// Maximum characters allowed
+    pub maximum: usize,
+    /// Encountered number of characters
+    pub encountered: usize,
+}
+
+#[cfg(feature = "std")]
+impl Error for CapacityError {
+    fn description(&self) -> &str {
+        CAPERROR
+    }
+}
+
+impl fmt::Display for CapacityError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{}: maximum {}, encountered {}",
+            CAPERROR, self.maximum, self.encountered
+        )
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,8 +92,14 @@
 
 extern crate generic_array;
 extern crate hash32;
+#[macro_use]
+extern crate failure;
+
+
+
 #[cfg(test)]
 extern crate std;
+
 
 #[cfg(feature = "serde")]
 extern crate serde;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,6 +102,7 @@ extern crate serde;
 mod const_fn;
 
 pub use binary_heap::BinaryHeap;
+pub use errors::*;
 pub use generic_array::typenum::consts;
 pub use generic_array::ArrayLength;
 pub use indexmap::{FnvIndexMap, IndexMap};
@@ -111,6 +112,7 @@ pub use string::String;
 pub use vec::Vec;
 
 mod cfail;
+mod errors;
 mod indexmap;
 mod indexset;
 mod linear_map;

--- a/src/linear_map.rs
+++ b/src/linear_map.rs
@@ -5,6 +5,7 @@ use core::iter::FromIterator;
 use generic_array::ArrayLength;
 
 use Vec;
+use errors::CapacityError;
 
 /// A fixed capacity map / dictionary that performs lookups via linear search
 ///
@@ -186,7 +187,7 @@ where
     /// assert_eq!(map.insert(37, "c").unwrap(), Some("b"));
     /// assert_eq!(map[&37], "c");
     /// ```
-    pub fn insert(&mut self, key: K, mut value: V) -> Result<Option<V>, (K, V)> {
+    pub fn insert(&mut self, key: K, mut value: V) -> Result<Option<V>, ((K, V), CapacityError)> {
         if let Some((_, v)) = self.iter_mut().find(|&(k, _)| *k == key) {
             mem::swap(v, &mut value);
             return Ok(Some(value));

--- a/src/spsc/split.rs
+++ b/src/spsc/split.rs
@@ -5,6 +5,7 @@ use generic_array::ArrayLength;
 
 use sealed;
 use spsc::{MultiCore, Queue};
+use errors::CapacityError;
 
 impl<T, N, U, C> Queue<T, N, U, C>
 where
@@ -141,7 +142,7 @@ macro_rules! impl_ {
             /// Adds an `item` to the end of the queue
             ///
             /// Returns back the `item` if the queue is full
-            pub fn enqueue(&mut self, item: T) -> Result<(), T> {
+            pub fn enqueue(&mut self, item: T) -> Result<(), (T, CapacityError)> {
                 let cap = unsafe { self.rb.as_ref().capacity() };
                 let tail = unsafe { self.rb.as_ref().tail.load_relaxed() };
                 // NOTE we could replace this `load_acquire` with a `load_relaxed` and this method
@@ -152,7 +153,11 @@ macro_rules! impl_ {
                 let head = unsafe { self.rb.as_ref().head.load_acquire() }; // ▼
 
                 if tail.wrapping_sub(head) > cap - 1 {
-                    Err(item)
+                    let err = unsafe { (item, CapacityError {
+                        maximum: self.rb.as_ref().capacity_usize() - 1,
+                        encountered: self.rb.as_ref().capacity_usize()
+                    }) };
+                    Err(err)
                 } else {
                     unsafe { self._enqueue(tail, item) }; // ▲
                     Ok(())

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -4,6 +4,7 @@ use generic_array::{ArrayLength, GenericArray};
 use hash32;
 
 use __core::mem::MaybeUninit;
+use errors::CapacityError;
 
 use core::hash;
 use core::iter::FromIterator;
@@ -99,13 +100,18 @@ where
     /// vec.extend_from_slice(&[2, 3, 4]).unwrap();
     /// assert_eq!(*vec, [1, 2, 3, 4]);
     /// ```
-    pub fn extend_from_slice(&mut self, other: &[T]) -> Result<(), ()>
+    pub fn extend_from_slice(&mut self, other: &[T]) -> Result<(), CapacityError>
     where
         T: Clone,
     {
-        if self.len() + other.len() > self.capacity() {
+        let encountered = self.len() + other.len();
+
+        if encountered > self.capacity() {
             // won't fit in the `Vec`; don't modify anything and return an error
-            Err(())
+            Err(CapacityError {
+                maximum: self.capacity(),
+                encountered,
+            })
         } else {
             for elem in other {
                 self.push(elem.clone()).ok();

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -142,12 +142,16 @@ where
     /// Appends an `item` to the back of the collection
     ///
     /// Returns back the `item` if the vector is full
-    pub fn push(&mut self, item: T) -> Result<(), T> {
+    pub fn push(&mut self, item: T) -> Result<(), (T, CapacityError)> {
         if self.len < self.capacity() {
             unsafe { self.push_unchecked(item) }
             Ok(())
         } else {
-            Err(item)
+            let err = (item, CapacityError {
+                maximum: self.capacity(),
+                encountered: self.capacity() + 1
+            });
+            Err(err)
         }
     }
 
@@ -181,12 +185,15 @@ where
     /// new_len is less than len, the Vec is simply truncated.
     ///
     /// See also [`resize_default`](struct.Vec.html#method.resize_default).
-    pub fn resize(&mut self, new_len: usize, value: T) -> Result<(), ()>
+    pub fn resize(&mut self, new_len: usize, value: T) -> Result<(), CapacityError>
     where
         T: Clone,
     {
         if new_len > self.capacity() {
-            return Err(());
+            return Err(CapacityError {
+                maximum: self.capacity(),
+                encountered: new_len,
+            });
         }
 
         if new_len > self.len {
@@ -207,7 +214,7 @@ where
     /// If `new_len` is less than `len`, the `Vec` is simply truncated.
     ///
     /// See also [`resize`](struct.Vec.html#method.resize).
-    pub fn resize_default(&mut self, new_len: usize) -> Result<(), ()>
+    pub fn resize_default(&mut self, new_len: usize) -> Result<(), CapacityError>
     where
         T: Clone + Default,
     {


### PR DESCRIPTION
Lets have a discussion about how Errors might be handeled in 0.5.x

I think going with failure is more resonable, especially since it supports `no-std`.

The biggest open question I have is: How do we handle operations that failed inserting an element?
It might be desirable to get the element back, in order to do something with it, (e.g., place it in another buffer). However putting this element into the CapacityError is not going to work because the element would need to implement `Send + Sync`.

What are your opinions on this?
@vorot93 @japaric 

ref #76 