### PR TITLE
histbuf: replace slow modulo operations

### DIFF
--- a/src/histbuf.rs
+++ b/src/histbuf.rs
@@ -122,7 +122,7 @@ where
     /// Writes an element to the buffer, overwriting the oldest value.
     pub fn write(&mut self, t: T) {
         self.data[self.write_at] = t;
-        self.write_at = self.write_at + 1;
+        self.write_at += 1;
         if self.write_at == self.len() {
             self.write_at = 0;
         }
@@ -156,9 +156,9 @@ where
     /// ```
     pub fn recent(&self) -> &T {
         if self.write_at == 0 {
-            &self.data[(self.len() - 1)]
+            &self.data[self.len() - 1]
         } else {
-            &self.data[(self.write_at - 1)]
+            &self.data[self.write_at - 1]
         }
     }
 

--- a/src/histbuf.rs
+++ b/src/histbuf.rs
@@ -122,7 +122,10 @@ where
     /// Writes an element to the buffer, overwriting the oldest value.
     pub fn write(&mut self, t: T) {
         self.data[self.write_at] = t;
-        self.write_at = (self.write_at + 1) % self.len();
+        self.write_at = self.write_at + 1;
+        if self.write_at == self.len() {
+            self.write_at = 0;
+        }
     }
 
     /// Clones and writes all elements in a slice to the buffer.
@@ -152,7 +155,11 @@ where
     /// assert_eq!(x.recent(), &10);
     /// ```
     pub fn recent(&self) -> &T {
-        &self.data[(self.write_at + self.len() - 1) % self.len()]
+        if self.write_at == 0 {
+            &self.data[(self.len() - 1)]
+        } else {
+            &self.data[(self.write_at - 1)]
+        }
     }
 
     /// Returns the array slice backing the buffer, without keeping track


### PR DESCRIPTION
STM32G081 Cortex-M0 64MHz
thumbv6m-none-eabi
Rust 1.43.1

RTFM application where data from ADC channels is added to `HistoryBuffers`:
```Rust
// this is shared with DMA
static mut ADC_DATA: [u16; 6] = [0; 6];
...
// this interrupt fires when DMA has finished sequencing all ADC channels
#[task(binds = DMA_CHANNEL1, resources = [pa9, adc_data, hist0, hist1, hist2, hist3, hist4, hist5])]
fn adc_data_ready(ctx: adc_data_ready::Context) {
    let dma = unsafe { &(*stm32::DMA::ptr()) };
    // transfer complete flag clear
    dma.ifcr.write(|w| w.ctcif1().set_bit());

    ctx.resources.pa9.set_high().unwrap();
    
    ctx.resources.hist0.write(ctx.resources.adc_data[0]);
    ctx.resources.hist1.write(ctx.resources.adc_data[1]);
    ctx.resources.hist2.write(ctx.resources.adc_data[2]);
    ctx.resources.hist3.write(ctx.resources.adc_data[3]);
    ctx.resources.hist4.write(ctx.resources.adc_data[4]);
    ctx.resources.hist5.write(ctx.resources.adc_data[5]);
    
    ctx.resources.pa9.set_low().unwrap();
}
```

Time is measured from `PA9` pin using logic analyzer.
```
[profile.release]
opt-level = "s"
codegen-units = 1
debug = true
lto = true
```

- before `27.6 us`
- with fix `4.4 us`


```
[profile.release]
opt-level = 2
codegen-units = 1
debug = true
lto = true
```

- before `25.9 us`
- with fix `2.9 us`