### PR TITLE
Make Producer<..., SingleCore> Send, like Consumer

### DIFF
--- a/src/spsc/split.rs
+++ b/src/spsc/split.rs
@@ -61,11 +61,12 @@ where
     _marker: PhantomData<&'a ()>,
 }
 
-unsafe impl<'a, T, N, U> Send for Producer<'a, T, N, U>
+unsafe impl<'a, T, N, U, C> Send for Producer<'a, T, N, U, C>
 where
     N: ArrayLength<T>,
     T: Send,
     U: sealed::Uxx,
+    C: sealed::XCore,
 {
 }
 


### PR DESCRIPTION
I assume there's no reason that only multi-core Producers are marked
Send, while Consumers are not (they're pretty symmetrical).

(Context: I'm trying to use an SPSC queue on a single cortex-m0 MCU.
So I can guarantee that a SingleCore queue is safe because there is no
other core it could possibly be shared with.  The RTFM framework adds
an assert_send on the producer, since it's shared between init and an
SPI receiver interrupt.  It also adds an assert_send on the Consumer,
since it's shared between init and the I2C transmit interrupt, but that one
works since Consumer has this extra C type in the impl already.)