### PR TITLE
Update as-slice requirement from 0.1.0 to 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ version = "0.5.1"
 scoped_threadpool = "0.1.8"
 
 [dependencies]
-as-slice = "0.1.0"
+as-slice = "0.2.0"
 generic-array = "0.13.0"
 hash32 = "0.1.0"
 


### PR DESCRIPTION
Hi,

I had a automated PR coming in into my fork of `heapless` from dependabot.

The `as_slice::{AsSlice, AsMutSlice}` traits are used in the `pool` and `pool::singleton` modules as trait bounds on public implementations for the public struct `Box`.
Therefore I suppose that this PR is a **breaking change**, as it alters the compatibility of the public interface, at least on the version level. I suppose there are no changes in code needed.

The breaking change in `as_slice` was caused by an update of `generic_array` to 0.13.0. This is the same version that `heapless` uses.


--- ORIGINAL PR MESSAGE ---

Updates the requirements on [as-slice](https://github.com/japaric/as-slice) to permit the latest version.
- [Release notes](https://github.com/japaric/as-slice/releases)
- [Changelog](https://github.com/japaric/as-slice/blob/master/CHANGELOG.md)
- [Commits](https://github.com/japaric/as-slice/compare/v0.1.0...v0.2.0)

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>