### PR TITLE
Extend ARMv7-R `Pool` support to the bare-metal `armebv7r-` targets

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -11,7 +11,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         println!("cargo:rustc-cfg=armv7m");
     } else if target.starts_with("thumbv7em-") {
         println!("cargo:rustc-cfg=armv7m");
-    } else if target.starts_with("armv7r-") {
+    } else if target.starts_with("armv7r-") | target.starts_with("armebv7r-") {
         println!("cargo:rustc-cfg=armv7r");
     } else if target.starts_with("thumbv8m.base") {
         println!("cargo:rustc-cfg=armv8m_base");


### PR DESCRIPTION
Extends support for singleton `Pool`s to include the `armebv7r-none-eabi` and `armebv7r-none-eabihf` targets.