### PR TITLE
remove unnecessary parentheses

### DIFF
--- a/src/string.rs
+++ b/src/string.rs
@@ -96,7 +96,7 @@ where
     /// assert!(String::from_utf8(v).is_err());
     /// ```
     #[inline]
-    pub fn from_utf8(vec: Vec<u8, N>) -> Result<(String<N>), Utf8Error> {
+    pub fn from_utf8(vec: Vec<u8, N>) -> Result<String<N>, Utf8Error> {
         // validate input
         str::from_utf8(&*vec)?;
 


### PR DESCRIPTION
This commit handles a new rustc warning currently in nightly.

I think this is why #129 failed. 🙂 