### PR TITLE
tweak crate::MaybeUninit::unitialized

### DIFF
--- a/src/__core.rs
+++ b/src/__core.rs
@@ -26,7 +26,9 @@ pub mod mem {
 
         #[cfg(not(feature = "const-fn"))]
         pub unsafe fn uninitialized() -> Self {
-            mem::uninitialized()
+            MaybeUninit {
+                value: ManuallyDrop::new(mem::uninitialized()),
+            }
         }
 
         /// Get a reference to the contained value.


### PR DESCRIPTION
to not cause UB when unoptimized

appears to fix japaric/cortex-m-rtfm#182