### PR TITLE
Deserialize maps as maps

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -182,7 +182,7 @@ where
                 Ok(values)
             }
         }
-        deserializer.deserialize_seq(ValueVisitor(PhantomData))
+        deserializer.deserialize_map(ValueVisitor(PhantomData))
     }
 }
 
@@ -225,7 +225,7 @@ where
                 Ok(values)
             }
         }
-        deserializer.deserialize_seq(ValueVisitor(PhantomData))
+        deserializer.deserialize_map(ValueVisitor(PhantomData))
     }
 }
 


### PR DESCRIPTION
The maps are already being serialized as maps, and serde_json will detect
that despite us claiming that maps are seqs, it falls back to parsing them
as maps; however, serde-json-core does not have that fallback logic, so it
makes more sense to give the correct hint here (especially when this is
merged: https://github.com/japaric/serde-json-core/pull/23)