### PR TITLE
Version bump dependency 'as-slice' -> 0.1.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ __trybuild = []
 scoped_threadpool = "0.1.8"
 
 [dependencies]
-as-slice = "0.1.0"
+as-slice = "0.1.4"
 generic-array = "0.13.0"
 hash32 = "0.1.0"
 


### PR DESCRIPTION
This fixes the issue I was having targeting AVR.

See: https://github.com/japaric/heapless/issues/177#issuecomment-697341580

## REPRO

```
(base) ~/temp/break/abc $ cargo build
    Updating crates.io index
   Compiling compiler_builtins v0.1.35
   Compiling core v0.0.0 (/home/todd/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core)
   Compiling typenum v1.12.0
   Compiling version_check v0.9.2
   Compiling byteorder v1.3.4
   Compiling heapless v0.5.6 (/home/todd/temp/heapless)
   Compiling generic-array v0.14.4
   Compiling rustc-std-workspace-core v1.99.0 (/home/todd/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/rustc-std-workspace-core)
   Compiling stable_deref_trait v1.2.0
   Compiling hash32 v0.1.1
   Compiling generic-array v0.12.3
   Compiling generic-array v0.13.2
   Compiling as-slice v0.1.4
   Compiling abc v0.1.0 (/home/todd/temp/break/abc)
    Finished dev [unoptimized + debuginfo] target(s) in 26.46s
```