### PR TITLE
Turn `binary_heap::Kind` into a sealed trait

### DIFF
--- a/src/binary_heap.rs
+++ b/src/binary_heap.rs
@@ -9,7 +9,6 @@
 // n)` in-place heapsort.
 
 use core::{
-    cmp::Ordering,
     fmt,
     marker::PhantomData,
     mem::{self, ManuallyDrop},
@@ -18,31 +17,13 @@ use core::{
 
 use generic_array::{ArrayLength, GenericArray};
 
+use crate::sealed::binary_heap::Kind;
+
 /// Min-heap
 pub enum Min {}
 
 /// Max-heap
 pub enum Max {}
-
-/// The binary heap kind: min-heap or max-heap
-///
-/// Do *not* implement this trait yourself!
-pub unsafe trait Kind {
-    #[doc(hidden)]
-    fn ordering() -> Ordering;
-}
-
-unsafe impl Kind for Min {
-    fn ordering() -> Ordering {
-        Ordering::Less
-    }
-}
-
-unsafe impl Kind for Max {
-    fn ordering() -> Ordering {
-        Ordering::Greater
-    }
-}
 
 impl<A, K> crate::i::BinaryHeap<A, K> {
     /// `BinaryHeap` `const` constructor; wrap the returned value in

--- a/src/de.rs
+++ b/src/de.rs
@@ -5,7 +5,7 @@ use hash32::{BuildHasherDefault, Hash, Hasher};
 use serde::de::{self, Deserialize, Deserializer, Error, MapAccess, SeqAccess};
 
 use crate::{
-    binary_heap,
+    sealed::binary_heap::Kind as BinaryHeapKind,
     indexmap::{Bucket, Pos},
     BinaryHeap, IndexMap, IndexSet, LinearMap, String, Vec,
 };
@@ -16,7 +16,7 @@ impl<'de, T, N, KIND> Deserialize<'de> for BinaryHeap<T, N, KIND>
 where
     T: Ord + Deserialize<'de>,
     N: ArrayLength<T>,
-    KIND: binary_heap::Kind,
+    KIND: BinaryHeapKind,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -28,7 +28,7 @@ where
         where
             T: Ord + Deserialize<'de>,
             N: ArrayLength<T>,
-            KIND: binary_heap::Kind,
+            KIND: BinaryHeapKind,
         {
             type Value = BinaryHeap<T, N, KIND>;
 

--- a/src/sealed.rs
+++ b/src/sealed.rs
@@ -1,5 +1,7 @@
-use core::sync::atomic::{self, AtomicU16, AtomicU8, AtomicUsize, Ordering};
+/// Sealed traits and implementations for `spsc`
+pub mod spsc {
 
+use core::sync::atomic::{self, AtomicU16, AtomicU8, AtomicUsize, Ordering};
 use crate::spsc::{MultiCore, SingleCore};
 
 pub unsafe trait XCore {
@@ -149,4 +151,32 @@ unsafe impl Uxx for usize {
             (*(x as *const AtomicUsize)).store(val, Ordering::Relaxed); // write
         }
     }
+}
+
+}
+
+/// Sealed traits and implementations for `binary_heap`
+pub mod binary_heap {
+
+use core::cmp::Ordering;
+use crate::binary_heap::{Min, Max};
+
+/// The binary heap kind: min-heap or max-heap
+pub unsafe trait Kind {
+    #[doc(hidden)]
+    fn ordering() -> Ordering;
+}
+
+unsafe impl Kind for Min {
+    fn ordering() -> Ordering {
+        Ordering::Less
+    }
+}
+
+unsafe impl Kind for Max {
+    fn ordering() -> Ordering {
+        Ordering::Greater
+    }
+}
+
 }

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -3,7 +3,7 @@ use hash32::{BuildHasher, Hash};
 use serde::ser::{Serialize, SerializeMap, SerializeSeq, Serializer};
 
 use crate::{
-    binary_heap::Kind as BinaryHeapKind,
+    sealed::binary_heap::Kind as BinaryHeapKind,
     indexmap::{Bucket, Pos},
     BinaryHeap, IndexMap, IndexSet, LinearMap, String, Vec,
 };

--- a/src/spsc/mod.rs
+++ b/src/spsc/mod.rs
@@ -5,7 +5,7 @@ use core::{cell::UnsafeCell, fmt, hash, marker::PhantomData, mem::MaybeUninit, p
 use generic_array::{ArrayLength, GenericArray};
 use hash32;
 
-use crate::sealed;
+use crate::sealed::spsc as sealed;
 pub use split::{Consumer, Producer};
 
 mod split;

--- a/src/spsc/split.rs
+++ b/src/spsc/split.rs
@@ -3,7 +3,7 @@ use core::{marker::PhantomData, ptr::NonNull};
 use generic_array::ArrayLength;
 
 use crate::{
-    sealed,
+    sealed::spsc as sealed,
     spsc::{MultiCore, Queue},
 };
 


### PR DESCRIPTION
resolves #72

breaking change, since a previously public trait is now private