### PR TITLE
Update generic-array and as-slice to security patched versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ scoped_threadpool = "0.1.8"
 
 [dependencies]
 as-slice = "0.1.4"
-generic-array = "0.14.2"
+generic-array = "0.14.4"
 hash32 = "0.1.0"
 
 [dependencies.serde]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ __trybuild = []
 scoped_threadpool = "0.1.8"
 
 [dependencies]
-as-slice = "0.1.4"
+as-slice = "0.1.5"
 generic-array = "0.14.4"
 hash32 = "0.1.0"
 


### PR DESCRIPTION
Resolves RUSTSEC-2020-0145

https://github.com/RustSec/advisory-db/pull/779
