### PR TITLE
Remove GHA ci-failure job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -310,16 +310,3 @@ jobs:
     steps:
       - name: Mark the job as a success
         run: exit 0
-  ci-failure:
-    name: ci
-    if: github.event_name == 'push' && !success()
-    needs:
-      - style
-      - check
-      - testcpass
-      - testtsan
-      - testcfail
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Mark the job as a failure
-        run: exit 1


### PR DESCRIPTION
Needed for full GHA functionality together with Bors

See [here](https://github.com/bors-ng/bors-ng/issues/1129) for details on the Bors change.

RTIC project among others faced the same issue