### PR TITLE
mpmc: use i8 to calculate dif to deal with u8 wrapping

### DIFF
--- a/src/mpmc.rs
+++ b/src/mpmc.rs
@@ -571,8 +571,8 @@ mod tests {
     fn drain_at_pos255() {
         let q = Q2::new();
         for _ in 0..255 {
-            q.enqueue(0).unwrap();
-            q.dequeue();
+            assert!(q.enqueue(0).is_ok());
+            assert_eq!(q.dequeue(), Some(0));
         }
         // this should not block forever
         assert_eq!(q.dequeue(), None);

--- a/src/mpmc.rs
+++ b/src/mpmc.rs
@@ -479,7 +479,7 @@ unsafe fn dequeue<T>(buffer: *mut Cell<T>, dequeue_pos: &AtomicU8, mask: u8) -> 
     loop {
         cell = buffer.add(usize::from(pos & mask));
         let seq = (*cell).sequence.load(Ordering::Acquire);
-        let dif = i16::from(seq) - i16::from(pos.wrapping_add(1));
+        let dif = (seq as i8) - ((pos.wrapping_add(1)) as i8);
 
         if dif == 0 {
             if dequeue_pos
@@ -496,11 +496,7 @@ unsafe fn dequeue<T>(buffer: *mut Cell<T>, dequeue_pos: &AtomicU8, mask: u8) -> 
         } else if dif < 0 {
             return None;
         } else {
-            if pos == 255 && dif == 255 {
-                return None;
-            } else {
-                pos = dequeue_pos.load(Ordering::Relaxed);
-            }
+            pos = dequeue_pos.load(Ordering::Relaxed);
         }
     }
 
@@ -523,7 +519,7 @@ unsafe fn enqueue<T>(
     loop {
         cell = buffer.add(usize::from(pos & mask));
         let seq = (*cell).sequence.load(Ordering::Acquire);
-        let dif = i16::from(seq) - i16::from(pos);
+        let dif = (seq as i8) - (pos as i8);
 
         if dif == 0 {
             if enqueue_pos

--- a/src/mpmc.rs
+++ b/src/mpmc.rs
@@ -577,4 +577,18 @@ mod tests {
         // this should not block forever
         assert_eq!(q.dequeue(), None);
     }
+
+    #[test]
+    fn full_at_wrapped_pos0() {
+        let q = Q2::new();
+        for _ in 0..254 {
+            assert!(q.enqueue(0).is_ok());
+            assert_eq!(q.dequeue(), Some(0));
+        }
+        assert!(q.enqueue(0).is_ok());
+        assert!(q.enqueue(0).is_ok());
+        // this should not block forever
+        assert!(q.enqueue(0).is_err());
+    }
+
 }

--- a/src/mpmc.rs
+++ b/src/mpmc.rs
@@ -568,13 +568,13 @@ mod tests {
     }
 
     #[test]
-    fn blocking() {
+    fn drain_at_pos255() {
         let q = Q2::new();
         for _ in 0..255 {
             q.enqueue(0).unwrap();
             q.dequeue();
         }
         // this should not block forever
-        q.dequeue();
+        assert_eq!(q.dequeue(), None);
     }
 }

--- a/src/mpmc.rs
+++ b/src/mpmc.rs
@@ -586,5 +586,4 @@ mod tests {
         // this should not block forever
         assert!(q.enqueue(0).is_err());
     }
-
 }


### PR DESCRIPTION
This p-r adds a new test case `full_at_wrapped_pos0`, which went into infinite loop. This p-r fixes the problem by using `i8` (instead of `i16`) to calculate the `dif` (`seq - pos` in `enqueue`, `seq - (pos + 1)` in `dequeue`).

The root cause of this problem was basically the same as #121: when the `pos` goes beyond 255, it wraps back to 0 because `pos` is in `u8`. When the `u8` wrapping occurs, the sign of `dif` becomes inverse, which caused the problem.

Using `i8` for `dif` fixes the problem, because even when the `u8` wrapping occurs, the `dif` is wrapped again in `i8`, so we get the right sign for `dif`. `i8` only allows values in [-127, 128], but `|dif|` is at most the size of the queue. The size of the queue is at most 64 in this library, so it's no problem.

This p-r removes the fix introduced by #121, because the fix in this p-r also fixes the problem reported in it.
