### PR TITLE
Bugfix in mpmc queue

### DIFF
--- a/src/mpmc.rs
+++ b/src/mpmc.rs
@@ -494,7 +494,11 @@ unsafe fn dequeue<T>(buffer: *mut Cell<T>, dequeue_pos: &AtomicU8, mask: u8) -> 
         } else if dif < 0 {
             return None;
         } else {
-            pos = dequeue_pos.load(Ordering::Relaxed);
+            if pos == 255 && dif == 255{
+                return None;
+            } else {
+                pos = dequeue_pos.load(Ordering::Relaxed);
+            }
         }
     }
 


### PR DESCRIPTION
This update prevents the entry into an infinite loop after calling Q_::dequeue() under certain conditions. The following code leads to an infinite loop:
```rust
#[test]
    fn blocking(){
        let q = Q2::new();
        for _ in 0..255 {
            q.enqueue(0).unwrap();
            q.dequeue();
        }
        q.dequeue();
    }
```