### PR TITLE
Implement StableDeref for singleton::Box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Added `StableDeref` implementation for `pool::Box` and `pool::singleton::Box`.
+
 ## [v0.5.3] - 2020-01-27
 
 ### Added

--- a/src/pool/mod.rs
+++ b/src/pool/mod.rs
@@ -375,7 +375,7 @@ unsafe impl<T, S> Send for Box<T, S> where T: Send {}
 
 unsafe impl<T, S> Sync for Box<T, S> where T: Sync {}
 
-unsafe impl<T> stable_deref_trait::StableDeref for Box<T>  {}
+unsafe impl<T> stable_deref_trait::StableDeref for Box<T> {}
 
 impl<A> AsSlice for Box<A>
 where

--- a/src/pool/singleton.rs
+++ b/src/pool/singleton.rs
@@ -160,6 +160,8 @@ where
     }
 }
 
+unsafe impl<P: Pool> stable_deref_trait::StableDeref for Box<P> {}
+
 impl<P> fmt::Debug for Box<P>
 where
     P: Pool,


### PR DESCRIPTION
There was a discussion in the riot channel about what it's needed for a buffer to be DMA safe, where ra_kete came up with this POC:
https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=339a9a29fb59c080b42b6d77a902acb6

Where it seems that the requirements described in the [Embedonomicon](https://docs.rust-embedded.org/embedonomicon/dma.html#static-bound) doesn't seem to be enough to prevent stack corruption.

If that is really the case and we decide to use `StableDeref` instead, then a implementation for Box is very important to be able to easily use it on DMA APIs and a new point release would be necessary.

CC @korken89 