### PR TITLE
indexmap: expose PowerOfTwo, Bucket and Pos

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,9 +68,9 @@
 #![deny(warnings)]
 
 pub use binary_heap::BinaryHeap;
-pub use generic_array::typenum::consts;
+pub use generic_array::typenum::{consts, PowerOfTwo};
 pub use generic_array::ArrayLength;
-pub use indexmap::{FnvIndexMap, IndexMap};
+pub use indexmap::{Bucket, FnvIndexMap, IndexMap, Pos};
 pub use indexset::{FnvIndexSet, IndexSet};
 pub use linear_map::LinearMap;
 pub use string::String;


### PR DESCRIPTION
This change allows the create custom structs based on `IndexMap` with size arguments outside
the heapless crate itself.

For example:
```rust
use heapless::consts::*;
use heapless::{ArrayLength, Bucket, FnvIndexMap, Pos, PowerOfTwo};

struct CustomMap<S>
where
    S: ArrayLength<Bucket<u8, u16>> + ArrayLength<Option<Pos>> + PowerOfTwo,
{
    map: FnvIndexMap<u8, u16, S>,
}

impl<S> CustomMap<S>
where
    S: ArrayLength<Bucket<u8, u16>> + ArrayLength<Option<Pos>> + PowerOfTwo,
{
    fn new() -> CustomMap<S> {
        CustomMap {
            map: FnvIndexMap::<_, _, S>::new(),
        }
    }
}

fn main() {
    let mut bla = CustomMap::<U8>::new();

    bla.map.insert(8, 16).unwrap();
}
```

I can imagine that exposing these types is not preferable, but at least it would help for my usecase. Or is there a way where exposing these types is not needed?