### PR TITLE
add [target.x86_64-apple-darwin.dev-dependencies]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ x86-sync-pool = []
 __trybuild = []
 
 [target.x86_64-unknown-linux-gnu.dev-dependencies]
+[target.x86_64-apple-darwin.dev-dependencies]
 scoped_threadpool = "0.1.8"
 
 [dependencies]


### PR DESCRIPTION
Now it can be built on macOS.