### PR TITLE
Bump generic-array to v0.14.2 (MSRV remains the same)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.6.0] - 2021-02-02
+
+### Changed
+
+- [breaking-change] The version of the `generic-array` dependency has been
+  bumped to v0.14.2.
+
 ## [v0.5.6] - 2020-09-18
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ keywords = [
 license = "MIT OR Apache-2.0"
 name = "heapless"
 repository = "https://github.com/japaric/heapless"
-version = "0.5.6"
+version = "0.6.0"
 
 [features]
 default = ["cas"]
@@ -33,7 +33,7 @@ scoped_threadpool = "0.1.8"
 
 [dependencies]
 as-slice = "0.1.4"
-generic-array = "0.13.0"
+generic-array = "0.14.2"
 hash32 = "0.1.0"
 
 [dependencies.serde]


### PR DESCRIPTION
En attendant `min_const_generics` :)

Fixes the UB reported in https://github.com/fizyk20/generic-array/issues/97.
Thanks to https://github.com/fizyk20/generic-array/pull/102, the MSRV remains the same, 1.36.0.

Closes https://github.com/japaric/heapless/issues/166.
