### PR TITLE
defmt impl for Vec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ x86-sync-pool = []
 __trybuild = []
 # Enable larger MPMC sizes.
 mpmc_large = []
+defmt-impl = ["defmt"]
 
 [target.x86_64-unknown-linux-gnu.dev-dependencies]
 scoped_threadpool = "0.1.8"
@@ -49,3 +50,12 @@ optional = true
 
 [dev-dependencies.ufmt]
 version = "0.1"
+
+[dependencies.defmt]
+version = "0.2.1"
+optional = true
+
+[dev-dependencies.defmt]
+version = "0.2.1"
+features = ["unstable-test"]
+

--- a/src/defmt.rs
+++ b/src/defmt.rs
@@ -5,8 +5,8 @@ use crate::Vec;
 use defmt::Formatter;
 
 impl<T, const N: usize> defmt::Format for Vec<T, N>
-    where
-        T: defmt::Format,
+where
+    T: defmt::Format,
 {
     fn format(&self, fmt: Formatter<'_>) {
         defmt::write!(fmt, "{=[?]}", self.as_slice())
@@ -14,8 +14,8 @@ impl<T, const N: usize> defmt::Format for Vec<T, N>
 }
 
 impl<const N: usize> defmt::Format for crate::String<N>
-    where
-        u8: defmt::Format,
+where
+    u8: defmt::Format,
 {
     fn format(&self, fmt: Formatter<'_>) {
         defmt::write!(fmt, "{=str}", self.as_str());

--- a/src/defmt.rs
+++ b/src/defmt.rs
@@ -1,0 +1,56 @@
+//! Defmt implementations for heapless types
+//!
+
+use crate::Vec;
+use defmt::Formatter;
+
+impl<T, const N: usize> defmt::Format for Vec<T, N>
+    where
+        T: defmt::Format,
+{
+    fn format(&self, fmt: Formatter<'_>) {
+        defmt::write!(fmt, "{=[?]}", self.as_slice())
+    }
+}
+
+impl<const N: usize> defmt::Format for crate::String<N>
+    where
+        u8: defmt::Format,
+{
+    fn format(&self, fmt: Formatter<'_>) {
+        defmt::write!(fmt, "{=str}", self.as_str());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Vec;
+    use defmt::Format;
+
+    #[test]
+    /// Tests encoding Vec with defmt, asserting these types may be serialized
+    /// Note: the exact wire format is NOT checked since its an unstable implementation detail of an external crate.
+    /// based on https://github.com/knurling-rs/defmt/blob/697a8e807bd766a80ada2d57514a9da1232dbc9a/tests/encode.rs#L523
+    fn test_defmt_format_vec() {
+        let val: Vec<_, 8> = Vec::from_slice(b"abc").unwrap();
+
+        let mut f = defmt::InternalFormatter::new();
+        let g = defmt::Formatter { inner: &mut f };
+        val.format(g);
+        f.finalize();
+    }
+
+    /// Tests encoding String with defmt, asserting these types may be serialized
+    /// Note: the exact wire format is NOT checked since its an unstable implementation detail of an external crate.
+    /// based loosely on https://github.com/knurling-rs/defmt/blob/main/tests/encode.rs#L483
+    #[test]
+    fn test_defmt_format_str() {
+        let mut val: crate::String<32> = crate::String::new();
+        val.push_str("foo").unwrap();
+
+        let mut f = defmt::InternalFormatter::new();
+        let g = defmt::Formatter { inner: &mut f };
+        val.format(g);
+        f.finalize();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,8 @@ mod de;
 mod ser;
 
 pub mod binary_heap;
+#[cfg(feature = "defmt-impl")]
+mod defmt;
 #[cfg(all(has_cas, feature = "cas"))]
 pub mod mpmc;
 #[cfg(all(has_cas, feature = "cas"))]


### PR DESCRIPTION
This PR adds support for encoding `heapless::Vec` for usage with `defmt`.
`defmt` can already handle slices, so this impl simply invokes that encoder method.

I chose to use the slice implementation is I did not perceive the difference between a Vec and a Slice to be of specific importance in a log file, but rather the contents of the vec / slice to be of interest. It also appeared to me as the path of least resistance.

I am marking this as a draft as I have yet to be able to validate this against my local hardware, `probe-run` is giving me some grief that I am reasonably sure is unrelated to this change set. 

Relates to #171 