### PR TITLE
Extend the ARMv7-A `Pool` support to the bare-metal `armv7a-` targets.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.5.3] - 2020-01-27
+
+### Added
+
+- Extend the ARMv7-A `Pool` support to the bare-metal `armv7a-` targets.
+
 ## [v0.5.2] - 2020-01-15
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ keywords = [
 license = "MIT OR Apache-2.0"
 name = "heapless"
 repository = "https://github.com/japaric/heapless"
-version = "0.5.2"
+version = "0.5.3"
 
 [features]
 default = ["cas"]

--- a/build.rs
+++ b/build.rs
@@ -17,7 +17,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         println!("cargo:rustc-cfg=armv8m_base");
     } else if target.starts_with("thumbv8m.main") {
         println!("cargo:rustc-cfg=armv8m_main");
-    } else if target.starts_with("armv7-") {
+    } else if target.starts_with("armv7-") | target.starts_with("armv7a-") {
         println!("cargo:rustc-cfg=armv7a");
     }
 


### PR DESCRIPTION
The built-in rustc targets ended with names that start with `armv7a-` so #140
does not cover them though the intention was to support them; this commit fixes
that