### PR TITLE
Remove unecessary conditional

### DIFF
--- a/src/spsc/mod.rs
+++ b/src/spsc/mod.rs
@@ -400,12 +400,7 @@ macro_rules! impl_ {
             pub fn len(&self) -> $uxx {
                 let head = self.0.head.load_relaxed();
                 let tail = self.0.tail.load_relaxed();
-
-                if head > tail {
-                    tail.wrapping_sub(head)
-                } else {
-                    tail - head
-                }
+                tail.wrapping_sub(head)
             }
         }
 


### PR DESCRIPTION
In both cases, head is subtracted from tail, wrapping when necessary.