### PR TITLE
Enable MSRV 1.36 for travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,17 @@ language: rust
 
 matrix:
   include:
-    # TODO MSRV
-    # - env: TARGET=x86_64-unknown-linux-gnu
-    #   rust: 1.36.0
-    #   if: branch != master
 
+    # MSRV: Minimum Supported Rust Version
+    - env: TARGET=x86_64-unknown-linux-gnu
+      rust: 1.36.0
+      if: branch != master
+
+    - env: TARGET=x86_64-unknown-linux-gnu
+      rust: stable
+      if: branch != master
+
+    # build docs on master
     - env: TARGET=x86_64-unknown-linux-gnu
       rust: nightly
 


### PR DESCRIPTION
This PR enables CI runs for Rust 1.36 and current stable for on Ci branches for bors.