### PR TITLE
Fix boxed Error in build.rs for nightly

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,7 +2,7 @@
 
 use std::{env, error::Error};
 
-fn main() -> Result<(), Box<Error>> {
+fn main() -> Result<(), Box<dyn Error>> {
     let target = env::var("TARGET")?;
 
     if target.starts_with("thumbv6m-") {


### PR DESCRIPTION
on nightly (rustc 1.37.0-nightly (7840a0b75 2019-05-31)) the build is currently broken (see below).

Adding `dyn Error` as the error result in `build.rs` solves the problem.

```
$ cargo +nightly build      
   Compiling typenum v1.10.0
   Compiling stable_deref_trait v1.1.1
   Compiling byteorder v1.2.7
   Compiling heapless v0.5.0-alpha.2 (/home/felix/workspace/rust/heapless)
error: trait objects without an explicit `dyn` are deprecated
 --> build.rs:5:29
  |
5 | fn main() -> Result<(), Box<Error>> {
  |                             ^^^^^ help: use `dyn`: `dyn Error`
  |
note: lint level defined here
 --> build.rs:1:9
  |
1 | #![deny(warnings)]
  |         ^^^^^^^^
  = note: #[deny(bare_trait_objects)] implied by #[deny(warnings)]

error: aborting due to previous error

error: Could not compile `heapless`.
warning: build failed, waiting for other jobs to finish...
error: build failed
```