### PR TITLE
CapacityError and CapacityResult with Failure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,8 @@ hash32 = "0.1.0"
 version = "1"
 optional = true
 default-features = false
+
+[dependencies.failure]
+version = "0.1.5"
+default-features = false
+features = ["derive"]

--- a/src/binary_heap.rs
+++ b/src/binary_heap.rs
@@ -294,7 +294,7 @@ where
         }
 
         unsafe { self.push_unchecked(item) }
-        CapacityResult::ok()
+        CapacityResult::ok(())
     }
 
     /// Pushes an item onto the binary heap without first checking if it's full.

--- a/src/binary_heap.rs
+++ b/src/binary_heap.rs
@@ -288,7 +288,7 @@ where
     /// assert_eq!(heap.len(), 3);
     /// assert_eq!(heap.peek(), Some(&5));
     /// ```
-    pub fn push(&mut self, item: T) -> CapacityResult<T> {
+    pub fn push(&mut self, item: T) -> CapacityResult<(), T> {
         if self.data.is_full() {
             return CapacityResult::err(item, CapacityError::one_more_than(self.capacity()))
         }

--- a/src/binary_heap.rs
+++ b/src/binary_heap.rs
@@ -16,6 +16,7 @@ use core::{mem, ptr, slice, fmt};
 use generic_array::ArrayLength;
 
 use Vec;
+use errors::CapacityError;
 
 /// Min-heap
 pub enum Min {}
@@ -286,9 +287,13 @@ where
     /// assert_eq!(heap.len(), 3);
     /// assert_eq!(heap.peek(), Some(&5));
     /// ```
-    pub fn push(&mut self, item: T) -> Result<(), T> {
+    pub fn push(&mut self, item: T) -> Result<(), (T, CapacityError)> {
         if self.data.is_full() {
-            return Err(item);
+            let err = (item, CapacityError {
+                maximum: self.capacity(),
+                encountered: self.capacity() + 1
+            });
+            return Err(err);
         }
 
         unsafe { self.push_unchecked(item) }

--- a/src/binary_heap.rs
+++ b/src/binary_heap.rs
@@ -16,7 +16,8 @@ use core::{mem, ptr, slice, fmt};
 use generic_array::ArrayLength;
 
 use Vec;
-use errors::CapacityError;
+use CapacityError;
+use CapacityResult;
 
 /// Min-heap
 pub enum Min {}
@@ -287,17 +288,13 @@ where
     /// assert_eq!(heap.len(), 3);
     /// assert_eq!(heap.peek(), Some(&5));
     /// ```
-    pub fn push(&mut self, item: T) -> Result<(), (T, CapacityError)> {
+    pub fn push(&mut self, item: T) -> CapacityResult<T> {
         if self.data.is_full() {
-            let err = (item, CapacityError {
-                maximum: self.capacity(),
-                encountered: self.capacity() + 1
-            });
-            return Err(err);
+            return CapacityResult::err(item, CapacityError::one_more_than(self.capacity()))
         }
 
         unsafe { self.push_unchecked(item) }
-        Ok(())
+        CapacityResult::ok()
     }
 
     /// Pushes an item onto the binary heap without first checking if it's full.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -31,10 +31,22 @@ impl CapacityError {
 
 }
 
-/// Result returned from insertion operation
-/// Generic over the rest of the data, that cound not be inserted
+/// Result returned from insertion operation.
+/// The insertion operation can either succeed
+/// or fail due to an capacity overflow.
+///
+/// If the operation suceeded, the result is ok,
+/// containing an value of thype `T`.
+/// For many insert operation this value is `()`,
+/// however if the insertion replaced an existing value in an collection,
+/// the return value might be `Some(replaced_value)`.
+///
+/// If the operation failed fue to an capacity overflow,
+/// this result contains two pieces of data
+///   - an `CapacityError`, which describes by how for the capacity was exceeded
+///   - an `rest` of type `R`, which is the rest of the data, that could not be inserted.
 #[derive(Debug)]
-#[must_use = "this `Capacity result might be an error vairant and must be used"]
+#[must_use = "this `CapacityResult` might be an error variant and must be used"]
 pub struct CapacityResult<T, R> (Result<T, (R, CapacityError)>);
 
 impl<T, R> CapacityResult<T, R> {
@@ -66,11 +78,11 @@ impl<T, R> CapacityResult<T, R> {
     ///
     /// This method can be used to perform error handling,
     /// when the returned `rest` is not relevant.
-    /// The returned result can by used with the `?` operator
+    /// The returned result can by used with the `?` operator.
     ///
     /// # Examples
     ///
-    /// basic usage
+    /// Basic usage:
     ///
     /// ```
     /// use heapless::CapacityResult;
@@ -83,7 +95,7 @@ impl<T, R> CapacityResult<T, R> {
     /// assert_eq!(b.into_result(), Err(CapacityError::one_more_than(1)));
     /// ```
     ///
-    /// For error handling
+    /// For error handling:
     ///
     /// ```
     /// use heapless::CapacityResult;
@@ -102,7 +114,7 @@ impl<T, R> CapacityResult<T, R> {
     }
 
     /// Use the result as an optional reference to `rest`,
-    /// which could not be inserted due to capacity errors
+    /// which could not be inserted due to capacity errors.
     pub fn as_rest(&self) -> Option<&R> {
         self.0.as_ref()
             .err()
@@ -110,7 +122,7 @@ impl<T, R> CapacityResult<T, R> {
     }
 
     /// Use the result as an optional mutable reference to `rest`,
-    /// which could not be inserted due to capacity errors
+    /// which could not be inserted due to capacity errors.
     pub fn as_mut_rest(&mut self) -> Option<&mut R> {
         self.0.as_mut()
             .err()
@@ -118,14 +130,14 @@ impl<T, R> CapacityResult<T, R> {
     }
 
     /// Convert the result to an optional `rest`,
-    /// which could not be inserted due to capacity errors
+    /// which could not be inserted due to capacity errors.
     ///
     /// This method can be used to try to recover from the given CapacityError
-    /// by performing some operation with the element that could not be inserted
+    /// by performing some operation with the element that could not be inserted.
     ///
     /// # Examples
     ///
-    /// Basic usage
+    /// Basic usage:
     ///
     /// ```
     /// use heapless::CapacityResult;
@@ -172,9 +184,11 @@ impl<T, R> CapacityResult<T, R> {
             .map(|e| &mut e.1)
     }
 
-    /// Convert the result to an optional error
+    /// Convert the result to an optional error.
     ///
     /// # Examples
+    ///
+    /// Basic usage:
     ///
     /// ```
     /// use heapless::CapacityResult;
@@ -187,9 +201,11 @@ impl<T, R> CapacityResult<T, R> {
             .map(|e| e.1)
     }
 
-    /// returns `true` if the result is ok
+    /// Returns `true` if the result is ok.
     ///
     /// # Examples
+    ///
+    /// Basic usage:
     ///
     /// ```
     /// use heapless::CapacityResult;
@@ -201,9 +217,11 @@ impl<T, R> CapacityResult<T, R> {
         self.0.is_ok()
     }
 
-    /// returns `true` if the result is err
+    /// Returns `true` if the result is an error.
     ///
     /// # Examples
+    ///
+    /// Basic usage:
     ///
     /// ```
     /// use heapless::CapacityResult;
@@ -216,13 +234,15 @@ impl<T, R> CapacityResult<T, R> {
         self.0.is_err()
     }
 
-    /// Unwrap the result, panic if was an error
+    /// Unwrap the result to access the contained value.
     ///
     /// # Panics
     ///
-    /// Panics if it was an error
+    /// Panics if the result was an error.
     ///
     /// # Examples
+    ///
+    /// Basic usage:
     ///
     /// ```
     /// use heapless::CapacityResult;
@@ -230,6 +250,8 @@ impl<T, R> CapacityResult<T, R> {
     /// let x: CapacityResult<(), i32> = CapacityResult::ok(());
     /// x.unwrap(); // does not panic
     /// ```
+    ///
+    /// Panic on error:
     ///
     /// ```should_panic
     /// use heapless::CapacityResult;
@@ -242,29 +264,74 @@ impl<T, R> CapacityResult<T, R> {
         self.into_result().unwrap()
     }
 
-    /// Unwrap the result and panic with the given message if it was an error
+    /// Unwrap the result to access the contained value
+    /// and panic with the given message if it was an error.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the result was an error
     pub fn expect(self, msg: &str) -> T {
         self.into_result().expect(msg)
     }
 
-    /// Ignore this result, but use it.
-    /// this serves the same purpose as calling `Result::ok()`
-    /// but not using the value
+    /// Ignore this result, but consume it.
+    ///
+    /// This serves the same purpose as calling `Result::ok()`
+    /// but not using the `ok` value.
     pub fn ignore(self) {
         self.0.ok();
     }
 
-    /// If the result is an error, transform the contained rest
+    /// If the result is an error, transform the contained rest.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use heapless::CapacityResult;
+    /// use heapless::CapacityError;
+    ///
+    /// let x: CapacityResult<(), i32> = CapacityResult::err(42, CapacityError::one_more_than(1));
+    /// assert_eq!(x.map_rest(|i| i+1).into_rest(), Some(43));
+    /// ```
     pub fn map_rest<S, F: FnOnce(R) -> S>(self, f: F) -> CapacityResult<T, S> {
         CapacityResult(self.0.map_err(|(rest, err)| (f(rest), err)))
     }
 
     /// If the result is ok, transform the value
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use heapless::CapacityResult;
+    /// use heapless::CapacityError;
+    ///
+    /// let x: CapacityResult<i32, i32> = CapacityResult::ok(42);
+    /// assert_eq!(x.map(|i| i+1).into_result().ok(), Some(43));
+    /// ```
     pub fn map<U, F: FnOnce(T) -> U>(self, f: F) -> CapacityResult<U, R> {
         CapacityResult(self.0.map(f))
     }
 
-    /// Transform the error variant, ignore the contained rest
+    /// Transform the error variant, ignore the contained rest.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use heapless::CapacityResult;
+    /// use heapless::CapacityError;
+    ///
+    /// #[derive(Debug, PartialEq, Eq)]
+    /// struct FooError;
+    ///
+    /// let x: CapacityResult<(), i32> = CapacityResult::err(42, CapacityError::one_more_than(1));
+    /// assert_eq!(x.map_err(|_| FooError).err(), Some(FooError));
+    /// ```
     pub fn map_err<E, F: FnOnce(CapacityError) -> E>(self, f: F) -> Result<T, E> {
         self.0.map_err(|(_, err)| f(err))
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -50,6 +50,10 @@ impl<T> CapacityResult<T>  {
         CapacityResult(Err((rest, err)))
     }
 
+    pub(crate) fn into_inner(self) -> Result<(), (T, CapacityError)> {
+        self.0
+    }
+
     /// Use the result as an proper core::Result with references
     pub fn as_result(&self) -> Result<(), &CapacityError> {
         self.0.as_ref()
@@ -249,5 +253,18 @@ impl<T> CapacityResult<T>  {
         self.into_result().expect(msg);
     }
 
+    /// Ingore this result, but use it.
+    /// this serves the same purpose as calling `Result::ok()`
+    /// but not using the value
+    pub fn ignore(self) {
+        self.0.ok();
+    }
+
+    /// If the result is an error, transform the contained rest
+    pub fn map_rest<U, F: FnOnce(T) -> U>(self, f: F) -> CapacityResult<U> {
+        CapacityResult(self.0.map_err(|(rest, err)| (f(rest), err)))
+    }
+
 }
+
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -35,9 +35,9 @@ impl CapacityError {
 /// Generic over the rest of the data, that cound not be inserted
 #[derive(Debug)]
 #[must_use = "this `Capacity result might be an error vairant and must be used"]
-pub struct CapacityResult<R, T = ()> (Result<T, (R, CapacityError)>);
+pub struct CapacityResult<T, R> (Result<T, (R, CapacityError)>);
 
-impl<R, T> CapacityResult<R, T> {
+impl<T, R> CapacityResult<T, R> {
 
     /// Construct an Ok variant of this result
     pub fn ok(value: T) -> Self {
@@ -76,10 +76,10 @@ impl<R, T> CapacityResult<R, T> {
     /// use heapless::CapacityResult;
     /// use heapless::CapacityError;
     ///
-    /// let a: CapacityResult<i32> = CapacityResult::ok(());
+    /// let a: CapacityResult<(), i32> = CapacityResult::ok(());
     /// assert_eq!(a.into_result(), Ok(()));
     ///
-    /// let b: CapacityResult<i32> = CapacityResult::err(42, CapacityError::one_more_than(1));
+    /// let b: CapacityResult<(), i32> = CapacityResult::err(42, CapacityError::one_more_than(1));
     /// assert_eq!(b.into_result(), Err(CapacityError::one_more_than(1)));
     /// ```
     ///
@@ -131,7 +131,7 @@ impl<R, T> CapacityResult<R, T> {
     /// use heapless::CapacityResult;
     /// use heapless::CapacityError;
     ///
-    /// let x: CapacityResult<i32> = CapacityResult::err(42, CapacityError::one_more_than(1));
+    /// let x: CapacityResult<(), i32> = CapacityResult::err(42, CapacityError::one_more_than(1));
     /// assert_eq!(x.into_rest(), Some(42));
     /// ```
     ///
@@ -146,7 +146,7 @@ impl<R, T> CapacityResult<R, T> {
     ///     true
     /// }
     ///
-    /// let x: CapacityResult<i32> = CapacityResult::err(42, CapacityError::one_more_than(1));
+    /// let x: CapacityResult<(), i32> = CapacityResult::err(42, CapacityError::one_more_than(1));
     /// if let Some(r) = x.into_rest() {
     ///     if !recover(r) {
     ///         panic!("Failed while recovering");
@@ -180,7 +180,7 @@ impl<R, T> CapacityResult<R, T> {
     /// use heapless::CapacityResult;
     /// use heapless::CapacityError;
     ///
-    /// let x: CapacityResult<i32> = CapacityResult::err(42, CapacityError::one_more_than(1));
+    /// let x: CapacityResult<(), i32> = CapacityResult::err(42, CapacityError::one_more_than(1));
     /// assert_eq!(x.into_err(), Some(CapacityError::one_more_than(1)));
     pub fn into_err(self) -> Option<CapacityError> {
         self.0.err()
@@ -194,7 +194,7 @@ impl<R, T> CapacityResult<R, T> {
     /// ```
     /// use heapless::CapacityResult;
     ///
-    /// let x: CapacityResult<i32> = CapacityResult::ok(());
+    /// let x: CapacityResult<(), i32> = CapacityResult::ok(());
     /// assert!(x.is_ok());
     /// ```
     pub fn is_ok(&self) -> bool {
@@ -209,7 +209,7 @@ impl<R, T> CapacityResult<R, T> {
     /// use heapless::CapacityResult;
     /// use heapless::CapacityError;
     ///
-    /// let x: CapacityResult<i32> = CapacityResult::err(42, CapacityError::one_more_than(1));
+    /// let x: CapacityResult<(), i32> = CapacityResult::err(42, CapacityError::one_more_than(1));
     /// assert!(x.is_err());
     /// ```
     pub fn is_err(&self) -> bool {
@@ -227,7 +227,7 @@ impl<R, T> CapacityResult<R, T> {
     /// ```
     /// use heapless::CapacityResult;
     ///
-    /// let x: CapacityResult<i32> = CapacityResult::ok(());
+    /// let x: CapacityResult<(), i32> = CapacityResult::ok(());
     /// x.unwrap(); // does not panic
     /// ```
     ///
@@ -235,7 +235,7 @@ impl<R, T> CapacityResult<R, T> {
     /// use heapless::CapacityResult;
     /// use heapless::CapacityError;
     ///
-    /// let x: CapacityResult<i32> = CapacityResult::err(42, CapacityError::one_more_than(1));
+    /// let x: CapacityResult<(), i32> = CapacityResult::err(42, CapacityError::one_more_than(1));
     /// x.unwrap(); // panics
     /// ```
     pub fn unwrap(self) -> T {
@@ -255,12 +255,12 @@ impl<R, T> CapacityResult<R, T> {
     }
 
     /// If the result is an error, transform the contained rest
-    pub fn map_rest<S, F: FnOnce(R) -> S>(self, f: F) -> CapacityResult<S, T> {
+    pub fn map_rest<S, F: FnOnce(R) -> S>(self, f: F) -> CapacityResult<T, S> {
         CapacityResult(self.0.map_err(|(rest, err)| (f(rest), err)))
     }
 
     /// If the result is ok, transform the value
-    pub fn map<U, F: FnOnce(T) -> U>(self, f: F) -> CapacityResult<R, U> {
+    pub fn map<U, F: FnOnce(T) -> U>(self, f: F) -> CapacityResult<U, R> {
         CapacityResult(self.0.map(f))
     }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -201,6 +201,33 @@ impl<T, R> CapacityResult<T, R> {
             .map(|e| e.1)
     }
 
+    /// Use the result as an optional reference to an ok value
+    pub fn as_ok(&self) -> Option<&T> {
+        self.0.as_ref()
+            .ok()
+    }
+
+    /// Use the result as an optional mutable reference to an ok value
+    pub fn as_mut_ok(&mut self) -> Option<&mut T> {
+        self.0.as_mut()
+            .ok()
+    }
+
+    /// Use the result as an optional ok value
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use heapless::CapacityResult;
+    ///
+    /// let x: CapacityResult<i32, i32> = CapacityResult::ok(42);
+    /// assert_eq!(x.into_ok(), Some(42));
+    pub fn into_ok(self) -> Option<T> {
+        self.0.ok()
+    }
+
     /// Returns `true` if the result is ok.
     ///
     /// # Examples

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -8,3 +8,99 @@ pub struct CapacityError
     /// Encountered number of characters
     pub encountered: usize,
 }
+
+/// Result returned from insertion operation
+/// Generic over the rest of the data, that cound not be inserted
+#[derive(Debug)]
+pub struct CapacityResult<T> (Result<(), (T, CapacityError)>);
+
+impl<T> CapacityResult<T>  {
+
+    /// Construct an Ok variant of this result
+    fn ok() -> Self {
+        CapacityResult(Ok(()))
+    }
+
+    /// Construct an Err variant of this result
+    /// containing the rest and the capacity error
+    fn err(rest: T, err: CapacityError) -> Self {
+        CapacityResult(Err((rest, err)))
+    }
+
+    /// Use the result as an proper core::Result with references
+    pub fn as_result(&self) -> Result<(), &CapacityError> {
+        self.0.as_ref()
+            .map(|_| ())
+            .map_err(|e| &e.1)
+    }
+
+    /// Use the result as a proper core::Result with mutable references
+    pub fn as_mut_result(&mut self) -> Result<(), &mut CapacityError> {
+        self.0.as_mut()
+            .map(|_| ())
+            .map_err(|e| &mut e.1)
+    }
+
+    /// Convert the result into a proper core::Result
+    ///
+    /// This can be used to perform error handling,
+    /// when the returned `rest` is not relevant
+    pub fn into_result(self) -> Result<(), CapacityError> {
+        self.0.map_err(|e| e.1)
+    }
+
+    /// Use the result as an optional reference to `rest`,
+    /// which could not be inserted due to capacity errors
+    pub fn as_rest(&self) -> Option<&T> {
+        self.0.as_ref()
+            .err()
+            .map(|e| &e.0)
+    }
+
+    /// Use the result as an optional mutable reference to `rest`,
+    /// which could not be inserted due to capacity errors
+    pub fn as_mut_rest(&mut self) -> Option<&mut T> {
+        self.0.as_mut()
+            .err()
+            .map(|e| &mut e.0)
+    }
+
+    /// Convert the result to an optional `rest`,
+    /// which could not be inserted due to capacity errors
+    pub fn into_rest(self) -> Option<T> {
+        self.0.err()
+            .map(|e| e.0)
+    }
+
+    /// Use the result as an optional reference to an error
+    pub fn as_err(&self) -> Option<&CapacityError> {
+        self.0.as_ref()
+            .err()
+            .map(|e| &e.1)
+    }
+
+    /// Use the result as an optional mutable reference to an error
+    pub fn as_mut_err(&mut self) -> Option<&mut CapacityError> {
+        self.0.as_mut()
+            .err()
+            .map(|e| &mut e.1)
+    }
+
+    /// Convert the result to an optional error
+    pub fn as_err(&self) -> Option<CapacityError> {
+        self.0.err()
+            .map(|e| e.1)
+    }
+
+    /// returns `true` if the result is ok
+    pub fn is_ok(&self) -> bool {
+        self.0.is_ok()
+    }
+
+    /// returns `true` if the result is err
+    pub fn is_err(&self) -> bool {
+        self.0.is_err()
+    }
+
+}
+

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -10,6 +10,7 @@ pub struct CapacityError
 }
 
 impl CapacityError {
+
     /// Create an capacity error where the maximum capacity is exeeded be one
     ///
     /// # Examples
@@ -27,11 +28,13 @@ impl CapacityError {
             encountered: maximum + 1,
         }
     }
+
 }
 
 /// Result returned from insertion operation
 /// Generic over the rest of the data, that cound not be inserted
 #[derive(Debug)]
+#[must_use = "this `Capacity result might be an error vairant and must be used"]
 pub struct CapacityResult<T> (Result<(), (T, CapacityError)>);
 
 impl<T> CapacityResult<T>  {
@@ -192,6 +195,7 @@ impl<T> CapacityResult<T>  {
     ///
     /// ```
     /// use heapless::CapacityResult;
+    ///
     /// let x: CapacityResult<i32> = CapacityResult::ok();
     /// assert!(x.is_ok());
     /// ```
@@ -206,11 +210,43 @@ impl<T> CapacityResult<T>  {
     /// ```
     /// use heapless::CapacityResult;
     /// use heapless::CapacityError;
+    ///
     /// let x: CapacityResult<i32> = CapacityResult::err(42, CapacityError::one_more_than(1));
     /// assert!(x.is_err());
     /// ```
     pub fn is_err(&self) -> bool {
         self.0.is_err()
+    }
+
+    /// Unwrap the result, panic if was an error
+    ///
+    /// # Panics
+    ///
+    /// Panics if it was an error
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use heapless::CapacityResult;
+    ///
+    /// let x: CapacityResult<i32> = CapacityResult::ok();
+    /// x.unwrap(); // does not panic
+    /// ```
+    ///
+    /// ```should_panic
+    /// use heapless::CapacityResult;
+    /// use heapless::CapacityError;
+    ///
+    /// let x: CapacityResult<i32> = CapacityResult::err(42, CapacityError::one_more_than(1));
+    /// x.unwrap(); // panics
+    /// ```
+    pub fn unwrap(self) {
+        self.into_result().unwrap();
+    }
+
+    /// Unwrap the result and panic with the given message if it was an error
+    pub fn expect(self, msg: &str) {
+        self.into_result().expect(msg);
     }
 
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,31 +1,10 @@
-use core::fmt;
-#[cfg(feature = "std")]
-use std::error::Error;
-
-const CAPERROR: &'static str = "insufficient capacity";
-
 /// Capacity error returned when container's capacity is not enough to complete the operation
-#[derive(Debug, PartialEq)]
-pub struct CapacityError {
+#[derive(Fail, Debug, PartialEq, Eq)]
+#[fail(display= "Insufficient capacity: maximum {}, encountered {}", maximum, encountered)]
+pub struct CapacityError
+{
     /// Maximum characters allowed
     pub maximum: usize,
     /// Encountered number of characters
     pub encountered: usize,
-}
-
-#[cfg(feature = "std")]
-impl Error for CapacityError {
-    fn description(&self) -> &str {
-        CAPERROR
-    }
-}
-
-impl fmt::Display for CapacityError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "{}: maximum {}, encountered {}",
-            CAPERROR, self.maximum, self.encountered
-        )
-    }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,31 @@
+use core::fmt;
+#[cfg(feature = "std")]
+use std::error::Error;
+
+const CAPERROR: &'static str = "insufficient capacity";
+
+/// Capacity error returned when container's capacity is not enough to complete the operation
+#[derive(Debug, PartialEq)]
+pub struct CapacityError {
+    /// Maximum characters allowed
+    pub maximum: usize,
+    /// Encountered number of characters
+    pub encountered: usize,
+}
+
+#[cfg(feature = "std")]
+impl Error for CapacityError {
+    fn description(&self) -> &str {
+        CAPERROR
+    }
+}
+
+impl fmt::Display for CapacityError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{}: maximum {}, encountered {}",
+            CAPERROR, self.maximum, self.encountered
+        )
+    }
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -264,6 +264,11 @@ impl<R, T> CapacityResult<R, T> {
         CapacityResult(self.0.map(f))
     }
 
+    /// Transform the error variant, ignore the contained rest
+    pub fn map_err<E, F: FnOnce(CapacityError) -> E>(self, f: F) -> Result<T, E> {
+        self.0.map_err(|(_, err)| f(err))
+    }
+
 }
 
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -76,10 +76,10 @@ impl<R, T> CapacityResult<R, T> {
     /// use heapless::CapacityResult;
     /// use heapless::CapacityError;
     ///
-    /// let a: CapacityResult<i32> = CapacityResult::ok();
+    /// let a: CapacityResult<i32> = CapacityResult::ok(());
     /// assert_eq!(a.into_result(), Ok(()));
     ///
-    /// let b = CapacityResult::err(42, CapacityError::one_more_than(1));
+    /// let b: CapacityResult<i32> = CapacityResult::err(42, CapacityError::one_more_than(1));
     /// assert_eq!(b.into_result(), Err(CapacityError::one_more_than(1)));
     /// ```
     ///
@@ -131,7 +131,7 @@ impl<R, T> CapacityResult<R, T> {
     /// use heapless::CapacityResult;
     /// use heapless::CapacityError;
     ///
-    /// let x = CapacityResult::err(42, CapacityError::one_more_than(1));
+    /// let x: CapacityResult<i32> = CapacityResult::err(42, CapacityError::one_more_than(1));
     /// assert_eq!(x.into_rest(), Some(42));
     /// ```
     ///
@@ -146,7 +146,7 @@ impl<R, T> CapacityResult<R, T> {
     ///     true
     /// }
     ///
-    /// let x = CapacityResult::err(42, CapacityError::one_more_than(1));
+    /// let x: CapacityResult<i32> = CapacityResult::err(42, CapacityError::one_more_than(1));
     /// if let Some(r) = x.into_rest() {
     ///     if !recover(r) {
     ///         panic!("Failed while recovering");
@@ -180,7 +180,7 @@ impl<R, T> CapacityResult<R, T> {
     /// use heapless::CapacityResult;
     /// use heapless::CapacityError;
     ///
-    /// let x = CapacityResult::err(42, CapacityError::one_more_than(1));
+    /// let x: CapacityResult<i32> = CapacityResult::err(42, CapacityError::one_more_than(1));
     /// assert_eq!(x.into_err(), Some(CapacityError::one_more_than(1)));
     pub fn into_err(self) -> Option<CapacityError> {
         self.0.err()
@@ -194,7 +194,7 @@ impl<R, T> CapacityResult<R, T> {
     /// ```
     /// use heapless::CapacityResult;
     ///
-    /// let x: CapacityResult<i32> = CapacityResult::ok();
+    /// let x: CapacityResult<i32> = CapacityResult::ok(());
     /// assert!(x.is_ok());
     /// ```
     pub fn is_ok(&self) -> bool {
@@ -227,7 +227,7 @@ impl<R, T> CapacityResult<R, T> {
     /// ```
     /// use heapless::CapacityResult;
     ///
-    /// let x: CapacityResult<i32> = CapacityResult::ok();
+    /// let x: CapacityResult<i32> = CapacityResult::ok(());
     /// x.unwrap(); // does not panic
     /// ```
     ///

--- a/src/indexmap.rs
+++ b/src/indexmap.rs
@@ -10,6 +10,7 @@ use hash32::{BuildHasher, BuildHasherDefault, FnvHasher, Hash, Hasher};
 
 use Vec;
 use CapacityError;
+use CapacityResult;
 use __core::mem;
 
 /// An `IndexMap` using the default FNV hasher
@@ -640,12 +641,11 @@ where
     /// assert_eq!(map.insert(37, "c"), Ok(Some("b")));
     /// assert_eq!(map[&37], "c");
     /// ```
-    /// FIXME: this return type is unergonimic
-    pub fn insert(&mut self, key: K, value: V) -> Result<Option<V>, ((K, V), CapacityError)> {
+    pub fn insert(&mut self, key: K, value: V) -> CapacityResult<(K, V), Option<V>> {
         if self.core.entries.is_full() {
-            Err(((key, value), CapacityError::one_more_than(self.capacity()))
+            CapacityResult::err((key, value), CapacityError::one_more_than(self.capacity()))
         } else {
-            Ok(match self.insert_phase_1(key, value) {
+            CapacityResult::ok(match self.insert_phase_1(key, value) {
                 Inserted::Swapped { prev_value } => Some(prev_value),
                 Inserted::Done => None,
                 Inserted::RobinHood { probe, old_pos } => {
@@ -822,7 +822,7 @@ where
         I: IntoIterator<Item = (K, V)>,
     {
         for (k, v) in iterable {
-            self.insert(k, v).ok().unwrap();
+            self.insert(k, v).unwrap();
         }
     }
 }

--- a/src/indexmap.rs
+++ b/src/indexmap.rs
@@ -641,7 +641,7 @@ where
     /// assert_eq!(map.insert(37, "c").into_result(), Ok(Some("b")));
     /// assert_eq!(map[&37], "c");
     /// ```
-    pub fn insert(&mut self, key: K, value: V) -> CapacityResult<(K, V), Option<V>> {
+    pub fn insert(&mut self, key: K, value: V) -> CapacityResult<Option<V>, (K, V)> {
         if self.core.entries.is_full() {
             CapacityResult::err((key, value), CapacityError::one_more_than(self.capacity()))
         } else {

--- a/src/indexmap.rs
+++ b/src/indexmap.rs
@@ -9,6 +9,7 @@ use generic_array::{ArrayLength, GenericArray};
 use hash32::{BuildHasher, BuildHasherDefault, FnvHasher, Hash, Hasher};
 
 use Vec;
+use CapacityError;
 use __core::mem;
 
 /// An `IndexMap` using the default FNV hasher
@@ -639,9 +640,10 @@ where
     /// assert_eq!(map.insert(37, "c"), Ok(Some("b")));
     /// assert_eq!(map[&37], "c");
     /// ```
-    pub fn insert(&mut self, key: K, value: V) -> Result<Option<V>, (K, V)> {
+    /// FIXME: this return type is unergonimic
+    pub fn insert(&mut self, key: K, value: V) -> Result<Option<V>, ((K, V), CapacityError)> {
         if self.core.entries.is_full() {
-            Err((key, value))
+            Err(((key, value), CapacityError::one_more_than(self.capacity()))
         } else {
             Ok(match self.insert_phase_1(key, value) {
                 Inserted::Swapped { prev_value } => Some(prev_value),

--- a/src/indexmap.rs
+++ b/src/indexmap.rs
@@ -634,11 +634,11 @@ where
     /// use heapless::consts::*;
     ///
     /// let mut map = FnvIndexMap::<_, _, U8>::new();
-    /// assert_eq!(map.insert(37, "a"), Ok(None));
+    /// assert_eq!(map.insert(37, "a").into_result(), Ok(None));
     /// assert_eq!(map.is_empty(), false);
     ///
     /// map.insert(37, "b");
-    /// assert_eq!(map.insert(37, "c"), Ok(Some("b")));
+    /// assert_eq!(map.insert(37, "c").into_result(), Ok(Some("b")));
     /// assert_eq!(map[&37], "c");
     /// ```
     pub fn insert(&mut self, key: K, value: V) -> CapacityResult<(K, V), Option<V>> {

--- a/src/indexset.rs
+++ b/src/indexset.rs
@@ -422,7 +422,7 @@ where
     /// assert_eq!(set.insert(2).unwrap(), false);
     /// assert_eq!(set.len(), 1);
     /// ```
-    pub fn insert(&mut self, value: T) -> CapacityResult<T, bool> {
+    pub fn insert(&mut self, value: T) -> CapacityResult<bool, T> {
         self.map
             .insert(value, ())
             .map(|old| old.is_none())

--- a/src/indexset.rs
+++ b/src/indexset.rs
@@ -7,7 +7,7 @@ use generic_array::ArrayLength;
 use hash32::{BuildHasher, BuildHasherDefault, FnvHasher, Hash, Hasher};
 
 use indexmap::{self, Bucket, IndexMap, Pos};
-use errors::CapacityError;
+use CapacityResult;
 
 /// An `IndexSet` using the default FNV hasher
 pub type FnvIndexSet<T, N> = IndexSet<T, N, BuildHasherDefault<FnvHasher>>;
@@ -422,14 +422,11 @@ where
     /// assert_eq!(set.insert(2).unwrap(), false);
     /// assert_eq!(set.len(), 1);
     /// ```
-    pub fn insert(&mut self, value: T) -> Result<bool, (T, CapacityError)> {
+    pub fn insert(&mut self, value: T) -> CapacityResult<T, bool> {
         self.map
             .insert(value, ())
             .map(|old| old.is_none())
-            .map_err(|(k, _)| (k, CapacityError {
-                maximum: self.capacity(),
-                encountered: self.capacity() + 1
-            }))
+            .map_rest(|(k, _)| k)
     }
 
     /// Removes a value from the set. Returns `true` if the value was present in the set.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,8 +92,14 @@
 
 extern crate generic_array;
 extern crate hash32;
+#[macro_use]
+extern crate failure;
+
+
+
 #[cfg(test)]
 extern crate std;
+
 
 #[cfg(feature = "serde")]
 extern crate serde;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,6 +102,7 @@ extern crate serde;
 mod const_fn;
 
 pub use binary_heap::BinaryHeap;
+pub use errors::*;
 pub use generic_array::typenum::consts;
 pub use generic_array::ArrayLength;
 pub use indexmap::{FnvIndexMap, IndexMap};
@@ -111,6 +112,7 @@ pub use string::String;
 pub use vec::Vec;
 
 mod cfail;
+mod errors;
 mod indexmap;
 mod indexset;
 mod linear_map;

--- a/src/linear_map.rs
+++ b/src/linear_map.rs
@@ -187,13 +187,14 @@ where
     /// assert_eq!(map.insert(37, "c").unwrap(), Some("b"));
     /// assert_eq!(map[&37], "c");
     /// ```
+    /// FIXME: this return type is unergonomic
     pub fn insert(&mut self, key: K, mut value: V) -> Result<Option<V>, ((K, V), CapacityError)> {
         if let Some((_, v)) = self.iter_mut().find(|&(k, _)| *k == key) {
             mem::swap(v, &mut value);
             return Ok(Some(value));
         }
 
-        self.buffer.push((key, value))?;
+        self.buffer.push((key, value)).into_inner()?;
         Ok(None)
     }
 

--- a/src/linear_map.rs
+++ b/src/linear_map.rs
@@ -5,6 +5,7 @@ use core::iter::FromIterator;
 use generic_array::ArrayLength;
 
 use Vec;
+use errors::CapacityError;
 
 /// A fixed capacity map / dictionary that performs lookups via linear search
 ///
@@ -186,7 +187,7 @@ where
     /// assert_eq!(map.insert(37, "c").unwrap(), Some("b"));
     /// assert_eq!(map[&37], "c");
     /// ```
-    pub fn insert(&mut self, key: K, mut value: V) -> Result<Option<V>, (K, V)> {
+    pub fn insert(&mut self, key: K, mut value: V) -> Result<Option<V>, ((K, V), CapacityError)> {
         if let Some((_, v)) = self.iter_mut().find(|&(k, _)| *k == key) {
             mem::swap(v, &mut value);
             return Ok(Some(value));

--- a/src/linear_map.rs
+++ b/src/linear_map.rs
@@ -187,7 +187,7 @@ where
     /// assert_eq!(map.insert(37, "c").unwrap(), Some("b"));
     /// assert_eq!(map[&37], "c");
     /// ```
-    pub fn insert(&mut self, key: K, mut value: V) -> CapacityResult<(K, V), Option<V>> {
+    pub fn insert(&mut self, key: K, mut value: V) -> CapacityResult<Option<V>, (K, V)> {
         if let Some((_, v)) = self.iter_mut().find(|&(k, _)| *k == key) {
             mem::swap(v, &mut value);
             return CapacityResult::ok(Some(value))

--- a/src/spsc/mod.rs
+++ b/src/spsc/mod.rs
@@ -354,7 +354,7 @@ macro_rules! impl_ {
             /// Adds an `item` to the end of the queue
             ///
             /// Returns back the `item` if the queue is full
-            pub fn enqueue(&mut self, item: T) -> CapacityResult<T> {
+            pub fn enqueue(&mut self, item: T) -> CapacityResult<(), T> {
                 let cap = self.capacity();
                 let head = *self.head.get_mut();
                 let tail = *self.tail.get_mut();

--- a/src/spsc/mod.rs
+++ b/src/spsc/mod.rs
@@ -364,7 +364,7 @@ macro_rules! impl_ {
                         CapacityError::one_more_than(self.capacity_usize() -1))
                 } else {
                     unsafe { self.enqueue_unchecked(item) }
-                    CapacityResult::ok()
+                    CapacityResult::ok(())
                 }
             }
 

--- a/src/spsc/mod.rs
+++ b/src/spsc/mod.rs
@@ -138,9 +138,9 @@ where
 ///     // ..
 ///
 ///     if condition {
-///         producer.enqueue(Event::A).ok().unwrap();
+///         producer.enqueue(Event::A).unwrap();
 ///     } else {
-///         producer.enqueue(Event::B).ok().unwrap();
+///         producer.enqueue(Event::B).unwrap();
 ///     }
 ///
 ///     // ..

--- a/src/spsc/split.rs
+++ b/src/spsc/split.rs
@@ -143,7 +143,7 @@ macro_rules! impl_ {
             /// Adds an `item` to the end of the queue
             ///
             /// Returns back the `item` if the queue is full
-            pub fn enqueue(&mut self, item: T) -> CapacityResult<T> {
+            pub fn enqueue(&mut self, item: T) -> CapacityResult<(), T> {
                 let cap = unsafe { self.rb.as_ref().capacity() };
                 let tail = unsafe { self.rb.as_ref().tail.load_relaxed() };
                 // NOTE we could replace this `load_acquire` with a `load_relaxed` and this method

--- a/src/spsc/split.rs
+++ b/src/spsc/split.rs
@@ -154,11 +154,13 @@ macro_rules! impl_ {
                 let head = unsafe { self.rb.as_ref().head.load_acquire() }; // ▼
 
                 if tail.wrapping_sub(head) > cap - 1 {
-                    CapacityResult::err(item,
-                        CapacityError::one_more_than(self.rb.as_ref().capacity_usize() - 1))
+                    unsafe {
+                        CapacityResult::err(item,
+                            CapacityError::one_more_than(self.rb.as_ref().capacity_usize() - 1))
+                    }
                 } else {
                     unsafe { self._enqueue(tail, item) }; // ▲
-                    CapacityResult::ok()
+                    CapacityResult::ok(())
                 }
             }
 

--- a/src/spsc/split.rs
+++ b/src/spsc/split.rs
@@ -5,6 +5,7 @@ use generic_array::ArrayLength;
 
 use sealed;
 use spsc::{MultiCore, Queue};
+use errors::CapacityError;
 
 impl<T, N, U, C> Queue<T, N, U, C>
 where
@@ -141,7 +142,7 @@ macro_rules! impl_ {
             /// Adds an `item` to the end of the queue
             ///
             /// Returns back the `item` if the queue is full
-            pub fn enqueue(&mut self, item: T) -> Result<(), T> {
+            pub fn enqueue(&mut self, item: T) -> Result<(), (T, CapacityError)> {
                 let cap = unsafe { self.rb.as_ref().capacity() };
                 let tail = unsafe { self.rb.as_ref().tail.load_relaxed() };
                 // NOTE we could replace this `load_acquire` with a `load_relaxed` and this method
@@ -152,7 +153,11 @@ macro_rules! impl_ {
                 let head = unsafe { self.rb.as_ref().head.load_acquire() }; // ▼
 
                 if tail.wrapping_sub(head) > cap - 1 {
-                    Err(item)
+                    let err = unsafe { (item, CapacityError {
+                        maximum: self.rb.as_ref().capacity_usize() - 1,
+                        encountered: self.rb.as_ref().capacity_usize()
+                    }) };
+                    Err(err)
                 } else {
                     unsafe { self._enqueue(tail, item) }; // ▲
                     Ok(())

--- a/src/string.rs
+++ b/src/string.rs
@@ -184,7 +184,7 @@ where
     /// assert!(s.push_str("tender").is_err());
     /// ```
     #[inline]
-    pub fn push_str<'a>(&mut self, string: &'a str) -> CapacityResult<&'a str> {
+    pub fn push_str<'a>(&mut self, string: &'a str) -> CapacityResult<(), &'a str> {
         self.vec.extend_from_slice(string.as_bytes())
             .map_rest(|_| string)
     }
@@ -230,7 +230,7 @@ where
     /// assert_eq!("abc123", s);
     /// ```
     #[inline]
-    pub fn push(&mut self, c: char) -> CapacityResult<char> {
+    pub fn push(&mut self, c: char) -> CapacityResult<(), char> {
         let bytelen = c.len_utf8();
         match bytelen {
             1 => self.vec

--- a/src/string.rs
+++ b/src/string.rs
@@ -235,7 +235,7 @@ where
         match bytelen {
             1 => self.vec
                 .push(c as u8)
-                .map_rest(|_| c)
+                .map_rest(|_| c),
             _ => self.vec
                 .extend_from_slice(c.encode_utf8(&mut [0; 4]).as_bytes())
                 .map_rest(|_| c),

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -4,6 +4,7 @@ use generic_array::{ArrayLength, GenericArray};
 use hash32;
 
 use __core::mem::MaybeUninit;
+use errors::CapacityError;
 
 use core::hash;
 use core::iter::FromIterator;
@@ -99,13 +100,18 @@ where
     /// vec.extend_from_slice(&[2, 3, 4]).unwrap();
     /// assert_eq!(*vec, [1, 2, 3, 4]);
     /// ```
-    pub fn extend_from_slice(&mut self, other: &[T]) -> Result<(), ()>
+    pub fn extend_from_slice(&mut self, other: &[T]) -> Result<(), CapacityError>
     where
         T: Clone,
     {
-        if self.len() + other.len() > self.capacity() {
+        let encountered = self.len() + other.len();
+
+        if encountered > self.capacity() {
             // won't fit in the `Vec`; don't modify anything and return an error
-            Err(())
+            Err(CapacityError {
+                maximum: self.capacity(),
+                encountered,
+            })
         } else {
             for elem in other {
                 self.push(elem.clone()).ok();

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -142,12 +142,16 @@ where
     /// Appends an `item` to the back of the collection
     ///
     /// Returns back the `item` if the vector is full
-    pub fn push(&mut self, item: T) -> Result<(), T> {
+    pub fn push(&mut self, item: T) -> Result<(), (T, CapacityError)> {
         if self.len < self.capacity() {
             unsafe { self.push_unchecked(item) }
             Ok(())
         } else {
-            Err(item)
+            let err = (item, CapacityError {
+                maximum: self.capacity(),
+                encountered: self.capacity() + 1
+            });
+            Err(err)
         }
     }
 
@@ -181,12 +185,15 @@ where
     /// new_len is less than len, the Vec is simply truncated.
     ///
     /// See also [`resize_default`](struct.Vec.html#method.resize_default).
-    pub fn resize(&mut self, new_len: usize, value: T) -> Result<(), ()>
+    pub fn resize(&mut self, new_len: usize, value: T) -> Result<(), CapacityError>
     where
         T: Clone,
     {
         if new_len > self.capacity() {
-            return Err(());
+            return Err(CapacityError {
+                maximum: self.capacity(),
+                encountered: new_len,
+            });
         }
 
         if new_len > self.len {
@@ -207,7 +214,7 @@ where
     /// If `new_len` is less than `len`, the `Vec` is simply truncated.
     ///
     /// See also [`resize`](struct.Vec.html#method.resize).
-    pub fn resize_default(&mut self, new_len: usize) -> Result<(), ()>
+    pub fn resize_default(&mut self, new_len: usize) -> Result<(), CapacityError>
     where
         T: Clone + Default,
     {

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -776,6 +776,7 @@ mod tests {
     }
 
     #[test]
+    #[should_panic]
     fn resize_size_limit() {
         let mut v: Vec<u8, U4> = Vec::new();
 

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -115,9 +115,9 @@ where
             })
         } else {
             for elem in other {
-                self.push(elem.clone()).ok();
+                self.push(elem.clone()).ignore();
             }
-            CapacityResult::ok()
+            CapacityResult::ok(())
         }
     }
 
@@ -146,9 +146,9 @@ where
     pub fn push(&mut self, item: T) -> CapacityResult<T> {
         if self.len < self.capacity() {
             unsafe { self.push_unchecked(item) }
-            CapacityResult::ok()
+            CapacityResult::ok(())
         } else {
-            CapacityResult::err(item, CapacityError::one_more_than(self.capacity())
+            CapacityResult::err(item, CapacityError::one_more_than(self.capacity()))
         }
     }
 
@@ -201,7 +201,7 @@ where
             self.truncate(new_len);
         }
 
-        CapacityResult::ok()
+        CapacityResult::ok(())
     }
 
     /// Resizes the `Vec` in-place so that `len` is equal to `new_len`.

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -101,7 +101,7 @@ where
     /// vec.extend_from_slice(&[2, 3, 4]).unwrap();
     /// assert_eq!(*vec, [1, 2, 3, 4]);
     /// ```
-    pub fn extend_from_slice<'a>(&mut self, other: &'a[T]) -> CapacityResult<&'a[T]>
+    pub fn extend_from_slice<'a>(&mut self, other: &'a[T]) -> CapacityResult<(), &'a[T]>
     where
         T: Clone,
     {
@@ -143,7 +143,7 @@ where
     /// Appends an `item` to the back of the collection
     ///
     /// Returns back the `item` if the vector is full
-    pub fn push(&mut self, item: T) -> CapacityResult<T> {
+    pub fn push(&mut self, item: T) -> CapacityResult<(), T> {
         if self.len < self.capacity() {
             unsafe { self.push_unchecked(item) }
             CapacityResult::ok(())
@@ -182,7 +182,7 @@ where
     /// new_len is less than len, the Vec is simply truncated.
     ///
     /// See also [`resize_default`](struct.Vec.html#method.resize_default).
-    pub fn resize(&mut self, new_len: usize, value: T) -> CapacityResult<T>
+    pub fn resize(&mut self, new_len: usize, value: T) -> CapacityResult<(), T>
     where
         T: Clone,
     {
@@ -211,7 +211,7 @@ where
     /// If `new_len` is less than `len`, the `Vec` is simply truncated.
     ///
     /// See also [`resize`](struct.Vec.html#method.resize).
-    pub fn resize_default(&mut self, new_len: usize) -> CapacityResult<()>
+    pub fn resize_default(&mut self, new_len: usize) -> CapacityResult<(), ()>
     where
         T: Clone + Default,
     {

--- a/tests/tsan.rs
+++ b/tests/tsan.rs
@@ -94,7 +94,7 @@ fn contention() {
 
                 for i in 0..(2 * N::to_u32()) {
                     sum = sum.wrapping_add(i);
-                    while let Err(_) = p.enqueue(i as u8) {}
+                    while p.enqueue(i as u8).is_err() {}
                 }
 
                 println!("producer: {}", sum);


### PR DESCRIPTION
This PR introduces an `CapacityResult` used for insertion operations.
It can either be Ok or an error. If it is ok, it contains an return value. If it is an error, it contains an CapacityError and an `rest` item .

This result type makes the insertion API more ergonomic, as the `CapacityResult` can be transformed into a normal result by calling `CapacityResult::into_result()`. This regular result can then be used for error handling without the `rest` data.

ref #85 #76 