### PR TITLE
Allow u8 and u16 to be used as the length of Vec-based containers

### DIFF
--- a/cfail/ui/u16-vec.rs
+++ b/cfail/ui/u16-vec.rs
@@ -1,0 +1,9 @@
+//! Vec with u16 length and capacity of 65536
+
+use core::marker::PhantomData;
+
+use heapless::{consts::*, Vec};
+
+fn main() {
+    let _s: PhantomData<Vec<u8, U65536, u16>>;
+}

--- a/cfail/ui/u16-vec.stderr
+++ b/cfail/ui/u16-vec.stderr
@@ -1,0 +1,7 @@
+error[E0277]: the trait bound `typenum::bit::B0: typenum::marker_traits::NonZero` is not satisfied
+ --> $DIR/u16-vec.rs:8:13
+  |
+8 |     let _s: PhantomData<Vec<u8, U65536, u16>>;
+  |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `typenum::marker_traits::NonZero` is not implemented for `typenum::bit::B0`
+  |
+  = note: required by `heapless::vec::Vec`

--- a/cfail/ui/u8-vec.rs
+++ b/cfail/ui/u8-vec.rs
@@ -1,0 +1,9 @@
+//! Vec with u8 length and capacity of 256
+
+use core::marker::PhantomData;
+
+use heapless::{consts::*, Vec};
+
+fn main() {
+    let _s: PhantomData<Vec<u8, U256, u8>>;
+}

--- a/cfail/ui/u8-vec.stderr
+++ b/cfail/ui/u8-vec.stderr
@@ -1,0 +1,7 @@
+error[E0277]: the trait bound `typenum::bit::B0: typenum::marker_traits::NonZero` is not satisfied
+ --> $DIR/u8-vec.rs:8:13
+  |
+8 |     let _s: PhantomData<Vec<u8, U256, u8>>;
+  |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `typenum::marker_traits::NonZero` is not implemented for `typenum::bit::B0`
+  |
+  = note: required by `heapless::vec::Vec`

--- a/src/binary_heap.rs
+++ b/src/binary_heap.rs
@@ -26,13 +26,13 @@ pub enum Min {}
 /// Max-heap
 pub enum Max {}
 
-impl<A, K> crate::i::BinaryHeap<A, K> {
+impl<A, K, U> crate::i::BinaryHeap<A, K, U> {
     /// `BinaryHeap` `const` constructor; wrap the returned value in
     /// [`BinaryHeap`](../struct.BinaryHeap.html)
     pub const fn new() -> Self {
         Self {
             _kind: PhantomData,
-            data: crate::i::Vec::new(),
+            data: crate::i::Vec::<A, U>::new(),
         }
     }
 }
@@ -84,15 +84,15 @@ impl<A, K> crate::i::BinaryHeap<A, K> {
 /// // The heap should now be empty.
 /// assert!(heap.is_empty())
 /// ```
-pub struct BinaryHeap<T, N, KIND>(
-    #[doc(hidden)] pub crate::i::BinaryHeap<GenericArray<T, N>, KIND>,
+pub struct BinaryHeap<T, N, KIND, U>(
+    #[doc(hidden)] pub crate::i::BinaryHeap<GenericArray<T, N>, KIND, U>,
 )
 where
     T: Ord,
     N: ArrayLength<T>,
     KIND: Kind;
 
-impl<T, N, K> BinaryHeap<T, N, K>
+impl<T, N, K, U> BinaryHeap<T, N, K, U>
 where
     T: Ord,
     N: ArrayLength<T>,
@@ -254,7 +254,7 @@ where
     ///
     /// assert_eq!(heap.peek(), Some(&2));
     /// ```
-    pub fn peek_mut(&mut self) -> Option<PeekMut<'_, T, N, K>> {
+    pub fn peek_mut(&mut self) -> Option<PeekMut<'_, T, N, K, U>> {
         if self.is_empty() {
             None
         } else {
@@ -437,17 +437,17 @@ impl<'a, T> Hole<'a, T> {
 ///
 /// [`peek_mut`]: struct.BinaryHeap.html#method.peek_mut
 /// [`BinaryHeap`]: struct.BinaryHeap.html
-pub struct PeekMut<'a, T, N, K>
+pub struct PeekMut<'a, T, N, K, U>
 where
     T: Ord,
     N: ArrayLength<T>,
     K: Kind,
 {
-    heap: &'a mut BinaryHeap<T, N, K>,
+    heap: &'a mut BinaryHeap<T, N, K, U>,
     sift: bool,
 }
 
-impl<T, N, K> Drop for PeekMut<'_, T, N, K>
+impl<T, N, K, U> Drop for PeekMut<'_, T, N, K, U>
 where
     T: Ord,
     N: ArrayLength<T>,
@@ -460,7 +460,7 @@ where
     }
 }
 
-impl<T, N, K> Deref for PeekMut<'_, T, N, K>
+impl<T, N, K, U> Deref for PeekMut<'_, T, N, K, U>
 where
     T: Ord,
     N: ArrayLength<T>,
@@ -474,7 +474,7 @@ where
     }
 }
 
-impl<T, N, K> DerefMut for PeekMut<'_, T, N, K>
+impl<T, N, K, U> DerefMut for PeekMut<'_, T, N, K, U>
 where
     T: Ord,
     N: ArrayLength<T>,
@@ -487,14 +487,14 @@ where
     }
 }
 
-impl<'a, T, N, K> PeekMut<'a, T, N, K>
+impl<'a, T, N, K, U> PeekMut<'a, T, N, K, U>
 where
     T: Ord,
     N: ArrayLength<T>,
     K: Kind,
 {
     /// Removes the peeked value from the heap and returns it.
-    pub fn pop(mut this: PeekMut<'a, T, N, K>) -> T {
+    pub fn pop(mut this: PeekMut<'a, T, N, K, U>) -> T {
         let value = this.heap.pop().unwrap();
         this.sift = false;
         value
@@ -512,7 +512,7 @@ impl<'a, T> Drop for Hole<'a, T> {
     }
 }
 
-impl<T, N, K> Default for BinaryHeap<T, N, K>
+impl<T, N, K, U> Default for BinaryHeap<T, N, K, U>
 where
     T: Ord,
     N: ArrayLength<T>,
@@ -523,7 +523,7 @@ where
     }
 }
 
-impl<T, N, K> Clone for BinaryHeap<T, N, K>
+impl<T, N, K, U> Clone for BinaryHeap<T, N, K, U>
 where
     N: ArrayLength<T>,
     K: Kind,
@@ -537,7 +537,7 @@ where
     }
 }
 
-impl<T, N, K> Drop for BinaryHeap<T, N, K>
+impl<T, N, K, U> Drop for BinaryHeap<T, N, K, U>
 where
     N: ArrayLength<T>,
     K: Kind,
@@ -548,7 +548,7 @@ where
     }
 }
 
-impl<T, N, K> fmt::Debug for BinaryHeap<T, N, K>
+impl<T, N, K, U> fmt::Debug for BinaryHeap<T, N, K, U>
 where
     N: ArrayLength<T>,
     K: Kind,
@@ -559,7 +559,7 @@ where
     }
 }
 
-impl<'a, T, N, K> IntoIterator for &'a BinaryHeap<T, N, K>
+impl<'a, T, N, K, U> IntoIterator for &'a BinaryHeap<T, N, K, U>
 where
     N: ArrayLength<T>,
     K: Kind,
@@ -584,7 +584,7 @@ mod tests {
 
     #[test]
     fn static_new() {
-        static mut _B: BinaryHeap<i32, U16, Min> = BinaryHeap(crate::i::BinaryHeap::new());
+        static mut _B: BinaryHeap<i32, U16, Min, usize> = BinaryHeap(crate::i::BinaryHeap::new());
     }
 
     #[test]

--- a/src/binary_heap.rs
+++ b/src/binary_heap.rs
@@ -607,12 +607,13 @@ mod tests {
 
     #[test]
     fn static_new() {
-        static mut _B: BinaryHeap<i32, U16, Min, usize> = BinaryHeap(crate::i::BinaryHeap::new());
+        static mut _B: BinaryHeap<i32, U16, Min, u8> =
+            BinaryHeap(crate::i::BinaryHeap::<_, _, u8>::new());
     }
 
     #[test]
     fn min() {
-        let mut heap = BinaryHeap::<_, U16, Min>::new();
+        let mut heap = BinaryHeap::<_, U16, Min, u8>::new();
         heap.push(1).unwrap();
         heap.push(2).unwrap();
         heap.push(3).unwrap();
@@ -664,7 +665,7 @@ mod tests {
 
     #[test]
     fn max() {
-        let mut heap = BinaryHeap::<_, U16, binary_heap::Max>::new();
+        let mut heap = BinaryHeap::<_, U16, binary_heap::Max, u8>::new();
         heap.push(1).unwrap();
         heap.push(2).unwrap();
         heap.push(3).unwrap();

--- a/src/binary_heap.rs
+++ b/src/binary_heap.rs
@@ -16,7 +16,7 @@ use core::{
     ptr, slice,
 };
 
-use generic_array::{ArrayLength, GenericArray};
+use generic_array::{typenum::IsLess, ArrayLength, GenericArray};
 
 use crate::{sealed::binary_heap::Kind, vec::MaxCapacity};
 
@@ -97,14 +97,14 @@ pub struct BinaryHeap<T, N, KIND, U>(
 )
 where
     T: Ord,
-    N: ArrayLength<T>,
+    N: ArrayLength<T> + IsLess<U::Cap>,
     KIND: Kind,
     U: MaxCapacity;
 
 impl<T, N, K, U> BinaryHeap<T, N, K, U>
 where
     T: Ord,
-    N: ArrayLength<T>,
+    N: ArrayLength<T> + IsLess<U::Cap>,
     K: Kind,
     U: MaxCapacity,
 {
@@ -453,7 +453,7 @@ impl<'a, T> Hole<'a, T> {
 pub struct PeekMut<'a, T, N, K, U>
 where
     T: Ord,
-    N: ArrayLength<T>,
+    N: ArrayLength<T> + IsLess<U::Cap>,
     K: Kind,
     U: MaxCapacity,
 {
@@ -464,7 +464,7 @@ where
 impl<T, N, K, U> Drop for PeekMut<'_, T, N, K, U>
 where
     T: Ord,
-    N: ArrayLength<T>,
+    N: ArrayLength<T> + IsLess<U::Cap>,
     K: Kind,
     U: MaxCapacity,
 {
@@ -478,7 +478,7 @@ where
 impl<T, N, K, U> Deref for PeekMut<'_, T, N, K, U>
 where
     T: Ord,
-    N: ArrayLength<T>,
+    N: ArrayLength<T> + IsLess<U::Cap>,
     K: Kind,
     U: MaxCapacity,
 {
@@ -493,7 +493,7 @@ where
 impl<T, N, K, U> DerefMut for PeekMut<'_, T, N, K, U>
 where
     T: Ord,
-    N: ArrayLength<T>,
+    N: ArrayLength<T> + IsLess<U::Cap>,
     K: Kind,
     U: MaxCapacity,
 {
@@ -507,7 +507,7 @@ where
 impl<'a, T, N, K, U> PeekMut<'a, T, N, K, U>
 where
     T: Ord,
-    N: ArrayLength<T>,
+    N: ArrayLength<T> + IsLess<U::Cap>,
     K: Kind,
     U: MaxCapacity,
 {
@@ -533,7 +533,7 @@ impl<'a, T> Drop for Hole<'a, T> {
 impl<T, N, K, U> Default for BinaryHeap<T, N, K, U>
 where
     T: Ord,
-    N: ArrayLength<T>,
+    N: ArrayLength<T> + IsLess<U::Cap>,
     K: Kind,
     U: MaxCapacity,
 {
@@ -544,7 +544,7 @@ where
 
 impl<T, N, K, U> Clone for BinaryHeap<T, N, K, U>
 where
-    N: ArrayLength<T>,
+    N: ArrayLength<T> + IsLess<U::Cap>,
     K: Kind,
     T: Ord + Clone,
     U: MaxCapacity,
@@ -559,7 +559,7 @@ where
 
 impl<T, N, K, U> Drop for BinaryHeap<T, N, K, U>
 where
-    N: ArrayLength<T>,
+    N: ArrayLength<T> + IsLess<U::Cap>,
     K: Kind,
     T: Ord,
     U: MaxCapacity,
@@ -571,7 +571,7 @@ where
 
 impl<T, N, K, U> fmt::Debug for BinaryHeap<T, N, K, U>
 where
-    N: ArrayLength<T>,
+    N: ArrayLength<T> + IsLess<U::Cap>,
     K: Kind,
     T: Ord + fmt::Debug,
     U: MaxCapacity,
@@ -583,7 +583,7 @@ where
 
 impl<'a, T, N, K, U> IntoIterator for &'a BinaryHeap<T, N, K, U>
 where
-    N: ArrayLength<T>,
+    N: ArrayLength<T> + IsLess<U::Cap>,
     K: Kind,
     T: Ord,
     U: MaxCapacity,

--- a/src/binary_heap.rs
+++ b/src/binary_heap.rs
@@ -16,7 +16,10 @@ use core::{
     ptr, slice,
 };
 
-use generic_array::{typenum::IsLess, ArrayLength, GenericArray};
+use generic_array::{
+    typenum::{IsLess, NonZero},
+    ArrayLength, GenericArray,
+};
 
 use crate::{sealed::binary_heap::Kind, vec::MaxCapacity};
 
@@ -99,6 +102,7 @@ pub struct BinaryHeap<T, N, KIND, U = usize>(
 where
     T: Ord,
     N: ArrayLength<T> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     KIND: Kind,
     U: MaxCapacity;
 
@@ -106,6 +110,7 @@ impl<T, N, K, U> BinaryHeap<T, N, K, U>
 where
     T: Ord,
     N: ArrayLength<T> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     K: Kind,
     U: MaxCapacity,
 {
@@ -455,6 +460,7 @@ pub struct PeekMut<'a, T, N, K, U>
 where
     T: Ord,
     N: ArrayLength<T> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     K: Kind,
     U: MaxCapacity,
 {
@@ -466,6 +472,7 @@ impl<T, N, K, U> Drop for PeekMut<'_, T, N, K, U>
 where
     T: Ord,
     N: ArrayLength<T> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     K: Kind,
     U: MaxCapacity,
 {
@@ -480,6 +487,7 @@ impl<T, N, K, U> Deref for PeekMut<'_, T, N, K, U>
 where
     T: Ord,
     N: ArrayLength<T> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     K: Kind,
     U: MaxCapacity,
 {
@@ -495,6 +503,7 @@ impl<T, N, K, U> DerefMut for PeekMut<'_, T, N, K, U>
 where
     T: Ord,
     N: ArrayLength<T> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     K: Kind,
     U: MaxCapacity,
 {
@@ -509,6 +518,7 @@ impl<'a, T, N, K, U> PeekMut<'a, T, N, K, U>
 where
     T: Ord,
     N: ArrayLength<T> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     K: Kind,
     U: MaxCapacity,
 {
@@ -535,6 +545,7 @@ impl<T, N, K, U> Default for BinaryHeap<T, N, K, U>
 where
     T: Ord,
     N: ArrayLength<T> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     K: Kind,
     U: MaxCapacity,
 {
@@ -546,6 +557,7 @@ where
 impl<T, N, K, U> Clone for BinaryHeap<T, N, K, U>
 where
     N: ArrayLength<T> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     K: Kind,
     T: Ord + Clone,
     U: MaxCapacity,
@@ -561,6 +573,7 @@ where
 impl<T, N, K, U> Drop for BinaryHeap<T, N, K, U>
 where
     N: ArrayLength<T> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     K: Kind,
     T: Ord,
     U: MaxCapacity,
@@ -573,6 +586,7 @@ where
 impl<T, N, K, U> fmt::Debug for BinaryHeap<T, N, K, U>
 where
     N: ArrayLength<T> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     K: Kind,
     T: Ord + fmt::Debug,
     U: MaxCapacity,
@@ -585,6 +599,7 @@ where
 impl<'a, T, N, K, U> IntoIterator for &'a BinaryHeap<T, N, K, U>
 where
     N: ArrayLength<T> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     K: Kind,
     T: Ord,
     U: MaxCapacity,

--- a/src/binary_heap.rs
+++ b/src/binary_heap.rs
@@ -26,19 +26,24 @@ pub enum Min {}
 /// Max-heap
 pub enum Max {}
 
-impl<A, K, U> crate::i::BinaryHeap<A, K, U>
-where
-    U: MaxCapacity,
-{
-    /// `BinaryHeap` `const` constructor; wrap the returned value in
-    /// [`BinaryHeap`](../struct.BinaryHeap.html)
-    pub const fn new() -> Self {
-        Self {
-            _kind: PhantomData,
-            data: crate::i::Vec::<A, U>::new(),
+macro_rules! impl_new {
+    ($u:ident) => {
+        impl<A, K> crate::i::BinaryHeap<A, K, $u> {
+            /// `BinaryHeap` `const` constructor; wrap the returned value in
+            /// [`BinaryHeap`](../struct.BinaryHeap.html)
+            pub const fn new() -> Self {
+                Self {
+                    _kind: PhantomData,
+                    data: crate::i::Vec::<A, $u>::new(),
+                }
+            }
         }
-    }
+    };
 }
+
+impl_new!(u8);
+impl_new!(u16);
+impl_new!(usize);
 
 /// A priority queue implemented with a binary heap.
 ///
@@ -118,7 +123,10 @@ where
     /// static mut HEAP: BinaryHeap<i32, U8, Max> = BinaryHeap(heapless::i::BinaryHeap::new());
     /// ```
     pub fn new() -> Self {
-        BinaryHeap(crate::i::BinaryHeap::new())
+        BinaryHeap(crate::i::BinaryHeap {
+            _kind: PhantomData,
+            data: crate::i::Vec::new_nonconst(),
+        })
     }
 
     /* Public API */

--- a/src/binary_heap.rs
+++ b/src/binary_heap.rs
@@ -92,7 +92,7 @@ impl_new!(usize);
 /// // The heap should now be empty.
 /// assert!(heap.is_empty())
 /// ```
-pub struct BinaryHeap<T, N, KIND, U>(
+pub struct BinaryHeap<T, N, KIND, U = usize>(
     #[doc(hidden)] pub crate::i::BinaryHeap<GenericArray<T, N>, KIND, U>,
 )
 where

--- a/src/binary_heap.rs
+++ b/src/binary_heap.rs
@@ -18,7 +18,7 @@ use core::{
 
 use generic_array::{ArrayLength, GenericArray};
 
-use crate::sealed::binary_heap::Kind;
+use crate::{sealed::binary_heap::Kind, vec::MaxCapacity};
 
 /// Min-heap
 pub enum Min {}
@@ -26,7 +26,10 @@ pub enum Min {}
 /// Max-heap
 pub enum Max {}
 
-impl<A, K, U> crate::i::BinaryHeap<A, K, U> {
+impl<A, K, U> crate::i::BinaryHeap<A, K, U>
+where
+    U: MaxCapacity,
+{
     /// `BinaryHeap` `const` constructor; wrap the returned value in
     /// [`BinaryHeap`](../struct.BinaryHeap.html)
     pub const fn new() -> Self {
@@ -90,13 +93,15 @@ pub struct BinaryHeap<T, N, KIND, U>(
 where
     T: Ord,
     N: ArrayLength<T>,
-    KIND: Kind;
+    KIND: Kind,
+    U: MaxCapacity;
 
 impl<T, N, K, U> BinaryHeap<T, N, K, U>
 where
     T: Ord,
     N: ArrayLength<T>,
     K: Kind,
+    U: MaxCapacity,
 {
     /* Constructors */
     /// Creates an empty BinaryHeap as a $K-heap.
@@ -155,7 +160,7 @@ where
     /// assert_eq!(heap.len(), 2);
     /// ```
     pub fn len(&self) -> usize {
-        self.0.data.len
+        self.0.data.len.into()
     }
 
     /// Checks if the binary heap is empty.
@@ -442,6 +447,7 @@ where
     T: Ord,
     N: ArrayLength<T>,
     K: Kind,
+    U: MaxCapacity,
 {
     heap: &'a mut BinaryHeap<T, N, K, U>,
     sift: bool,
@@ -452,6 +458,7 @@ where
     T: Ord,
     N: ArrayLength<T>,
     K: Kind,
+    U: MaxCapacity,
 {
     fn drop(&mut self) {
         if self.sift {
@@ -465,6 +472,7 @@ where
     T: Ord,
     N: ArrayLength<T>,
     K: Kind,
+    U: MaxCapacity,
 {
     type Target = T;
     fn deref(&self) -> &T {
@@ -479,6 +487,7 @@ where
     T: Ord,
     N: ArrayLength<T>,
     K: Kind,
+    U: MaxCapacity,
 {
     fn deref_mut(&mut self) -> &mut T {
         debug_assert!(!self.heap.is_empty());
@@ -492,6 +501,7 @@ where
     T: Ord,
     N: ArrayLength<T>,
     K: Kind,
+    U: MaxCapacity,
 {
     /// Removes the peeked value from the heap and returns it.
     pub fn pop(mut this: PeekMut<'a, T, N, K, U>) -> T {
@@ -517,6 +527,7 @@ where
     T: Ord,
     N: ArrayLength<T>,
     K: Kind,
+    U: MaxCapacity,
 {
     fn default() -> Self {
         Self::new()
@@ -528,6 +539,7 @@ where
     N: ArrayLength<T>,
     K: Kind,
     T: Ord + Clone,
+    U: MaxCapacity,
 {
     fn clone(&self) -> Self {
         BinaryHeap(crate::i::BinaryHeap {
@@ -542,6 +554,7 @@ where
     N: ArrayLength<T>,
     K: Kind,
     T: Ord,
+    U: MaxCapacity,
 {
     fn drop(&mut self) {
         unsafe { ptr::drop_in_place(self.0.data.as_mut_slice()) }
@@ -553,6 +566,7 @@ where
     N: ArrayLength<T>,
     K: Kind,
     T: Ord + fmt::Debug,
+    U: MaxCapacity,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_list().entries(self.iter()).finish()
@@ -564,6 +578,7 @@ where
     N: ArrayLength<T>,
     K: Kind,
     T: Ord,
+    U: MaxCapacity,
 {
     type Item = &'a T;
     type IntoIter = slice::Iter<'a, T>;

--- a/src/binary_heap.rs
+++ b/src/binary_heap.rs
@@ -27,23 +27,24 @@ pub enum Min {}
 pub enum Max {}
 
 macro_rules! impl_new {
-    ($u:ident) => {
+    ($u:ident, $name:ident) => {
         impl<A, K> crate::i::BinaryHeap<A, K, $u> {
             /// `BinaryHeap` `const` constructor; wrap the returned value in
             /// [`BinaryHeap`](../struct.BinaryHeap.html)
-            pub const fn new() -> Self {
+            pub const fn $name() -> Self {
                 Self {
                     _kind: PhantomData,
-                    data: crate::i::Vec::<A, $u>::new(),
+                    data: crate::i::Vec::<A, $u>::$name(),
                 }
             }
         }
     };
 }
 
-impl_new!(u8);
-impl_new!(u16);
-impl_new!(usize);
+impl_new!(u8, u8);
+impl_new!(u16, u16);
+impl_new!(usize, usize);
+impl_new!(usize, new);
 
 /// A priority queue implemented with a binary heap.
 ///
@@ -607,8 +608,7 @@ mod tests {
 
     #[test]
     fn static_new() {
-        static mut _B: BinaryHeap<i32, U16, Min, u8> =
-            BinaryHeap(crate::i::BinaryHeap::<_, _, u8>::new());
+        static mut _B: BinaryHeap<i32, U16, Min, u8> = BinaryHeap(crate::i::BinaryHeap::u8());
     }
 
     #[test]

--- a/src/de.rs
+++ b/src/de.rs
@@ -1,6 +1,9 @@
 use core::{fmt, marker::PhantomData};
 
-use generic_array::{typenum::PowerOfTwo, ArrayLength};
+use generic_array::{
+    typenum::{IsLess, PowerOfTwo},
+    ArrayLength,
+};
 use hash32::{BuildHasherDefault, Hash, Hasher};
 use serde::de::{self, Deserialize, Deserializer, Error, MapAccess, SeqAccess};
 
@@ -16,7 +19,7 @@ use crate::{
 impl<'de, T, N, KIND, U> Deserialize<'de> for BinaryHeap<T, N, KIND, U>
 where
     T: Ord + Deserialize<'de>,
-    N: ArrayLength<T>,
+    N: ArrayLength<T> + IsLess<U::Cap>,
     KIND: BinaryHeapKind,
     U: MaxCapacity,
 {
@@ -29,7 +32,7 @@ where
         impl<'de, T, N, KIND, U> de::Visitor<'de> for ValueVisitor<'de, T, N, KIND, U>
         where
             T: Ord + Deserialize<'de>,
-            N: ArrayLength<T>,
+            N: ArrayLength<T> + IsLess<U::Cap>,
             KIND: BinaryHeapKind,
             U: MaxCapacity,
         {
@@ -62,7 +65,7 @@ impl<'de, T, N, S, U> Deserialize<'de> for IndexSet<T, N, BuildHasherDefault<S>,
 where
     T: Eq + Hash + Deserialize<'de>,
     S: Hasher + Default,
-    N: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>> + PowerOfTwo,
+    N: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>> + PowerOfTwo + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
@@ -75,7 +78,7 @@ where
         where
             T: Eq + Hash + Deserialize<'de>,
             S: Hasher + Default,
-            N: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>> + PowerOfTwo,
+            N: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>> + PowerOfTwo + IsLess<U::Cap>,
             U: MaxCapacity,
         {
             type Value = IndexSet<T, N, BuildHasherDefault<S>, U>;
@@ -105,7 +108,7 @@ where
 
 impl<'de, T, N, U> Deserialize<'de> for Vec<T, N, U>
 where
-    N: ArrayLength<T>,
+    N: ArrayLength<T> + IsLess<U::Cap>,
     T: Deserialize<'de>,
     U: MaxCapacity,
 {
@@ -117,7 +120,7 @@ where
 
         impl<'de, T, N, U> de::Visitor<'de> for ValueVisitor<'de, T, N, U>
         where
-            N: ArrayLength<T>,
+            N: ArrayLength<T> + IsLess<U::Cap>,
             T: Deserialize<'de>,
             U: MaxCapacity,
         {
@@ -152,7 +155,7 @@ impl<'de, K, V, N, S, U> Deserialize<'de> for IndexMap<K, V, N, BuildHasherDefau
 where
     K: Eq + Hash + Deserialize<'de>,
     V: Deserialize<'de>,
-    N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>> + PowerOfTwo,
+    N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>> + PowerOfTwo + IsLess<U::Cap>,
     S: Default + Hasher,
     U: MaxCapacity,
 {
@@ -166,7 +169,7 @@ where
         where
             K: Eq + Hash + Deserialize<'de>,
             V: Deserialize<'de>,
-            N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>> + PowerOfTwo,
+            N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>> + PowerOfTwo + IsLess<U::Cap>,
             S: Default + Hasher,
             U: MaxCapacity,
         {
@@ -199,7 +202,7 @@ impl<'de, K, V, N, U> Deserialize<'de> for LinearMap<K, V, N, U>
 where
     K: Eq + Deserialize<'de>,
     V: Deserialize<'de>,
-    N: ArrayLength<(K, V)>,
+    N: ArrayLength<(K, V)> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
@@ -212,7 +215,7 @@ where
         where
             K: Eq + Deserialize<'de>,
             V: Deserialize<'de>,
-            N: ArrayLength<(K, V)>,
+            N: ArrayLength<(K, V)> + IsLess<U::Cap>,
             U: MaxCapacity,
         {
             type Value = LinearMap<K, V, N, U>;
@@ -244,7 +247,7 @@ where
 
 impl<'de, N, U> Deserialize<'de> for String<N, U>
 where
-    N: ArrayLength<u8>,
+    N: ArrayLength<u8> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
@@ -255,7 +258,7 @@ where
 
         impl<'de, N, U> de::Visitor<'de> for ValueVisitor<'de, N, U>
         where
-            N: ArrayLength<u8>,
+            N: ArrayLength<u8> + IsLess<U::Cap>,
             U: MaxCapacity,
         {
             type Value = String<N, U>;

--- a/src/de.rs
+++ b/src/de.rs
@@ -12,7 +12,7 @@ use crate::{
 
 // Sequential containers
 
-impl<'de, T, N, KIND> Deserialize<'de> for BinaryHeap<T, N, KIND>
+impl<'de, T, N, KIND, U> Deserialize<'de> for BinaryHeap<T, N, KIND, U>
 where
     T: Ord + Deserialize<'de>,
     N: ArrayLength<T>,
@@ -22,15 +22,15 @@ where
     where
         D: Deserializer<'de>,
     {
-        struct ValueVisitor<'de, T, N, KIND>(PhantomData<(&'de (), T, N, KIND)>);
+        struct ValueVisitor<'de, T, N, KIND, U>(PhantomData<(&'de (), T, N, KIND, U)>);
 
-        impl<'de, T, N, KIND> de::Visitor<'de> for ValueVisitor<'de, T, N, KIND>
+        impl<'de, T, N, KIND, U> de::Visitor<'de> for ValueVisitor<'de, T, N, KIND, U>
         where
             T: Ord + Deserialize<'de>,
             N: ArrayLength<T>,
             KIND: BinaryHeapKind,
         {
-            type Value = BinaryHeap<T, N, KIND>;
+            type Value = BinaryHeap<T, N, KIND, U>;
 
             fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                 formatter.write_str("a sequence")
@@ -55,7 +55,7 @@ where
     }
 }
 
-impl<'de, T, N, S> Deserialize<'de> for IndexSet<T, N, BuildHasherDefault<S>>
+impl<'de, T, N, S, U> Deserialize<'de> for IndexSet<T, N, BuildHasherDefault<S>, U>
 where
     T: Eq + Hash + Deserialize<'de>,
     S: Hasher + Default,
@@ -65,15 +65,15 @@ where
     where
         D: Deserializer<'de>,
     {
-        struct ValueVisitor<'de, T, N, S>(PhantomData<(&'de (), T, N, S)>);
+        struct ValueVisitor<'de, T, N, S, U>(PhantomData<(&'de (), T, N, S, U)>);
 
-        impl<'de, T, N, S> de::Visitor<'de> for ValueVisitor<'de, T, N, S>
+        impl<'de, T, N, S, U> de::Visitor<'de> for ValueVisitor<'de, T, N, S, U>
         where
             T: Eq + Hash + Deserialize<'de>,
             S: Hasher + Default,
             N: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>> + PowerOfTwo,
         {
-            type Value = IndexSet<T, N, BuildHasherDefault<S>>;
+            type Value = IndexSet<T, N, BuildHasherDefault<S>, U>;
 
             fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                 formatter.write_str("a sequence")
@@ -98,7 +98,7 @@ where
     }
 }
 
-impl<'de, T, N> Deserialize<'de> for Vec<T, N>
+impl<'de, T, N, U> Deserialize<'de> for Vec<T, N, U>
 where
     N: ArrayLength<T>,
     T: Deserialize<'de>,
@@ -107,14 +107,14 @@ where
     where
         D: Deserializer<'de>,
     {
-        struct ValueVisitor<'de, T, N>(PhantomData<(&'de (), T, N)>);
+        struct ValueVisitor<'de, T, N, U>(PhantomData<(&'de (), T, N, U)>);
 
-        impl<'de, T, N> de::Visitor<'de> for ValueVisitor<'de, T, N>
+        impl<'de, T, N, U> de::Visitor<'de> for ValueVisitor<'de, T, N, U>
         where
             N: ArrayLength<T>,
             T: Deserialize<'de>,
         {
-            type Value = Vec<T, N>;
+            type Value = Vec<T, N, U>;
 
             fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                 formatter.write_str("a sequence")
@@ -141,7 +141,7 @@ where
 
 // Dictionaries
 
-impl<'de, K, V, N, S> Deserialize<'de> for IndexMap<K, V, N, BuildHasherDefault<S>>
+impl<'de, K, V, N, S, U> Deserialize<'de> for IndexMap<K, V, N, BuildHasherDefault<S>, U>
 where
     K: Eq + Hash + Deserialize<'de>,
     V: Deserialize<'de>,
@@ -152,16 +152,16 @@ where
     where
         D: Deserializer<'de>,
     {
-        struct ValueVisitor<'de, K, V, N, S>(PhantomData<(&'de (), K, V, N, S)>);
+        struct ValueVisitor<'de, K, V, N, S, U>(PhantomData<(&'de (), K, V, N, S, U)>);
 
-        impl<'de, K, V, N, S> de::Visitor<'de> for ValueVisitor<'de, K, V, N, S>
+        impl<'de, K, V, N, S, U> de::Visitor<'de> for ValueVisitor<'de, K, V, N, S, U>
         where
             K: Eq + Hash + Deserialize<'de>,
             V: Deserialize<'de>,
             N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>> + PowerOfTwo,
             S: Default + Hasher,
         {
-            type Value = IndexMap<K, V, N, BuildHasherDefault<S>>;
+            type Value = IndexMap<K, V, N, BuildHasherDefault<S>, U>;
 
             fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                 formatter.write_str("a map")
@@ -186,7 +186,7 @@ where
     }
 }
 
-impl<'de, K, V, N> Deserialize<'de> for LinearMap<K, V, N>
+impl<'de, K, V, N, U> Deserialize<'de> for LinearMap<K, V, N, U>
 where
     K: Eq + Deserialize<'de>,
     V: Deserialize<'de>,
@@ -196,15 +196,15 @@ where
     where
         D: Deserializer<'de>,
     {
-        struct ValueVisitor<'de, K, V, N>(PhantomData<(&'de (), K, V, N)>);
+        struct ValueVisitor<'de, K, V, N, U>(PhantomData<(&'de (), K, V, N, U)>);
 
-        impl<'de, K, V, N> de::Visitor<'de> for ValueVisitor<'de, K, V, N>
+        impl<'de, K, V, N, U> de::Visitor<'de> for ValueVisitor<'de, K, V, N, U>
         where
             K: Eq + Deserialize<'de>,
             V: Deserialize<'de>,
             N: ArrayLength<(K, V)>,
         {
-            type Value = LinearMap<K, V, N>;
+            type Value = LinearMap<K, V, N, U>;
 
             fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                 formatter.write_str("a map")
@@ -231,7 +231,7 @@ where
 
 // String containers
 
-impl<'de, N> Deserialize<'de> for String<N>
+impl<'de, N, U> Deserialize<'de> for String<N, U>
 where
     N: ArrayLength<u8>,
 {
@@ -239,13 +239,13 @@ where
     where
         D: Deserializer<'de>,
     {
-        struct ValueVisitor<'de, N>(PhantomData<(&'de (), N)>);
+        struct ValueVisitor<'de, N, U>(PhantomData<(&'de (), N, U)>);
 
-        impl<'de, N> de::Visitor<'de> for ValueVisitor<'de, N>
+        impl<'de, N, U> de::Visitor<'de> for ValueVisitor<'de, N, U>
         where
             N: ArrayLength<u8>,
         {
-            type Value = String<N>;
+            type Value = String<N, U>;
 
             fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                 write!(

--- a/src/de.rs
+++ b/src/de.rs
@@ -1,7 +1,7 @@
 use core::{fmt, marker::PhantomData};
 
 use generic_array::{
-    typenum::{IsLess, PowerOfTwo},
+    typenum::{IsLess, NonZero, PowerOfTwo},
     ArrayLength,
 };
 use hash32::{BuildHasherDefault, Hash, Hasher};
@@ -20,6 +20,7 @@ impl<'de, T, N, KIND, U> Deserialize<'de> for BinaryHeap<T, N, KIND, U>
 where
     T: Ord + Deserialize<'de>,
     N: ArrayLength<T> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     KIND: BinaryHeapKind,
     U: MaxCapacity,
 {
@@ -33,6 +34,7 @@ where
         where
             T: Ord + Deserialize<'de>,
             N: ArrayLength<T> + IsLess<U::Cap>,
+            <N as IsLess<U::Cap>>::Output: NonZero,
             KIND: BinaryHeapKind,
             U: MaxCapacity,
         {
@@ -66,6 +68,7 @@ where
     T: Eq + Hash + Deserialize<'de>,
     S: Hasher + Default,
     N: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>> + PowerOfTwo + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
@@ -79,6 +82,7 @@ where
             T: Eq + Hash + Deserialize<'de>,
             S: Hasher + Default,
             N: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>> + PowerOfTwo + IsLess<U::Cap>,
+            <N as IsLess<U::Cap>>::Output: NonZero,
             U: MaxCapacity,
         {
             type Value = IndexSet<T, N, BuildHasherDefault<S>, U>;
@@ -109,6 +113,7 @@ where
 impl<'de, T, N, U> Deserialize<'de> for Vec<T, N, U>
 where
     N: ArrayLength<T> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     T: Deserialize<'de>,
     U: MaxCapacity,
 {
@@ -121,6 +126,7 @@ where
         impl<'de, T, N, U> de::Visitor<'de> for ValueVisitor<'de, T, N, U>
         where
             N: ArrayLength<T> + IsLess<U::Cap>,
+            <N as IsLess<U::Cap>>::Output: NonZero,
             T: Deserialize<'de>,
             U: MaxCapacity,
         {
@@ -156,6 +162,7 @@ where
     K: Eq + Hash + Deserialize<'de>,
     V: Deserialize<'de>,
     N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>> + PowerOfTwo + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     S: Default + Hasher,
     U: MaxCapacity,
 {
@@ -170,6 +177,7 @@ where
             K: Eq + Hash + Deserialize<'de>,
             V: Deserialize<'de>,
             N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>> + PowerOfTwo + IsLess<U::Cap>,
+            <N as IsLess<U::Cap>>::Output: NonZero,
             S: Default + Hasher,
             U: MaxCapacity,
         {
@@ -203,6 +211,7 @@ where
     K: Eq + Deserialize<'de>,
     V: Deserialize<'de>,
     N: ArrayLength<(K, V)> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
@@ -216,6 +225,7 @@ where
             K: Eq + Deserialize<'de>,
             V: Deserialize<'de>,
             N: ArrayLength<(K, V)> + IsLess<U::Cap>,
+            <N as IsLess<U::Cap>>::Output: NonZero,
             U: MaxCapacity,
         {
             type Value = LinearMap<K, V, N, U>;
@@ -248,6 +258,7 @@ where
 impl<'de, N, U> Deserialize<'de> for String<N, U>
 where
     N: ArrayLength<u8> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
@@ -259,6 +270,7 @@ where
         impl<'de, N, U> de::Visitor<'de> for ValueVisitor<'de, N, U>
         where
             N: ArrayLength<u8> + IsLess<U::Cap>,
+            <N as IsLess<U::Cap>>::Output: NonZero,
             U: MaxCapacity,
         {
             type Value = String<N, U>;

--- a/src/de.rs
+++ b/src/de.rs
@@ -7,6 +7,7 @@ use serde::de::{self, Deserialize, Deserializer, Error, MapAccess, SeqAccess};
 use crate::{
     indexmap::{Bucket, Pos},
     sealed::binary_heap::Kind as BinaryHeapKind,
+    vec::MaxCapacity,
     BinaryHeap, IndexMap, IndexSet, LinearMap, String, Vec,
 };
 
@@ -17,6 +18,7 @@ where
     T: Ord + Deserialize<'de>,
     N: ArrayLength<T>,
     KIND: BinaryHeapKind,
+    U: MaxCapacity,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -29,6 +31,7 @@ where
             T: Ord + Deserialize<'de>,
             N: ArrayLength<T>,
             KIND: BinaryHeapKind,
+            U: MaxCapacity,
         {
             type Value = BinaryHeap<T, N, KIND, U>;
 
@@ -60,6 +63,7 @@ where
     T: Eq + Hash + Deserialize<'de>,
     S: Hasher + Default,
     N: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>> + PowerOfTwo,
+    U: MaxCapacity,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -72,6 +76,7 @@ where
             T: Eq + Hash + Deserialize<'de>,
             S: Hasher + Default,
             N: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>> + PowerOfTwo,
+            U: MaxCapacity,
         {
             type Value = IndexSet<T, N, BuildHasherDefault<S>, U>;
 
@@ -102,6 +107,7 @@ impl<'de, T, N, U> Deserialize<'de> for Vec<T, N, U>
 where
     N: ArrayLength<T>,
     T: Deserialize<'de>,
+    U: MaxCapacity,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -113,6 +119,7 @@ where
         where
             N: ArrayLength<T>,
             T: Deserialize<'de>,
+            U: MaxCapacity,
         {
             type Value = Vec<T, N, U>;
 
@@ -147,6 +154,7 @@ where
     V: Deserialize<'de>,
     N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>> + PowerOfTwo,
     S: Default + Hasher,
+    U: MaxCapacity,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -160,6 +168,7 @@ where
             V: Deserialize<'de>,
             N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>> + PowerOfTwo,
             S: Default + Hasher,
+            U: MaxCapacity,
         {
             type Value = IndexMap<K, V, N, BuildHasherDefault<S>, U>;
 
@@ -191,6 +200,7 @@ where
     K: Eq + Deserialize<'de>,
     V: Deserialize<'de>,
     N: ArrayLength<(K, V)>,
+    U: MaxCapacity,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -203,6 +213,7 @@ where
             K: Eq + Deserialize<'de>,
             V: Deserialize<'de>,
             N: ArrayLength<(K, V)>,
+            U: MaxCapacity,
         {
             type Value = LinearMap<K, V, N, U>;
 
@@ -234,6 +245,7 @@ where
 impl<'de, N, U> Deserialize<'de> for String<N, U>
 where
     N: ArrayLength<u8>,
+    U: MaxCapacity,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -244,6 +256,7 @@ where
         impl<'de, N, U> de::Visitor<'de> for ValueVisitor<'de, N, U>
         where
             N: ArrayLength<u8>,
+            U: MaxCapacity,
         {
             type Value = String<N, U>;
 
@@ -279,6 +292,6 @@ where
             }
         }
 
-        deserializer.deserialize_str(ValueVisitor::<'de, N>(PhantomData))
+        deserializer.deserialize_str(ValueVisitor::<'de, N, U>(PhantomData))
     }
 }

--- a/src/i.rs
+++ b/src/i.rs
@@ -6,19 +6,19 @@ use core::{marker::PhantomData, mem::MaybeUninit};
 use crate::spsc::{Atomic, MultiCore};
 
 /// `const-fn` version of [`BinaryHeap`](../binary_heap/struct.BinaryHeap.html)
-pub struct BinaryHeap<A, K> {
+pub struct BinaryHeap<A, K, U> {
     pub(crate) _kind: PhantomData<K>,
-    pub(crate) data: Vec<A>,
+    pub(crate) data: Vec<A, U>,
 }
 
 /// `const-fn` version of [`LinearMap`](../struct.LinearMap.html)
-pub struct LinearMap<A> {
-    pub(crate) buffer: Vec<A>,
+pub struct LinearMap<A, U> {
+    pub(crate) buffer: Vec<A, U>,
 }
 
 /// `const-fn` version of [`spsc::Queue`](../spsc/struct.Queue.html)
 #[cfg(has_atomics)]
-pub struct Queue<A, U = usize, C = MultiCore> {
+pub struct Queue<A, U, C = MultiCore> {
     // this is from where we dequeue items
     pub(crate) head: Atomic<U, C>,
 
@@ -29,12 +29,12 @@ pub struct Queue<A, U = usize, C = MultiCore> {
 }
 
 /// `const-fn` version of [`String`](../struct.String.html)
-pub struct String<A> {
-    pub(crate) vec: Vec<A>,
+pub struct String<A, U> {
+    pub(crate) vec: Vec<A, U>,
 }
 
 /// `const-fn` version of [`Vec`](../struct.Vec.html)
-pub struct Vec<A> {
+pub struct Vec<A, U> {
     pub(crate) buffer: MaybeUninit<A>,
-    pub(crate) len: usize,
+    pub(crate) len: U,
 }

--- a/src/i.rs
+++ b/src/i.rs
@@ -6,19 +6,19 @@ use core::{marker::PhantomData, mem::MaybeUninit};
 use crate::spsc::{Atomic, MultiCore};
 
 /// `const-fn` version of [`BinaryHeap`](../binary_heap/struct.BinaryHeap.html)
-pub struct BinaryHeap<A, K, U> {
+pub struct BinaryHeap<A, K, U = usize> {
     pub(crate) _kind: PhantomData<K>,
     pub(crate) data: Vec<A, U>,
 }
 
 /// `const-fn` version of [`LinearMap`](../struct.LinearMap.html)
-pub struct LinearMap<A, U> {
+pub struct LinearMap<A, U = usize> {
     pub(crate) buffer: Vec<A, U>,
 }
 
 /// `const-fn` version of [`spsc::Queue`](../spsc/struct.Queue.html)
 #[cfg(has_atomics)]
-pub struct Queue<A, U, C = MultiCore> {
+pub struct Queue<A, U = usize, C = MultiCore> {
     // this is from where we dequeue items
     pub(crate) head: Atomic<U, C>,
 
@@ -29,12 +29,12 @@ pub struct Queue<A, U, C = MultiCore> {
 }
 
 /// `const-fn` version of [`String`](../struct.String.html)
-pub struct String<A, U> {
+pub struct String<A, U = usize> {
     pub(crate) vec: Vec<A, U>,
 }
 
 /// `const-fn` version of [`Vec`](../struct.Vec.html)
-pub struct Vec<A, U> {
+pub struct Vec<A, U = usize> {
     pub(crate) buffer: MaybeUninit<A>,
     pub(crate) len: U,
 }

--- a/src/indexmap.rs
+++ b/src/indexmap.rs
@@ -57,7 +57,7 @@ use crate::{vec::MaxCapacity, Vec};
 ///     println!("{}: \"{}\"", book, review);
 /// }
 /// ```
-pub type FnvIndexMap<K, V, N, U> = IndexMap<K, V, N, BuildHasherDefault<FnvHasher>, U>;
+pub type FnvIndexMap<K, V, N, U = usize> = IndexMap<K, V, N, BuildHasherDefault<FnvHasher>, U>;
 
 #[derive(Clone, Copy, Eq, PartialEq)]
 struct HashValue(u16);
@@ -379,7 +379,7 @@ where
 ///     println!("{}: \"{}\"", book, review);
 /// }
 /// ```
-pub struct IndexMap<K, V, N, S, U>
+pub struct IndexMap<K, V, N, S, U = usize>
 where
     K: Eq + Hash,
     N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,

--- a/src/indexmap.rs
+++ b/src/indexmap.rs
@@ -54,7 +54,7 @@ use crate::Vec;
 ///     println!("{}: \"{}\"", book, review);
 /// }
 /// ```
-pub type FnvIndexMap<K, V, N> = IndexMap<K, V, N, BuildHasherDefault<FnvHasher>>;
+pub type FnvIndexMap<K, V, N, U> = IndexMap<K, V, N, BuildHasherDefault<FnvHasher>, U>;
 
 #[derive(Clone, Copy, Eq, PartialEq)]
 struct HashValue(u16);
@@ -126,16 +126,16 @@ macro_rules! probe_loop {
     }
 }
 
-struct CoreMap<K, V, N>
+struct CoreMap<K, V, N, U>
 where
     K: Eq + Hash,
     N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>>,
 {
-    entries: Vec<Bucket<K, V>, N>,
+    entries: Vec<Bucket<K, V>, N, U>,
     indices: GenericArray<Option<Pos>, N>,
 }
 
-impl<K, V, N> CoreMap<K, V, N>
+impl<K, V, N, U> CoreMap<K, V, N, U>
 where
     K: Eq + Hash,
     N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>>,
@@ -311,7 +311,7 @@ where
     }
 }
 
-impl<K, V, N> Clone for CoreMap<K, V, N>
+impl<K, V, N, U> Clone for CoreMap<K, V, N, U>
 where
     K: Eq + Hash + Clone,
     V: Clone,
@@ -373,16 +373,16 @@ where
 ///     println!("{}: \"{}\"", book, review);
 /// }
 /// ```
-pub struct IndexMap<K, V, N, S>
+pub struct IndexMap<K, V, N, S, U>
 where
     K: Eq + Hash,
     N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>>,
 {
-    core: CoreMap<K, V, N>,
+    core: CoreMap<K, V, N, U>,
     build_hasher: S,
 }
 
-impl<K, V, N, S> IndexMap<K, V, N, BuildHasherDefault<S>>
+impl<K, V, N, S, U> IndexMap<K, V, N, BuildHasherDefault<S>, U>
 where
     K: Eq + Hash,
     S: Default + Hasher,
@@ -400,7 +400,7 @@ where
     }
 }
 
-impl<K, V, N, S> IndexMap<K, V, N, S>
+impl<K, V, N, S, U> IndexMap<K, V, N, S, U>
 where
     K: Eq + Hash,
     S: BuildHasher,
@@ -762,7 +762,7 @@ where
     }
 }
 
-impl<'a, K, Q, V, N, S> ops::Index<&'a Q> for IndexMap<K, V, N, S>
+impl<'a, K, Q, V, N, S, U> ops::Index<&'a Q> for IndexMap<K, V, N, S, U>
 where
     K: Eq + Hash + Borrow<Q>,
     Q: ?Sized + Eq + Hash,
@@ -776,7 +776,7 @@ where
     }
 }
 
-impl<'a, K, Q, V, N, S> ops::IndexMut<&'a Q> for IndexMap<K, V, N, S>
+impl<'a, K, Q, V, N, S, U> ops::IndexMut<&'a Q> for IndexMap<K, V, N, S, U>
 where
     K: Eq + Hash + Borrow<Q>,
     Q: ?Sized + Eq + Hash,
@@ -788,7 +788,7 @@ where
     }
 }
 
-impl<K, V, N, S> Clone for IndexMap<K, V, N, S>
+impl<K, V, N, S, U> Clone for IndexMap<K, V, N, S, U>
 where
     K: Eq + Hash + Clone,
     V: Clone,
@@ -803,7 +803,7 @@ where
     }
 }
 
-impl<K, V, N, S> fmt::Debug for IndexMap<K, V, N, S>
+impl<K, V, N, S, U> fmt::Debug for IndexMap<K, V, N, S, U>
 where
     K: Eq + Hash + fmt::Debug,
     V: fmt::Debug,
@@ -815,7 +815,7 @@ where
     }
 }
 
-impl<K, V, N, S> Default for IndexMap<K, V, N, S>
+impl<K, V, N, S, U> Default for IndexMap<K, V, N, S, U>
 where
     K: Eq + Hash,
     S: BuildHasher + Default,
@@ -829,7 +829,7 @@ where
     }
 }
 
-impl<K, V, N, S, N2, S2> PartialEq<IndexMap<K, V, N2, S2>> for IndexMap<K, V, N, S>
+impl<K, V, N, S, N2, S2, U> PartialEq<IndexMap<K, V, N2, S2, U>> for IndexMap<K, V, N, S, U>
 where
     K: Eq + Hash,
     V: Eq,
@@ -838,7 +838,7 @@ where
     S2: BuildHasher,
     N2: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>>,
 {
-    fn eq(&self, other: &IndexMap<K, V, N2, S2>) -> bool {
+    fn eq(&self, other: &IndexMap<K, V, N2, S2, U>) -> bool {
         self.len() == other.len()
             && self
                 .iter()
@@ -846,7 +846,7 @@ where
     }
 }
 
-impl<K, V, N, S> Eq for IndexMap<K, V, N, S>
+impl<K, V, N, S, U> Eq for IndexMap<K, V, N, S, U>
 where
     K: Eq + Hash,
     V: Eq,
@@ -855,7 +855,7 @@ where
 {
 }
 
-impl<K, V, N, S> Extend<(K, V)> for IndexMap<K, V, N, S>
+impl<K, V, N, S, U> Extend<(K, V)> for IndexMap<K, V, N, S, U>
 where
     K: Eq + Hash,
     S: BuildHasher,
@@ -871,7 +871,7 @@ where
     }
 }
 
-impl<'a, K, V, N, S> Extend<(&'a K, &'a V)> for IndexMap<K, V, N, S>
+impl<'a, K, V, N, S, U> Extend<(&'a K, &'a V)> for IndexMap<K, V, N, S, U>
 where
     K: Eq + Hash + Copy,
     V: Copy,
@@ -886,7 +886,7 @@ where
     }
 }
 
-impl<K, V, N, S> FromIterator<(K, V)> for IndexMap<K, V, N, S>
+impl<K, V, N, S, U> FromIterator<(K, V)> for IndexMap<K, V, N, S, U>
 where
     K: Eq + Hash,
     S: BuildHasher + Default,
@@ -902,7 +902,7 @@ where
     }
 }
 
-impl<'a, K, V, N, S> IntoIterator for &'a IndexMap<K, V, N, S>
+impl<'a, K, V, N, S, U> IntoIterator for &'a IndexMap<K, V, N, S, U>
 where
     K: Eq + Hash,
     S: BuildHasher,
@@ -916,7 +916,7 @@ where
     }
 }
 
-impl<'a, K, V, N, S> IntoIterator for &'a mut IndexMap<K, V, N, S>
+impl<'a, K, V, N, S, U> IntoIterator for &'a mut IndexMap<K, V, N, S, U>
 where
     K: Eq + Hash,
     S: BuildHasher,

--- a/src/indexmap.rs
+++ b/src/indexmap.rs
@@ -1010,23 +1010,23 @@ mod tests {
 
         let cap = Cap::to_usize();
         assert_eq!(
-            mem::size_of::<FnvIndexMap<i16, u16, Cap>>(),
+            mem::size_of::<FnvIndexMap<i16, u16, Cap, u8>>(),
             cap * mem::size_of::<u32>() + // indices
                 cap * (mem::size_of::<i16>() + // key
                      mem::size_of::<u16>() + // value
                      mem::size_of::<u16>() // hash
                 ) + // buckets
-                mem::size_of::<usize>() // entries.length
+                mem::size_of::<u32>() // entries.length (aligned 32 bits)
         )
     }
 
     #[test]
     fn partial_eq() {
         {
-            let mut a: FnvIndexMap<_, _, U4> = FnvIndexMap::new();
+            let mut a: FnvIndexMap<_, _, U4, u8> = FnvIndexMap::new();
             a.insert("k1", "v1").unwrap();
 
-            let mut b: FnvIndexMap<_, _, U4> = FnvIndexMap::new();
+            let mut b: FnvIndexMap<_, _, U4, u8> = FnvIndexMap::new();
             b.insert("k1", "v1").unwrap();
 
             assert!(a == b);
@@ -1037,11 +1037,11 @@ mod tests {
         }
 
         {
-            let mut a: FnvIndexMap<_, _, U4> = FnvIndexMap::new();
+            let mut a: FnvIndexMap<_, _, U4, u8> = FnvIndexMap::new();
             a.insert("k1", "v1").unwrap();
             a.insert("k2", "v2").unwrap();
 
-            let mut b: FnvIndexMap<_, _, U4> = FnvIndexMap::new();
+            let mut b: FnvIndexMap<_, _, U4, u8> = FnvIndexMap::new();
             b.insert("k2", "v2").unwrap();
             b.insert("k1", "v1").unwrap();
 

--- a/src/indexmap.rs
+++ b/src/indexmap.rs
@@ -7,7 +7,10 @@ use core::{
     ops, slice,
 };
 
-use generic_array::{typenum::PowerOfTwo, ArrayLength, GenericArray};
+use generic_array::{
+    typenum::{IsLess, PowerOfTwo},
+    ArrayLength, GenericArray,
+};
 use hash32::{BuildHasher, BuildHasherDefault, FnvHasher, Hash, Hasher};
 
 use crate::{vec::MaxCapacity, Vec};
@@ -129,7 +132,7 @@ macro_rules! probe_loop {
 struct CoreMap<K, V, N, U>
 where
     K: Eq + Hash,
-    N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>>,
+    N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     entries: Vec<Bucket<K, V>, N, U>,
@@ -139,7 +142,7 @@ where
 impl<K, V, N, U> CoreMap<K, V, N, U>
 where
     K: Eq + Hash,
-    N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>>,
+    N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     // TODO turn into a `const fn`; needs `mem::zeroed` to be a `const fn`
@@ -317,7 +320,7 @@ impl<K, V, N, U> Clone for CoreMap<K, V, N, U>
 where
     K: Eq + Hash + Clone,
     V: Clone,
-    N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>>,
+    N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     fn clone(&self) -> Self {
@@ -379,7 +382,7 @@ where
 pub struct IndexMap<K, V, N, S, U>
 where
     K: Eq + Hash,
-    N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>>,
+    N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     core: CoreMap<K, V, N, U>,
@@ -390,7 +393,7 @@ impl<K, V, N, S, U> IndexMap<K, V, N, BuildHasherDefault<S>, U>
 where
     K: Eq + Hash,
     S: Default + Hasher,
-    N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>> + PowerOfTwo,
+    N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>> + PowerOfTwo + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     // TODO turn into a `const fn`; needs `mem::zeroed` to be a `const fn`
@@ -409,7 +412,7 @@ impl<K, V, N, S, U> IndexMap<K, V, N, S, U>
 where
     K: Eq + Hash,
     S: BuildHasher,
-    N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>>,
+    N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     /* Public API */
@@ -773,7 +776,7 @@ where
     K: Eq + Hash + Borrow<Q>,
     Q: ?Sized + Eq + Hash,
     S: BuildHasher,
-    N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>>,
+    N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     type Output = V;
@@ -788,7 +791,7 @@ where
     K: Eq + Hash + Borrow<Q>,
     Q: ?Sized + Eq + Hash,
     S: BuildHasher,
-    N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>>,
+    N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     fn index_mut(&mut self, key: &Q) -> &mut V {
@@ -801,7 +804,7 @@ where
     K: Eq + Hash + Clone,
     V: Clone,
     S: Clone,
-    N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>>,
+    N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     fn clone(&self) -> Self {
@@ -817,7 +820,7 @@ where
     K: Eq + Hash + fmt::Debug,
     V: fmt::Debug,
     S: BuildHasher,
-    N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>>,
+    N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -829,7 +832,7 @@ impl<K, V, N, S, U> Default for IndexMap<K, V, N, S, U>
 where
     K: Eq + Hash,
     S: BuildHasher + Default,
-    N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>>,
+    N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     fn default() -> Self {
@@ -845,9 +848,9 @@ where
     K: Eq + Hash,
     V: Eq,
     S: BuildHasher,
-    N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>>,
+    N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
     S2: BuildHasher,
-    N2: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>>,
+    N2: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     fn eq(&self, other: &IndexMap<K, V, N2, S2, U>) -> bool {
@@ -863,7 +866,7 @@ where
     K: Eq + Hash,
     V: Eq,
     S: BuildHasher,
-    N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>>,
+    N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
 }
@@ -872,7 +875,7 @@ impl<K, V, N, S, U> Extend<(K, V)> for IndexMap<K, V, N, S, U>
 where
     K: Eq + Hash,
     S: BuildHasher,
-    N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>>,
+    N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     fn extend<I>(&mut self, iterable: I)
@@ -890,7 +893,7 @@ where
     K: Eq + Hash + Copy,
     V: Copy,
     S: BuildHasher,
-    N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>>,
+    N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     fn extend<I>(&mut self, iterable: I)
@@ -905,7 +908,7 @@ impl<K, V, N, S, U> FromIterator<(K, V)> for IndexMap<K, V, N, S, U>
 where
     K: Eq + Hash,
     S: BuildHasher + Default,
-    N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>>,
+    N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     fn from_iter<I>(iterable: I) -> Self
@@ -922,7 +925,7 @@ impl<'a, K, V, N, S, U> IntoIterator for &'a IndexMap<K, V, N, S, U>
 where
     K: Eq + Hash,
     S: BuildHasher,
-    N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>>,
+    N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     type Item = (&'a K, &'a V);
@@ -937,7 +940,7 @@ impl<'a, K, V, N, S, U> IntoIterator for &'a mut IndexMap<K, V, N, S, U>
 where
     K: Eq + Hash,
     S: BuildHasher,
-    N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>>,
+    N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     type Item = (&'a K, &'a mut V);

--- a/src/indexmap.rs
+++ b/src/indexmap.rs
@@ -10,7 +10,7 @@ use core::{
 use generic_array::{typenum::PowerOfTwo, ArrayLength, GenericArray};
 use hash32::{BuildHasher, BuildHasherDefault, FnvHasher, Hash, Hasher};
 
-use crate::Vec;
+use crate::{vec::MaxCapacity, Vec};
 
 /// A [`heapless::IndexMap`](./struct.IndexMap.html) using the default FNV hasher
 ///
@@ -130,6 +130,7 @@ struct CoreMap<K, V, N, U>
 where
     K: Eq + Hash,
     N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>>,
+    U: MaxCapacity,
 {
     entries: Vec<Bucket<K, V>, N, U>,
     indices: GenericArray<Option<Pos>, N>,
@@ -139,6 +140,7 @@ impl<K, V, N, U> CoreMap<K, V, N, U>
 where
     K: Eq + Hash,
     N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>>,
+    U: MaxCapacity,
 {
     // TODO turn into a `const fn`; needs `mem::zeroed` to be a `const fn`
     fn new() -> Self {
@@ -316,6 +318,7 @@ where
     K: Eq + Hash + Clone,
     V: Clone,
     N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>>,
+    U: MaxCapacity,
 {
     fn clone(&self) -> Self {
         Self {
@@ -377,6 +380,7 @@ pub struct IndexMap<K, V, N, S, U>
 where
     K: Eq + Hash,
     N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>>,
+    U: MaxCapacity,
 {
     core: CoreMap<K, V, N, U>,
     build_hasher: S,
@@ -387,6 +391,7 @@ where
     K: Eq + Hash,
     S: Default + Hasher,
     N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>> + PowerOfTwo,
+    U: MaxCapacity,
 {
     // TODO turn into a `const fn`; needs `mem::zeroed` to be a `const fn`
     /// Creates an empty `IndexMap`.
@@ -405,6 +410,7 @@ where
     K: Eq + Hash,
     S: BuildHasher,
     N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>>,
+    U: MaxCapacity,
 {
     /* Public API */
     /// Returns the number of elements the map can hold
@@ -768,6 +774,7 @@ where
     Q: ?Sized + Eq + Hash,
     S: BuildHasher,
     N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>>,
+    U: MaxCapacity,
 {
     type Output = V;
 
@@ -782,6 +789,7 @@ where
     Q: ?Sized + Eq + Hash,
     S: BuildHasher,
     N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>>,
+    U: MaxCapacity,
 {
     fn index_mut(&mut self, key: &Q) -> &mut V {
         self.get_mut(key).expect("key not found")
@@ -794,6 +802,7 @@ where
     V: Clone,
     S: Clone,
     N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>>,
+    U: MaxCapacity,
 {
     fn clone(&self) -> Self {
         Self {
@@ -809,6 +818,7 @@ where
     V: fmt::Debug,
     S: BuildHasher,
     N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>>,
+    U: MaxCapacity,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_map().entries(self.iter()).finish()
@@ -820,6 +830,7 @@ where
     K: Eq + Hash,
     S: BuildHasher + Default,
     N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>>,
+    U: MaxCapacity,
 {
     fn default() -> Self {
         IndexMap {
@@ -837,6 +848,7 @@ where
     N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>>,
     S2: BuildHasher,
     N2: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>>,
+    U: MaxCapacity,
 {
     fn eq(&self, other: &IndexMap<K, V, N2, S2, U>) -> bool {
         self.len() == other.len()
@@ -852,6 +864,7 @@ where
     V: Eq,
     S: BuildHasher,
     N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>>,
+    U: MaxCapacity,
 {
 }
 
@@ -860,6 +873,7 @@ where
     K: Eq + Hash,
     S: BuildHasher,
     N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>>,
+    U: MaxCapacity,
 {
     fn extend<I>(&mut self, iterable: I)
     where
@@ -877,6 +891,7 @@ where
     V: Copy,
     S: BuildHasher,
     N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>>,
+    U: MaxCapacity,
 {
     fn extend<I>(&mut self, iterable: I)
     where
@@ -891,6 +906,7 @@ where
     K: Eq + Hash,
     S: BuildHasher + Default,
     N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>>,
+    U: MaxCapacity,
 {
     fn from_iter<I>(iterable: I) -> Self
     where
@@ -907,6 +923,7 @@ where
     K: Eq + Hash,
     S: BuildHasher,
     N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>>,
+    U: MaxCapacity,
 {
     type Item = (&'a K, &'a V);
     type IntoIter = Iter<'a, K, V>;
@@ -921,6 +938,7 @@ where
     K: Eq + Hash,
     S: BuildHasher,
     N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>>,
+    U: MaxCapacity,
 {
     type Item = (&'a K, &'a mut V);
     type IntoIter = IterMut<'a, K, V>;

--- a/src/indexmap.rs
+++ b/src/indexmap.rs
@@ -843,17 +843,18 @@ where
     }
 }
 
-impl<K, V, N, S, N2, S2, U> PartialEq<IndexMap<K, V, N2, S2, U>> for IndexMap<K, V, N, S, U>
+impl<K, V, N, S, N2, S2, U, U2> PartialEq<IndexMap<K, V, N2, S2, U2>> for IndexMap<K, V, N, S, U>
 where
     K: Eq + Hash,
     V: Eq,
     S: BuildHasher,
     N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
     S2: BuildHasher,
-    N2: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
+    N2: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>> + IsLess<U2::Cap>,
     U: MaxCapacity,
+    U2: MaxCapacity,
 {
-    fn eq(&self, other: &IndexMap<K, V, N2, S2, U>) -> bool {
+    fn eq(&self, other: &IndexMap<K, V, N2, S2, U2>) -> bool {
         self.len() == other.len()
             && self
                 .iter()

--- a/src/indexmap.rs
+++ b/src/indexmap.rs
@@ -8,7 +8,7 @@ use core::{
 };
 
 use generic_array::{
-    typenum::{IsLess, PowerOfTwo},
+    typenum::{IsLess, NonZero, PowerOfTwo},
     ArrayLength, GenericArray,
 };
 use hash32::{BuildHasher, BuildHasherDefault, FnvHasher, Hash, Hasher};
@@ -133,6 +133,7 @@ struct CoreMap<K, V, N, U>
 where
     K: Eq + Hash,
     N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     entries: Vec<Bucket<K, V>, N, U>,
@@ -143,6 +144,7 @@ impl<K, V, N, U> CoreMap<K, V, N, U>
 where
     K: Eq + Hash,
     N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     // TODO turn into a `const fn`; needs `mem::zeroed` to be a `const fn`
@@ -321,6 +323,7 @@ where
     K: Eq + Hash + Clone,
     V: Clone,
     N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     fn clone(&self) -> Self {
@@ -383,6 +386,7 @@ pub struct IndexMap<K, V, N, S, U = usize>
 where
     K: Eq + Hash,
     N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     core: CoreMap<K, V, N, U>,
@@ -394,6 +398,7 @@ where
     K: Eq + Hash,
     S: Default + Hasher,
     N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>> + PowerOfTwo + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     // TODO turn into a `const fn`; needs `mem::zeroed` to be a `const fn`
@@ -413,6 +418,7 @@ where
     K: Eq + Hash,
     S: BuildHasher,
     N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     /* Public API */
@@ -777,6 +783,7 @@ where
     Q: ?Sized + Eq + Hash,
     S: BuildHasher,
     N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     type Output = V;
@@ -792,6 +799,7 @@ where
     Q: ?Sized + Eq + Hash,
     S: BuildHasher,
     N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     fn index_mut(&mut self, key: &Q) -> &mut V {
@@ -805,6 +813,7 @@ where
     V: Clone,
     S: Clone,
     N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     fn clone(&self) -> Self {
@@ -821,6 +830,7 @@ where
     V: fmt::Debug,
     S: BuildHasher,
     N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -833,6 +843,7 @@ where
     K: Eq + Hash,
     S: BuildHasher + Default,
     N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     fn default() -> Self {
@@ -849,8 +860,10 @@ where
     V: Eq,
     S: BuildHasher,
     N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     S2: BuildHasher,
     N2: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>> + IsLess<U2::Cap>,
+    <N2 as IsLess<U2::Cap>>::Output: NonZero,
     U: MaxCapacity,
     U2: MaxCapacity,
 {
@@ -868,6 +881,7 @@ where
     V: Eq,
     S: BuildHasher,
     N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
 }
@@ -877,6 +891,7 @@ where
     K: Eq + Hash,
     S: BuildHasher,
     N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     fn extend<I>(&mut self, iterable: I)
@@ -895,6 +910,7 @@ where
     V: Copy,
     S: BuildHasher,
     N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     fn extend<I>(&mut self, iterable: I)
@@ -910,6 +926,7 @@ where
     K: Eq + Hash,
     S: BuildHasher + Default,
     N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     fn from_iter<I>(iterable: I) -> Self
@@ -927,6 +944,7 @@ where
     K: Eq + Hash,
     S: BuildHasher,
     N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     type Item = (&'a K, &'a V);
@@ -942,6 +960,7 @@ where
     K: Eq + Hash,
     S: BuildHasher,
     N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     type Item = (&'a K, &'a mut V);

--- a/src/indexset.rs
+++ b/src/indexset.rs
@@ -38,7 +38,7 @@ use crate::indexmap::{self, Bucket, IndexMap, Pos};
 ///     println!("{}", book);
 /// }
 /// ```
-pub type FnvIndexSet<T, N> = IndexSet<T, N, BuildHasherDefault<FnvHasher>>;
+pub type FnvIndexSet<T, N, U> = IndexSet<T, N, BuildHasherDefault<FnvHasher>, U>;
 
 /// Fixed capacity [`IndexSet`](https://docs.rs/indexmap/1/indexmap/set/struct.IndexSet.html).
 ///
@@ -79,15 +79,15 @@ pub type FnvIndexSet<T, N> = IndexSet<T, N, BuildHasherDefault<FnvHasher>>;
 ///     println!("{}", book);
 /// }
 /// ```
-pub struct IndexSet<T, N, S>
+pub struct IndexSet<T, N, S, U>
 where
     T: Eq + Hash,
     N: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>>,
 {
-    map: IndexMap<T, (), N, S>,
+    map: IndexMap<T, (), N, S, U>,
 }
 
-impl<T, N, S> IndexSet<T, N, BuildHasherDefault<S>>
+impl<T, N, S, U> IndexSet<T, N, BuildHasherDefault<S>, U>
 where
     T: Eq + Hash,
     S: Default + Hasher,
@@ -101,7 +101,7 @@ where
     }
 }
 
-impl<T, N, S> IndexSet<T, N, S>
+impl<T, N, S, U> IndexSet<T, N, S, U>
 where
     T: Eq + Hash,
     S: BuildHasher,
@@ -172,8 +172,8 @@ where
     /// ```
     pub fn difference<'a, N2, S2>(
         &'a self,
-        other: &'a IndexSet<T, N2, S2>,
-    ) -> Difference<'a, T, N2, S2>
+        other: &'a IndexSet<T, N2, S2, U>,
+    ) -> Difference<'a, T, N2, S2, U>
     where
         N2: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>>,
         S2: BuildHasher,
@@ -209,7 +209,7 @@ where
     /// ```
     pub fn symmetric_difference<'a, N2, S2>(
         &'a self,
-        other: &'a IndexSet<T, N2, S2>,
+        other: &'a IndexSet<T, N2, S2, U>,
     ) -> impl Iterator<Item = &'a T>
     where
         N2: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>>,
@@ -240,8 +240,8 @@ where
     /// ```
     pub fn intersection<'a, N2, S2>(
         &'a self,
-        other: &'a IndexSet<T, N2, S2>,
-    ) -> Intersection<'a, T, N2, S2>
+        other: &'a IndexSet<T, N2, S2, U>,
+    ) -> Intersection<'a, T, N2, S2, U>
     where
         N2: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>>,
         S2: BuildHasher,
@@ -274,7 +274,7 @@ where
     /// ```
     pub fn union<'a, N2, S2>(
         &'a self,
-        other: &'a IndexSet<T, N2, S2>,
+        other: &'a IndexSet<T, N2, S2, U>,
     ) -> impl Iterator<Item = &'a T>
     where
         N2: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>>,
@@ -375,7 +375,7 @@ where
     /// b.insert(1).unwrap();
     /// assert_eq!(a.is_disjoint(&b), false);
     /// ```
-    pub fn is_disjoint<N2, S2>(&self, other: &IndexSet<T, N2, S2>) -> bool
+    pub fn is_disjoint<N2, S2>(&self, other: &IndexSet<T, N2, S2, U>) -> bool
     where
         N2: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>>,
         S2: BuildHasher,
@@ -401,7 +401,7 @@ where
     /// set.insert(4).unwrap();
     /// assert_eq!(set.is_subset(&sup), false);
     /// ```
-    pub fn is_subset<N2, S2>(&self, other: &IndexSet<T, N2, S2>) -> bool
+    pub fn is_subset<N2, S2>(&self, other: &IndexSet<T, N2, S2, U>) -> bool
     where
         N2: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>>,
         S2: BuildHasher,
@@ -430,7 +430,7 @@ where
     /// set.insert(2).unwrap();
     /// assert_eq!(set.is_superset(&sub), true);
     /// ```
-    pub fn is_superset<N2, S2>(&self, other: &IndexSet<T, N2, S2>) -> bool
+    pub fn is_superset<N2, S2>(&self, other: &IndexSet<T, N2, S2, U>) -> bool
     where
         N2: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>>,
         S2: BuildHasher,
@@ -489,7 +489,7 @@ where
     }
 }
 
-impl<T, N, S> Clone for IndexSet<T, N, S>
+impl<T, N, S, U> Clone for IndexSet<T, N, S, U>
 where
     T: Eq + Hash + Clone,
     S: Clone,
@@ -502,7 +502,7 @@ where
     }
 }
 
-impl<T, N, S> fmt::Debug for IndexSet<T, N, S>
+impl<T, N, S, U> fmt::Debug for IndexSet<T, N, S, U>
 where
     T: Eq + Hash + fmt::Debug,
     S: BuildHasher,
@@ -513,7 +513,7 @@ where
     }
 }
 
-impl<T, N, S> Default for IndexSet<T, N, S>
+impl<T, N, S, U> Default for IndexSet<T, N, S, U>
 where
     T: Eq + Hash,
     S: BuildHasher + Default,
@@ -526,7 +526,7 @@ where
     }
 }
 
-impl<T, N1, N2, S1, S2> PartialEq<IndexSet<T, N2, S2>> for IndexSet<T, N1, S1>
+impl<T, N1, N2, S1, S2, U> PartialEq<IndexSet<T, N2, S2, U>> for IndexSet<T, N1, S1, U>
 where
     T: Eq + Hash,
     S1: BuildHasher,
@@ -534,12 +534,12 @@ where
     N1: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>>,
     N2: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>>,
 {
-    fn eq(&self, other: &IndexSet<T, N2, S2>) -> bool {
+    fn eq(&self, other: &IndexSet<T, N2, S2, U>) -> bool {
         self.len() == other.len() && self.is_subset(other)
     }
 }
 
-impl<T, N, S> Extend<T> for IndexSet<T, N, S>
+impl<T, N, S, U> Extend<T> for IndexSet<T, N, S, U>
 where
     T: Eq + Hash,
     S: BuildHasher,
@@ -553,7 +553,7 @@ where
     }
 }
 
-impl<'a, T, N, S> Extend<&'a T> for IndexSet<T, N, S>
+impl<'a, T, N, S, U> Extend<&'a T> for IndexSet<T, N, S, U>
 where
     T: 'a + Eq + Hash + Copy,
     S: BuildHasher,
@@ -567,7 +567,7 @@ where
     }
 }
 
-impl<T, N, S> FromIterator<T> for IndexSet<T, N, S>
+impl<T, N, S, U> FromIterator<T> for IndexSet<T, N, S, U>
 where
     T: Eq + Hash,
     S: BuildHasher + Default,
@@ -583,7 +583,7 @@ where
     }
 }
 
-impl<'a, T, N, S> IntoIterator for &'a IndexSet<T, N, S>
+impl<'a, T, N, S, U> IntoIterator for &'a IndexSet<T, N, S, U>
 where
     T: Eq + Hash,
     S: BuildHasher,
@@ -617,17 +617,17 @@ impl<'a, T> Clone for Iter<'a, T> {
     }
 }
 
-pub struct Difference<'a, T, N, S>
+pub struct Difference<'a, T, N, S, U>
 where
     S: BuildHasher,
     T: Eq + Hash,
     N: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>>,
 {
     iter: Iter<'a, T>,
-    other: &'a IndexSet<T, N, S>,
+    other: &'a IndexSet<T, N, S, U>,
 }
 
-impl<'a, T, N, S> Iterator for Difference<'a, T, N, S>
+impl<'a, T, N, S, U> Iterator for Difference<'a, T, N, S, U>
 where
     S: BuildHasher,
     T: Eq + Hash,
@@ -645,17 +645,17 @@ where
     }
 }
 
-pub struct Intersection<'a, T, N, S>
+pub struct Intersection<'a, T, N, S, U>
 where
     S: BuildHasher,
     T: Eq + Hash,
     N: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>>,
 {
     iter: Iter<'a, T>,
-    other: &'a IndexSet<T, N, S>,
+    other: &'a IndexSet<T, N, S, U>,
 }
 
-impl<'a, T, N, S> Iterator for Intersection<'a, T, N, S>
+impl<'a, T, N, S, U> Iterator for Intersection<'a, T, N, S, U>
 where
     S: BuildHasher,
     T: Eq + Hash,

--- a/src/indexset.rs
+++ b/src/indexset.rs
@@ -179,13 +179,14 @@ where
     /// let diff: FnvIndexSet<_, U16> = b.difference(&a).collect();
     /// assert_eq!(diff, [4].iter().collect::<FnvIndexSet<_, U16>>());
     /// ```
-    pub fn difference<'a, N2, S2>(
+    pub fn difference<'a, N2, S2, U2>(
         &'a self,
-        other: &'a IndexSet<T, N2, S2, U>,
-    ) -> Difference<'a, T, N2, S2, U>
+        other: &'a IndexSet<T, N2, S2, U2>,
+    ) -> Difference<'a, T, N2, S2, U2>
     where
-        N2: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
+        N2: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>> + IsLess<U2::Cap>,
         S2: BuildHasher,
+        U2: MaxCapacity,
     {
         Difference {
             iter: self.iter(),
@@ -216,13 +217,14 @@ where
     /// assert_eq!(diff1, diff2);
     /// assert_eq!(diff1, [1, 4].iter().collect::<FnvIndexSet<_, U16>>());
     /// ```
-    pub fn symmetric_difference<'a, N2, S2>(
+    pub fn symmetric_difference<'a, N2, S2, U2>(
         &'a self,
-        other: &'a IndexSet<T, N2, S2, U>,
+        other: &'a IndexSet<T, N2, S2, U2>,
     ) -> impl Iterator<Item = &'a T>
     where
-        N2: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
+        N2: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>> + IsLess<U2::Cap>,
         S2: BuildHasher,
+        U2: MaxCapacity,
     {
         self.difference(other).chain(other.difference(self))
     }
@@ -247,13 +249,14 @@ where
     /// let intersection: FnvIndexSet<_, U16> = a.intersection(&b).collect();
     /// assert_eq!(intersection, [2, 3].iter().collect::<FnvIndexSet<_, U16>>());
     /// ```
-    pub fn intersection<'a, N2, S2>(
+    pub fn intersection<'a, N2, S2, U2>(
         &'a self,
-        other: &'a IndexSet<T, N2, S2, U>,
-    ) -> Intersection<'a, T, N2, S2, U>
+        other: &'a IndexSet<T, N2, S2, U2>,
+    ) -> Intersection<'a, T, N2, S2, U2>
     where
-        N2: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
+        N2: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>> + IsLess<U2::Cap>,
         S2: BuildHasher,
+        U2: MaxCapacity,
     {
         Intersection {
             iter: self.iter(),
@@ -281,13 +284,14 @@ where
     /// let union: FnvIndexSet<_, U16> = a.union(&b).collect();
     /// assert_eq!(union, [1, 2, 3, 4].iter().collect::<FnvIndexSet<_, U16>>());
     /// ```
-    pub fn union<'a, N2, S2>(
+    pub fn union<'a, N2, S2, U2>(
         &'a self,
-        other: &'a IndexSet<T, N2, S2, U>,
+        other: &'a IndexSet<T, N2, S2, U2>,
     ) -> impl Iterator<Item = &'a T>
     where
-        N2: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
+        N2: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>> + IsLess<U2::Cap>,
         S2: BuildHasher,
+        U2: MaxCapacity,
     {
         self.iter().chain(other.difference(self))
     }
@@ -384,10 +388,11 @@ where
     /// b.insert(1).unwrap();
     /// assert_eq!(a.is_disjoint(&b), false);
     /// ```
-    pub fn is_disjoint<N2, S2>(&self, other: &IndexSet<T, N2, S2, U>) -> bool
+    pub fn is_disjoint<N2, S2, U2>(&self, other: &IndexSet<T, N2, S2, U2>) -> bool
     where
-        N2: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
+        N2: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>> + IsLess<U2::Cap>,
         S2: BuildHasher,
+        U2: MaxCapacity,
     {
         self.iter().all(|v| !other.contains(v))
     }
@@ -410,10 +415,11 @@ where
     /// set.insert(4).unwrap();
     /// assert_eq!(set.is_subset(&sup), false);
     /// ```
-    pub fn is_subset<N2, S2>(&self, other: &IndexSet<T, N2, S2, U>) -> bool
+    pub fn is_subset<N2, S2, U2>(&self, other: &IndexSet<T, N2, S2, U2>) -> bool
     where
-        N2: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
+        N2: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>> + IsLess<U2::Cap>,
         S2: BuildHasher,
+        U2: MaxCapacity,
     {
         self.iter().all(|v| other.contains(v))
     }
@@ -439,10 +445,11 @@ where
     /// set.insert(2).unwrap();
     /// assert_eq!(set.is_superset(&sub), true);
     /// ```
-    pub fn is_superset<N2, S2>(&self, other: &IndexSet<T, N2, S2, U>) -> bool
+    pub fn is_superset<N2, S2, U2>(&self, other: &IndexSet<T, N2, S2, U2>) -> bool
     where
-        N2: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
+        N2: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>> + IsLess<U2::Cap>,
         S2: BuildHasher,
+        U2: MaxCapacity,
     {
         other.is_subset(self)
     }
@@ -538,16 +545,17 @@ where
     }
 }
 
-impl<T, N1, N2, S1, S2, U> PartialEq<IndexSet<T, N2, S2, U>> for IndexSet<T, N1, S1, U>
+impl<T, N1, N2, S1, S2, U1, U2> PartialEq<IndexSet<T, N2, S2, U2>> for IndexSet<T, N1, S1, U1>
 where
     T: Eq + Hash,
     S1: BuildHasher,
     S2: BuildHasher,
-    N1: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
-    N2: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
-    U: MaxCapacity,
+    N1: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>> + IsLess<U1::Cap>,
+    N2: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>> + IsLess<U2::Cap>,
+    U1: MaxCapacity,
+    U2: MaxCapacity,
 {
-    fn eq(&self, other: &IndexSet<T, N2, S2, U>) -> bool {
+    fn eq(&self, other: &IndexSet<T, N2, S2, U2>) -> bool {
         self.len() == other.len() && self.is_subset(other)
     }
 }

--- a/src/indexset.rs
+++ b/src/indexset.rs
@@ -3,7 +3,10 @@ use core::{borrow::Borrow, fmt, iter::FromIterator};
 use generic_array::{typenum::PowerOfTwo, ArrayLength};
 use hash32::{BuildHasher, BuildHasherDefault, FnvHasher, Hash, Hasher};
 
-use crate::indexmap::{self, Bucket, IndexMap, Pos};
+use crate::{
+    indexmap::{self, Bucket, IndexMap, Pos},
+    vec::MaxCapacity,
+};
 
 /// A [`heapless::IndexSet`](./struct.IndexSet.html) using the
 /// default FNV hasher.
@@ -83,6 +86,7 @@ pub struct IndexSet<T, N, S, U>
 where
     T: Eq + Hash,
     N: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>>,
+    U: MaxCapacity,
 {
     map: IndexMap<T, (), N, S, U>,
 }
@@ -92,6 +96,7 @@ where
     T: Eq + Hash,
     S: Default + Hasher,
     N: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>> + PowerOfTwo,
+    U: MaxCapacity,
 {
     /// Creates an empty `IndexSet`
     pub fn new() -> Self {
@@ -106,6 +111,7 @@ where
     T: Eq + Hash,
     S: BuildHasher,
     N: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>>,
+    U: MaxCapacity,
 {
     /// Returns the number of elements the set can hold
     ///
@@ -494,6 +500,7 @@ where
     T: Eq + Hash + Clone,
     S: Clone,
     N: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>>,
+    U: MaxCapacity,
 {
     fn clone(&self) -> Self {
         Self {
@@ -507,6 +514,7 @@ where
     T: Eq + Hash + fmt::Debug,
     S: BuildHasher,
     N: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>>,
+    U: MaxCapacity,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_set().entries(self.iter()).finish()
@@ -518,6 +526,7 @@ where
     T: Eq + Hash,
     S: BuildHasher + Default,
     N: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>>,
+    U: MaxCapacity,
 {
     fn default() -> Self {
         IndexSet {
@@ -533,6 +542,7 @@ where
     S2: BuildHasher,
     N1: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>>,
     N2: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>>,
+    U: MaxCapacity,
 {
     fn eq(&self, other: &IndexSet<T, N2, S2, U>) -> bool {
         self.len() == other.len() && self.is_subset(other)
@@ -544,6 +554,7 @@ where
     T: Eq + Hash,
     S: BuildHasher,
     N: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>>,
+    U: MaxCapacity,
 {
     fn extend<I>(&mut self, iterable: I)
     where
@@ -558,6 +569,7 @@ where
     T: 'a + Eq + Hash + Copy,
     S: BuildHasher,
     N: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>>,
+    U: MaxCapacity,
 {
     fn extend<I>(&mut self, iterable: I)
     where
@@ -572,6 +584,7 @@ where
     T: Eq + Hash,
     S: BuildHasher + Default,
     N: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>>,
+    U: MaxCapacity,
 {
     fn from_iter<I>(iter: I) -> Self
     where
@@ -588,6 +601,7 @@ where
     T: Eq + Hash,
     S: BuildHasher,
     N: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>>,
+    U: MaxCapacity,
 {
     type Item = &'a T;
     type IntoIter = Iter<'a, T>;
@@ -622,6 +636,7 @@ where
     S: BuildHasher,
     T: Eq + Hash,
     N: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>>,
+    U: MaxCapacity,
 {
     iter: Iter<'a, T>,
     other: &'a IndexSet<T, N, S, U>,
@@ -632,6 +647,7 @@ where
     S: BuildHasher,
     T: Eq + Hash,
     N: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>>,
+    U: MaxCapacity,
 {
     type Item = &'a T;
 
@@ -650,6 +666,7 @@ where
     S: BuildHasher,
     T: Eq + Hash,
     N: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>>,
+    U: MaxCapacity,
 {
     iter: Iter<'a, T>,
     other: &'a IndexSet<T, N, S, U>,
@@ -660,6 +677,7 @@ where
     S: BuildHasher,
     T: Eq + Hash,
     N: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>>,
+    U: MaxCapacity,
 {
     type Item = &'a T;
 

--- a/src/indexset.rs
+++ b/src/indexset.rs
@@ -1,7 +1,7 @@
 use core::{borrow::Borrow, fmt, iter::FromIterator};
 
 use generic_array::{
-    typenum::{IsLess, PowerOfTwo},
+    typenum::{IsLess, NonZero, PowerOfTwo},
     ArrayLength,
 };
 use hash32::{BuildHasher, BuildHasherDefault, FnvHasher, Hash, Hasher};
@@ -89,6 +89,7 @@ pub struct IndexSet<T, N, S, U = usize>
 where
     T: Eq + Hash,
     N: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     map: IndexMap<T, (), N, S, U>,
@@ -99,6 +100,7 @@ where
     T: Eq + Hash,
     S: Default + Hasher,
     N: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>> + PowerOfTwo + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     /// Creates an empty `IndexSet`
@@ -114,6 +116,7 @@ where
     T: Eq + Hash,
     S: BuildHasher,
     N: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     /// Returns the number of elements the set can hold
@@ -185,6 +188,7 @@ where
     ) -> Difference<'a, T, N2, S2, U2>
     where
         N2: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>> + IsLess<U2::Cap>,
+        <N2 as IsLess<U2::Cap>>::Output: NonZero,
         S2: BuildHasher,
         U2: MaxCapacity,
     {
@@ -223,6 +227,7 @@ where
     ) -> impl Iterator<Item = &'a T>
     where
         N2: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>> + IsLess<U2::Cap>,
+        <N2 as IsLess<U2::Cap>>::Output: NonZero,
         S2: BuildHasher,
         U2: MaxCapacity,
     {
@@ -255,6 +260,7 @@ where
     ) -> Intersection<'a, T, N2, S2, U2>
     where
         N2: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>> + IsLess<U2::Cap>,
+        <N2 as IsLess<U2::Cap>>::Output: NonZero,
         S2: BuildHasher,
         U2: MaxCapacity,
     {
@@ -290,6 +296,7 @@ where
     ) -> impl Iterator<Item = &'a T>
     where
         N2: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>> + IsLess<U2::Cap>,
+        <N2 as IsLess<U2::Cap>>::Output: NonZero,
         S2: BuildHasher,
         U2: MaxCapacity,
     {
@@ -391,6 +398,7 @@ where
     pub fn is_disjoint<N2, S2, U2>(&self, other: &IndexSet<T, N2, S2, U2>) -> bool
     where
         N2: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>> + IsLess<U2::Cap>,
+        <N2 as IsLess<U2::Cap>>::Output: NonZero,
         S2: BuildHasher,
         U2: MaxCapacity,
     {
@@ -418,6 +426,7 @@ where
     pub fn is_subset<N2, S2, U2>(&self, other: &IndexSet<T, N2, S2, U2>) -> bool
     where
         N2: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>> + IsLess<U2::Cap>,
+        <N2 as IsLess<U2::Cap>>::Output: NonZero,
         S2: BuildHasher,
         U2: MaxCapacity,
     {
@@ -448,6 +457,7 @@ where
     pub fn is_superset<N2, S2, U2>(&self, other: &IndexSet<T, N2, S2, U2>) -> bool
     where
         N2: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>> + IsLess<U2::Cap>,
+        <N2 as IsLess<U2::Cap>>::Output: NonZero,
         S2: BuildHasher,
         U2: MaxCapacity,
     {
@@ -510,6 +520,7 @@ where
     T: Eq + Hash + Clone,
     S: Clone,
     N: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     fn clone(&self) -> Self {
@@ -524,6 +535,7 @@ where
     T: Eq + Hash + fmt::Debug,
     S: BuildHasher,
     N: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -536,6 +548,7 @@ where
     T: Eq + Hash,
     S: BuildHasher + Default,
     N: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     fn default() -> Self {
@@ -551,7 +564,9 @@ where
     S1: BuildHasher,
     S2: BuildHasher,
     N1: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>> + IsLess<U1::Cap>,
+    <N1 as IsLess<U1::Cap>>::Output: NonZero,
     N2: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>> + IsLess<U2::Cap>,
+    <N2 as IsLess<U2::Cap>>::Output: NonZero,
     U1: MaxCapacity,
     U2: MaxCapacity,
 {
@@ -565,6 +580,7 @@ where
     T: Eq + Hash,
     S: BuildHasher,
     N: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     fn extend<I>(&mut self, iterable: I)
@@ -580,6 +596,7 @@ where
     T: 'a + Eq + Hash + Copy,
     S: BuildHasher,
     N: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     fn extend<I>(&mut self, iterable: I)
@@ -595,6 +612,7 @@ where
     T: Eq + Hash,
     S: BuildHasher + Default,
     N: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     fn from_iter<I>(iter: I) -> Self
@@ -612,6 +630,7 @@ where
     T: Eq + Hash,
     S: BuildHasher,
     N: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     type Item = &'a T;
@@ -647,6 +666,7 @@ where
     S: BuildHasher,
     T: Eq + Hash,
     N: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     iter: Iter<'a, T>,
@@ -658,6 +678,7 @@ where
     S: BuildHasher,
     T: Eq + Hash,
     N: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     type Item = &'a T;
@@ -677,6 +698,7 @@ where
     S: BuildHasher,
     T: Eq + Hash,
     N: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     iter: Iter<'a, T>,
@@ -688,6 +710,7 @@ where
     S: BuildHasher,
     T: Eq + Hash,
     N: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     type Item = &'a T;

--- a/src/indexset.rs
+++ b/src/indexset.rs
@@ -44,7 +44,7 @@ use crate::{
 ///     println!("{}", book);
 /// }
 /// ```
-pub type FnvIndexSet<T, N, U> = IndexSet<T, N, BuildHasherDefault<FnvHasher>, U>;
+pub type FnvIndexSet<T, N, U = usize> = IndexSet<T, N, BuildHasherDefault<FnvHasher>, U>;
 
 /// Fixed capacity [`IndexSet`](https://docs.rs/indexmap/1/indexmap/set/struct.IndexSet.html).
 ///
@@ -85,7 +85,7 @@ pub type FnvIndexSet<T, N, U> = IndexSet<T, N, BuildHasherDefault<FnvHasher>, U>
 ///     println!("{}", book);
 /// }
 /// ```
-pub struct IndexSet<T, N, S, U>
+pub struct IndexSet<T, N, S, U = usize>
 where
     T: Eq + Hash,
     N: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,

--- a/src/linear_map.rs
+++ b/src/linear_map.rs
@@ -13,12 +13,14 @@ use crate::Vec;
 /// A fixed capacity map / dictionary that performs lookups via linear search
 ///
 /// Note that as this map doesn't use hashing so most operations are **O(N)** instead of O(1)
-pub struct LinearMap<K, V, N>(#[doc(hidden)] pub crate::i::LinearMap<GenericArray<(K, V), N>>)
+pub struct LinearMap<K, V, N, U>(
+    #[doc(hidden)] pub crate::i::LinearMap<GenericArray<(K, V), N>, U>,
+)
 where
     N: ArrayLength<(K, V)>,
     K: Eq;
 
-impl<A> crate::i::LinearMap<A> {
+impl<A, U> crate::i::LinearMap<A, U> {
     /// `LinearMap` `const` constructor; wrap the returned value in
     /// [`LinearMap`](../struct.LinearMap.html)
     pub const fn new() -> Self {
@@ -28,7 +30,7 @@ impl<A> crate::i::LinearMap<A> {
     }
 }
 
-impl<K, V, N> LinearMap<K, V, N>
+impl<K, V, N, U> LinearMap<K, V, N, U>
 where
     N: ArrayLength<(K, V)>,
     K: Eq,
@@ -378,7 +380,7 @@ where
     }
 }
 
-impl<'a, K, V, N, Q> ops::Index<&'a Q> for LinearMap<K, V, N>
+impl<'a, K, V, N, Q, U> ops::Index<&'a Q> for LinearMap<K, V, N, U>
 where
     N: ArrayLength<(K, V)>,
     K: Borrow<Q> + Eq,
@@ -391,7 +393,7 @@ where
     }
 }
 
-impl<'a, K, V, N, Q> ops::IndexMut<&'a Q> for LinearMap<K, V, N>
+impl<'a, K, V, N, Q, U> ops::IndexMut<&'a Q> for LinearMap<K, V, N, U>
 where
     N: ArrayLength<(K, V)>,
     K: Borrow<Q> + Eq,
@@ -402,7 +404,7 @@ where
     }
 }
 
-impl<K, V, N> Default for LinearMap<K, V, N>
+impl<K, V, N, U> Default for LinearMap<K, V, N, U>
 where
     N: ArrayLength<(K, V)>,
     K: Eq,
@@ -412,7 +414,7 @@ where
     }
 }
 
-impl<K, V, N> Clone for LinearMap<K, V, N>
+impl<K, V, N, U> Clone for LinearMap<K, V, N, U>
 where
     N: ArrayLength<(K, V)>,
     K: Eq + Clone,
@@ -425,7 +427,7 @@ where
     }
 }
 
-impl<K, V, N> fmt::Debug for LinearMap<K, V, N>
+impl<K, V, N, U> fmt::Debug for LinearMap<K, V, N, U>
 where
     N: ArrayLength<(K, V)>,
     K: Eq + fmt::Debug,
@@ -436,7 +438,7 @@ where
     }
 }
 
-impl<K, V, N> FromIterator<(K, V)> for LinearMap<K, V, N>
+impl<K, V, N, U> FromIterator<(K, V)> for LinearMap<K, V, N, U>
 where
     N: ArrayLength<(K, V)>,
     K: Eq,
@@ -451,15 +453,15 @@ where
     }
 }
 
-pub struct IntoIter<K, V, N>
+pub struct IntoIter<K, V, N, U>
 where
     N: ArrayLength<(K, V)>,
     K: Eq,
 {
-    inner: <Vec<(K, V), N> as IntoIterator>::IntoIter,
+    inner: <Vec<(K, V), N, U> as IntoIterator>::IntoIter,
 }
 
-impl<K, V, N> Iterator for IntoIter<K, V, N>
+impl<K, V, N, U> Iterator for IntoIter<K, V, N, U>
 where
     N: ArrayLength<(K, V)>,
     K: Eq,
@@ -470,13 +472,13 @@ where
     }
 }
 
-impl<K, V, N> IntoIterator for LinearMap<K, V, N>
+impl<K, V, N, U> IntoIterator for LinearMap<K, V, N, U>
 where
     N: ArrayLength<(K, V)>,
     K: Eq,
 {
     type Item = (K, V);
-    type IntoIter = IntoIter<K, V, N>;
+    type IntoIter = IntoIter<K, V, N, U>;
 
     fn into_iter(mut self) -> Self::IntoIter {
         // FIXME this may result in a memcpy at runtime
@@ -489,7 +491,7 @@ where
     }
 }
 
-impl<'a, K, V, N> IntoIterator for &'a LinearMap<K, V, N>
+impl<'a, K, V, N, U> IntoIterator for &'a LinearMap<K, V, N, U>
 where
     N: ArrayLength<(K, V)>,
     K: Eq,
@@ -522,7 +524,7 @@ impl<'a, K, V> Clone for Iter<'a, K, V> {
     }
 }
 
-impl<K, V, N> Drop for LinearMap<K, V, N>
+impl<K, V, N, U> Drop for LinearMap<K, V, N, U>
 where
     N: ArrayLength<(K, V)>,
     K: Eq,
@@ -544,14 +546,14 @@ impl<'a, K, V> Iterator for IterMut<'a, K, V> {
     }
 }
 
-impl<K, V, N, N2> PartialEq<LinearMap<K, V, N2>> for LinearMap<K, V, N>
+impl<K, V, N, N2, U> PartialEq<LinearMap<K, V, N2, U>> for LinearMap<K, V, N, U>
 where
     K: Eq,
     V: PartialEq,
     N: ArrayLength<(K, V)>,
     N2: ArrayLength<(K, V)>,
 {
-    fn eq(&self, other: &LinearMap<K, V, N2>) -> bool {
+    fn eq(&self, other: &LinearMap<K, V, N2, U>) -> bool {
         self.len() == other.len()
             && self
                 .iter()
@@ -559,7 +561,7 @@ where
     }
 }
 
-impl<K, V, N> Eq for LinearMap<K, V, N>
+impl<K, V, N, U> Eq for LinearMap<K, V, N, U>
 where
     K: Eq,
     V: PartialEq,
@@ -573,7 +575,7 @@ mod test {
 
     #[test]
     fn static_new() {
-        static mut _L: LinearMap<i32, i32, U8> = LinearMap(crate::i::LinearMap::new());
+        static mut _L: LinearMap<i32, i32, U8, usize> = LinearMap(crate::i::LinearMap::new());
     }
 
     #[test]

--- a/src/linear_map.rs
+++ b/src/linear_map.rs
@@ -13,7 +13,7 @@ use crate::{vec::MaxCapacity, Vec};
 /// A fixed capacity map / dictionary that performs lookups via linear search
 ///
 /// Note that as this map doesn't use hashing so most operations are **O(N)** instead of O(1)
-pub struct LinearMap<K, V, N, U>(
+pub struct LinearMap<K, V, N, U = usize>(
     #[doc(hidden)] pub crate::i::LinearMap<GenericArray<(K, V), N>, U>,
 )
 where

--- a/src/linear_map.rs
+++ b/src/linear_map.rs
@@ -22,22 +22,23 @@ where
     U: MaxCapacity;
 
 macro_rules! impl_new {
-    ($u:ident) => {
+    ($u:ident, $name:ident) => {
         impl<A> crate::i::LinearMap<A, $u> {
             /// `LinearMap` `const` constructor; wrap the returned value in
             /// [`LinearMap`](../struct.LinearMap.html)
-            pub const fn new() -> Self {
+            pub const fn $name() -> Self {
                 Self {
-                    buffer: crate::i::Vec::<_, $u>::new(),
+                    buffer: crate::i::Vec::<_, $u>::$name(),
                 }
             }
         }
     };
 }
 
-impl_new!(u8);
-impl_new!(u16);
-impl_new!(usize);
+impl_new!(u8, u8);
+impl_new!(u16, u16);
+impl_new!(usize, usize);
+impl_new!(usize, new);
 
 impl<K, V, N, U> LinearMap<K, V, N, U>
 where

--- a/src/linear_map.rs
+++ b/src/linear_map.rs
@@ -21,18 +21,23 @@ where
     K: Eq,
     U: MaxCapacity;
 
-impl<A, U> crate::i::LinearMap<A, U>
-where
-    U: MaxCapacity,
-{
-    /// `LinearMap` `const` constructor; wrap the returned value in
-    /// [`LinearMap`](../struct.LinearMap.html)
-    pub const fn new() -> Self {
-        Self {
-            buffer: crate::i::Vec::new(),
+macro_rules! impl_new {
+    ($u:ident) => {
+        impl<A> crate::i::LinearMap<A, $u> {
+            /// `LinearMap` `const` constructor; wrap the returned value in
+            /// [`LinearMap`](../struct.LinearMap.html)
+            pub const fn new() -> Self {
+                Self {
+                    buffer: crate::i::Vec::<_, $u>::new(),
+                }
+            }
         }
-    }
+    };
 }
+
+impl_new!(u8);
+impl_new!(u16);
+impl_new!(usize);
 
 impl<K, V, N, U> LinearMap<K, V, N, U>
 where
@@ -55,7 +60,9 @@ where
     /// static mut MAP: LinearMap<&str, isize, U8> = LinearMap(heapless::i::LinearMap::new());
     /// ```
     pub fn new() -> Self {
-        LinearMap(crate::i::LinearMap::new())
+        LinearMap(crate::i::LinearMap {
+            buffer: crate::i::Vec::new_nonconst(),
+        })
     }
 
     /// Returns the number of elements that the map can hold

--- a/src/linear_map.rs
+++ b/src/linear_map.rs
@@ -569,15 +569,16 @@ impl<'a, K, V> Iterator for IterMut<'a, K, V> {
     }
 }
 
-impl<K, V, N, N2, U> PartialEq<LinearMap<K, V, N2, U>> for LinearMap<K, V, N, U>
+impl<K, V, N, N2, U, U2> PartialEq<LinearMap<K, V, N2, U2>> for LinearMap<K, V, N, U>
 where
     K: Eq,
     V: PartialEq,
     N: ArrayLength<(K, V)> + IsLess<U::Cap>,
-    N2: ArrayLength<(K, V)> + IsLess<U::Cap>,
+    N2: ArrayLength<(K, V)> + IsLess<U2::Cap>,
     U: MaxCapacity,
+    U2: MaxCapacity,
 {
-    fn eq(&self, other: &LinearMap<K, V, N2, U>) -> bool {
+    fn eq(&self, other: &LinearMap<K, V, N2, U2>) -> bool {
         self.len() == other.len()
             && self
                 .iter()

--- a/src/linear_map.rs
+++ b/src/linear_map.rs
@@ -6,7 +6,7 @@ use core::{
     ops, ptr, slice,
 };
 
-use generic_array::{ArrayLength, GenericArray};
+use generic_array::{typenum::IsLess, ArrayLength, GenericArray};
 
 use crate::{vec::MaxCapacity, Vec};
 
@@ -17,7 +17,7 @@ pub struct LinearMap<K, V, N, U>(
     #[doc(hidden)] pub crate::i::LinearMap<GenericArray<(K, V), N>, U>,
 )
 where
-    N: ArrayLength<(K, V)>,
+    N: ArrayLength<(K, V)> + IsLess<U::Cap>,
     K: Eq,
     U: MaxCapacity;
 
@@ -41,7 +41,7 @@ impl_new!(usize);
 
 impl<K, V, N, U> LinearMap<K, V, N, U>
 where
-    N: ArrayLength<(K, V)>,
+    N: ArrayLength<(K, V)> + IsLess<U::Cap>,
     K: Eq,
     U: MaxCapacity,
 {
@@ -394,7 +394,7 @@ where
 
 impl<'a, K, V, N, Q, U> ops::Index<&'a Q> for LinearMap<K, V, N, U>
 where
-    N: ArrayLength<(K, V)>,
+    N: ArrayLength<(K, V)> + IsLess<U::Cap>,
     K: Borrow<Q> + Eq,
     Q: Eq + ?Sized,
     U: MaxCapacity,
@@ -408,7 +408,7 @@ where
 
 impl<'a, K, V, N, Q, U> ops::IndexMut<&'a Q> for LinearMap<K, V, N, U>
 where
-    N: ArrayLength<(K, V)>,
+    N: ArrayLength<(K, V)> + IsLess<U::Cap>,
     K: Borrow<Q> + Eq,
     Q: Eq + ?Sized,
     U: MaxCapacity,
@@ -420,7 +420,7 @@ where
 
 impl<K, V, N, U> Default for LinearMap<K, V, N, U>
 where
-    N: ArrayLength<(K, V)>,
+    N: ArrayLength<(K, V)> + IsLess<U::Cap>,
     K: Eq,
     U: MaxCapacity,
 {
@@ -431,7 +431,7 @@ where
 
 impl<K, V, N, U> Clone for LinearMap<K, V, N, U>
 where
-    N: ArrayLength<(K, V)>,
+    N: ArrayLength<(K, V)> + IsLess<U::Cap>,
     K: Eq + Clone,
     V: Clone,
     U: MaxCapacity,
@@ -445,7 +445,7 @@ where
 
 impl<K, V, N, U> fmt::Debug for LinearMap<K, V, N, U>
 where
-    N: ArrayLength<(K, V)>,
+    N: ArrayLength<(K, V)> + IsLess<U::Cap>,
     K: Eq + fmt::Debug,
     V: fmt::Debug,
     U: MaxCapacity,
@@ -457,7 +457,7 @@ where
 
 impl<K, V, N, U> FromIterator<(K, V)> for LinearMap<K, V, N, U>
 where
-    N: ArrayLength<(K, V)>,
+    N: ArrayLength<(K, V)> + IsLess<U::Cap>,
     K: Eq,
     U: MaxCapacity,
 {
@@ -473,7 +473,7 @@ where
 
 pub struct IntoIter<K, V, N, U>
 where
-    N: ArrayLength<(K, V)>,
+    N: ArrayLength<(K, V)> + IsLess<U::Cap>,
     K: Eq,
     U: MaxCapacity,
 {
@@ -482,7 +482,7 @@ where
 
 impl<K, V, N, U> Iterator for IntoIter<K, V, N, U>
 where
-    N: ArrayLength<(K, V)>,
+    N: ArrayLength<(K, V)> + IsLess<U::Cap>,
     K: Eq,
     U: MaxCapacity,
 {
@@ -494,7 +494,7 @@ where
 
 impl<K, V, N, U> IntoIterator for LinearMap<K, V, N, U>
 where
-    N: ArrayLength<(K, V)>,
+    N: ArrayLength<(K, V)> + IsLess<U::Cap>,
     K: Eq,
     U: MaxCapacity,
 {
@@ -514,7 +514,7 @@ where
 
 impl<'a, K, V, N, U> IntoIterator for &'a LinearMap<K, V, N, U>
 where
-    N: ArrayLength<(K, V)>,
+    N: ArrayLength<(K, V)> + IsLess<U::Cap>,
     K: Eq,
     U: MaxCapacity,
 {
@@ -548,7 +548,7 @@ impl<'a, K, V> Clone for Iter<'a, K, V> {
 
 impl<K, V, N, U> Drop for LinearMap<K, V, N, U>
 where
-    N: ArrayLength<(K, V)>,
+    N: ArrayLength<(K, V)> + IsLess<U::Cap>,
     K: Eq,
     U: MaxCapacity,
 {
@@ -573,8 +573,8 @@ impl<K, V, N, N2, U> PartialEq<LinearMap<K, V, N2, U>> for LinearMap<K, V, N, U>
 where
     K: Eq,
     V: PartialEq,
-    N: ArrayLength<(K, V)>,
-    N2: ArrayLength<(K, V)>,
+    N: ArrayLength<(K, V)> + IsLess<U::Cap>,
+    N2: ArrayLength<(K, V)> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     fn eq(&self, other: &LinearMap<K, V, N2, U>) -> bool {
@@ -589,7 +589,7 @@ impl<K, V, N, U> Eq for LinearMap<K, V, N, U>
 where
     K: Eq,
     V: PartialEq,
-    N: ArrayLength<(K, V)>,
+    N: ArrayLength<(K, V)> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
 }

--- a/src/linear_map.rs
+++ b/src/linear_map.rs
@@ -6,7 +6,10 @@ use core::{
     ops, ptr, slice,
 };
 
-use generic_array::{typenum::IsLess, ArrayLength, GenericArray};
+use generic_array::{
+    typenum::{IsLess, NonZero},
+    ArrayLength, GenericArray,
+};
 
 use crate::{vec::MaxCapacity, Vec};
 
@@ -18,6 +21,7 @@ pub struct LinearMap<K, V, N, U = usize>(
 )
 where
     N: ArrayLength<(K, V)> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     K: Eq,
     U: MaxCapacity;
 
@@ -43,6 +47,7 @@ impl_new!(usize, new);
 impl<K, V, N, U> LinearMap<K, V, N, U>
 where
     N: ArrayLength<(K, V)> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     K: Eq,
     U: MaxCapacity,
 {
@@ -396,6 +401,7 @@ where
 impl<'a, K, V, N, Q, U> ops::Index<&'a Q> for LinearMap<K, V, N, U>
 where
     N: ArrayLength<(K, V)> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     K: Borrow<Q> + Eq,
     Q: Eq + ?Sized,
     U: MaxCapacity,
@@ -410,6 +416,7 @@ where
 impl<'a, K, V, N, Q, U> ops::IndexMut<&'a Q> for LinearMap<K, V, N, U>
 where
     N: ArrayLength<(K, V)> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     K: Borrow<Q> + Eq,
     Q: Eq + ?Sized,
     U: MaxCapacity,
@@ -422,6 +429,7 @@ where
 impl<K, V, N, U> Default for LinearMap<K, V, N, U>
 where
     N: ArrayLength<(K, V)> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     K: Eq,
     U: MaxCapacity,
 {
@@ -433,6 +441,7 @@ where
 impl<K, V, N, U> Clone for LinearMap<K, V, N, U>
 where
     N: ArrayLength<(K, V)> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     K: Eq + Clone,
     V: Clone,
     U: MaxCapacity,
@@ -447,6 +456,7 @@ where
 impl<K, V, N, U> fmt::Debug for LinearMap<K, V, N, U>
 where
     N: ArrayLength<(K, V)> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     K: Eq + fmt::Debug,
     V: fmt::Debug,
     U: MaxCapacity,
@@ -459,6 +469,7 @@ where
 impl<K, V, N, U> FromIterator<(K, V)> for LinearMap<K, V, N, U>
 where
     N: ArrayLength<(K, V)> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     K: Eq,
     U: MaxCapacity,
 {
@@ -475,6 +486,7 @@ where
 pub struct IntoIter<K, V, N, U>
 where
     N: ArrayLength<(K, V)> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     K: Eq,
     U: MaxCapacity,
 {
@@ -484,6 +496,7 @@ where
 impl<K, V, N, U> Iterator for IntoIter<K, V, N, U>
 where
     N: ArrayLength<(K, V)> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     K: Eq,
     U: MaxCapacity,
 {
@@ -496,6 +509,7 @@ where
 impl<K, V, N, U> IntoIterator for LinearMap<K, V, N, U>
 where
     N: ArrayLength<(K, V)> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     K: Eq,
     U: MaxCapacity,
 {
@@ -516,6 +530,7 @@ where
 impl<'a, K, V, N, U> IntoIterator for &'a LinearMap<K, V, N, U>
 where
     N: ArrayLength<(K, V)> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     K: Eq,
     U: MaxCapacity,
 {
@@ -550,6 +565,7 @@ impl<'a, K, V> Clone for Iter<'a, K, V> {
 impl<K, V, N, U> Drop for LinearMap<K, V, N, U>
 where
     N: ArrayLength<(K, V)> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     K: Eq,
     U: MaxCapacity,
 {
@@ -575,7 +591,9 @@ where
     K: Eq,
     V: PartialEq,
     N: ArrayLength<(K, V)> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     N2: ArrayLength<(K, V)> + IsLess<U2::Cap>,
+    <N2 as IsLess<U2::Cap>>::Output: NonZero,
     U: MaxCapacity,
     U2: MaxCapacity,
 {
@@ -592,6 +610,7 @@ where
     K: Eq,
     V: PartialEq,
     N: ArrayLength<(K, V)> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
 }

--- a/src/linear_map.rs
+++ b/src/linear_map.rs
@@ -8,7 +8,7 @@ use core::{
 
 use generic_array::{ArrayLength, GenericArray};
 
-use crate::Vec;
+use crate::{vec::MaxCapacity, Vec};
 
 /// A fixed capacity map / dictionary that performs lookups via linear search
 ///
@@ -18,9 +18,13 @@ pub struct LinearMap<K, V, N, U>(
 )
 where
     N: ArrayLength<(K, V)>,
-    K: Eq;
+    K: Eq,
+    U: MaxCapacity;
 
-impl<A, U> crate::i::LinearMap<A, U> {
+impl<A, U> crate::i::LinearMap<A, U>
+where
+    U: MaxCapacity,
+{
     /// `LinearMap` `const` constructor; wrap the returned value in
     /// [`LinearMap`](../struct.LinearMap.html)
     pub const fn new() -> Self {
@@ -34,6 +38,7 @@ impl<K, V, N, U> LinearMap<K, V, N, U>
 where
     N: ArrayLength<(K, V)>,
     K: Eq,
+    U: MaxCapacity,
 {
     /// Creates an empty `LinearMap`
     ///
@@ -176,7 +181,7 @@ where
     /// assert_eq!(a.len(), 1);
     /// ```
     pub fn len(&self) -> usize {
-        self.0.buffer.len
+        self.0.buffer.len.into()
     }
 
     /// Inserts a key-value pair into the map.
@@ -385,6 +390,7 @@ where
     N: ArrayLength<(K, V)>,
     K: Borrow<Q> + Eq,
     Q: Eq + ?Sized,
+    U: MaxCapacity,
 {
     type Output = V;
 
@@ -398,6 +404,7 @@ where
     N: ArrayLength<(K, V)>,
     K: Borrow<Q> + Eq,
     Q: Eq + ?Sized,
+    U: MaxCapacity,
 {
     fn index_mut(&mut self, key: &Q) -> &mut V {
         self.get_mut(key).expect("no entry found for key")
@@ -408,6 +415,7 @@ impl<K, V, N, U> Default for LinearMap<K, V, N, U>
 where
     N: ArrayLength<(K, V)>,
     K: Eq,
+    U: MaxCapacity,
 {
     fn default() -> Self {
         Self::new()
@@ -419,6 +427,7 @@ where
     N: ArrayLength<(K, V)>,
     K: Eq + Clone,
     V: Clone,
+    U: MaxCapacity,
 {
     fn clone(&self) -> Self {
         Self(crate::i::LinearMap {
@@ -432,6 +441,7 @@ where
     N: ArrayLength<(K, V)>,
     K: Eq + fmt::Debug,
     V: fmt::Debug,
+    U: MaxCapacity,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_map().entries(self.iter()).finish()
@@ -442,6 +452,7 @@ impl<K, V, N, U> FromIterator<(K, V)> for LinearMap<K, V, N, U>
 where
     N: ArrayLength<(K, V)>,
     K: Eq,
+    U: MaxCapacity,
 {
     fn from_iter<I>(iter: I) -> Self
     where
@@ -457,6 +468,7 @@ pub struct IntoIter<K, V, N, U>
 where
     N: ArrayLength<(K, V)>,
     K: Eq,
+    U: MaxCapacity,
 {
     inner: <Vec<(K, V), N, U> as IntoIterator>::IntoIter,
 }
@@ -465,6 +477,7 @@ impl<K, V, N, U> Iterator for IntoIter<K, V, N, U>
 where
     N: ArrayLength<(K, V)>,
     K: Eq,
+    U: MaxCapacity,
 {
     type Item = (K, V);
     fn next(&mut self) -> Option<Self::Item> {
@@ -476,6 +489,7 @@ impl<K, V, N, U> IntoIterator for LinearMap<K, V, N, U>
 where
     N: ArrayLength<(K, V)>,
     K: Eq,
+    U: MaxCapacity,
 {
     type Item = (K, V);
     type IntoIter = IntoIter<K, V, N, U>;
@@ -495,6 +509,7 @@ impl<'a, K, V, N, U> IntoIterator for &'a LinearMap<K, V, N, U>
 where
     N: ArrayLength<(K, V)>,
     K: Eq,
+    U: MaxCapacity,
 {
     type Item = (&'a K, &'a V);
     type IntoIter = Iter<'a, K, V>;
@@ -528,6 +543,7 @@ impl<K, V, N, U> Drop for LinearMap<K, V, N, U>
 where
     N: ArrayLength<(K, V)>,
     K: Eq,
+    U: MaxCapacity,
 {
     fn drop(&mut self) {
         unsafe { ptr::drop_in_place(self.0.buffer.as_mut_slice()) }
@@ -552,6 +568,7 @@ where
     V: PartialEq,
     N: ArrayLength<(K, V)>,
     N2: ArrayLength<(K, V)>,
+    U: MaxCapacity,
 {
     fn eq(&self, other: &LinearMap<K, V, N2, U>) -> bool {
         self.len() == other.len()
@@ -566,6 +583,7 @@ where
     K: Eq,
     V: PartialEq,
     N: ArrayLength<(K, V)>,
+    U: MaxCapacity,
 {
 }
 

--- a/src/linear_map.rs
+++ b/src/linear_map.rs
@@ -601,16 +601,17 @@ mod test {
 
     #[test]
     fn static_new() {
-        static mut _L: LinearMap<i32, i32, U8, usize> = LinearMap(crate::i::LinearMap::new());
+        static mut _L: LinearMap<i32, i32, U8, usize> =
+            LinearMap(crate::i::LinearMap::<_, usize>::new());
     }
 
     #[test]
     fn partial_eq() {
         {
-            let mut a = LinearMap::<_, _, U1>::new();
+            let mut a = LinearMap::<_, _, U1, u8>::new();
             a.insert("k1", "v1").unwrap();
 
-            let mut b = LinearMap::<_, _, U2>::new();
+            let mut b = LinearMap::<_, _, U2, u8>::new();
             b.insert("k1", "v1").unwrap();
 
             assert!(a == b);
@@ -621,11 +622,11 @@ mod test {
         }
 
         {
-            let mut a = LinearMap::<_, _, U2>::new();
+            let mut a = LinearMap::<_, _, U2, u8>::new();
             a.insert("k1", "v1").unwrap();
             a.insert("k2", "v2").unwrap();
 
-            let mut b = LinearMap::<_, _, U2>::new();
+            let mut b = LinearMap::<_, _, U2, u8>::new();
             b.insert("k2", "v2").unwrap();
             b.insert("k1", "v1").unwrap();
 

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -10,7 +10,7 @@ use crate::{
 
 // Sequential containers
 
-impl<T, N, KIND> Serialize for BinaryHeap<T, N, KIND>
+impl<T, N, KIND, U> Serialize for BinaryHeap<T, N, KIND, U>
 where
     T: Ord + Serialize,
     N: ArrayLength<T>,
@@ -28,7 +28,7 @@ where
     }
 }
 
-impl<T, N, S> Serialize for IndexSet<T, N, S>
+impl<T, N, S, U> Serialize for IndexSet<T, N, S, U>
 where
     T: Eq + Hash + Serialize,
     S: BuildHasher,
@@ -46,7 +46,7 @@ where
     }
 }
 
-impl<T, N> Serialize for Vec<T, N>
+impl<T, N, U> Serialize for Vec<T, N, U>
 where
     T: Serialize,
     N: ArrayLength<T>,
@@ -65,7 +65,7 @@ where
 
 // Dictionaries
 
-impl<K, V, N, S> Serialize for IndexMap<K, V, N, S>
+impl<K, V, N, S, U> Serialize for IndexMap<K, V, N, S, U>
 where
     K: Eq + Hash + Serialize,
     N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>>,
@@ -84,7 +84,7 @@ where
     }
 }
 
-impl<K, V, N> Serialize for LinearMap<K, V, N>
+impl<K, V, N, U> Serialize for LinearMap<K, V, N, U>
 where
     N: ArrayLength<(K, V)>,
     K: Eq + Serialize,
@@ -104,7 +104,7 @@ where
 
 // String containers
 
-impl<N> Serialize for String<N>
+impl<N, U> Serialize for String<N, U>
 where
     N: ArrayLength<u8>,
 {

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -5,6 +5,7 @@ use serde::ser::{Serialize, SerializeMap, SerializeSeq, Serializer};
 use crate::{
     indexmap::{Bucket, Pos},
     sealed::binary_heap::Kind as BinaryHeapKind,
+    vec::MaxCapacity,
     BinaryHeap, IndexMap, IndexSet, LinearMap, String, Vec,
 };
 
@@ -15,6 +16,7 @@ where
     T: Ord + Serialize,
     N: ArrayLength<T>,
     KIND: BinaryHeapKind,
+    U: MaxCapacity,
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -33,6 +35,7 @@ where
     T: Eq + Hash + Serialize,
     S: BuildHasher,
     N: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>> + PowerOfTwo,
+    U: MaxCapacity,
 {
     fn serialize<SER>(&self, serializer: SER) -> Result<SER::Ok, SER::Error>
     where
@@ -50,6 +53,7 @@ impl<T, N, U> Serialize for Vec<T, N, U>
 where
     T: Serialize,
     N: ArrayLength<T>,
+    U: MaxCapacity,
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -71,6 +75,7 @@ where
     N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>>,
     S: BuildHasher,
     V: Serialize,
+    U: MaxCapacity,
 {
     fn serialize<SER>(&self, serializer: SER) -> Result<SER::Ok, SER::Error>
     where
@@ -89,6 +94,7 @@ where
     N: ArrayLength<(K, V)>,
     K: Eq + Serialize,
     V: Serialize,
+    U: MaxCapacity,
 {
     fn serialize<SER>(&self, serializer: SER) -> Result<SER::Ok, SER::Error>
     where
@@ -107,6 +113,7 @@ where
 impl<N, U> Serialize for String<N, U>
 where
     N: ArrayLength<u8>,
+    U: MaxCapacity,
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -1,4 +1,7 @@
-use generic_array::{typenum::PowerOfTwo, ArrayLength};
+use generic_array::{
+    typenum::{IsLess, PowerOfTwo},
+    ArrayLength,
+};
 use hash32::{BuildHasher, Hash};
 use serde::ser::{Serialize, SerializeMap, SerializeSeq, Serializer};
 
@@ -14,7 +17,7 @@ use crate::{
 impl<T, N, KIND, U> Serialize for BinaryHeap<T, N, KIND, U>
 where
     T: Ord + Serialize,
-    N: ArrayLength<T>,
+    N: ArrayLength<T> + IsLess<U::Cap>,
     KIND: BinaryHeapKind,
     U: MaxCapacity,
 {
@@ -34,7 +37,7 @@ impl<T, N, S, U> Serialize for IndexSet<T, N, S, U>
 where
     T: Eq + Hash + Serialize,
     S: BuildHasher,
-    N: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>> + PowerOfTwo,
+    N: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>> + PowerOfTwo + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     fn serialize<SER>(&self, serializer: SER) -> Result<SER::Ok, SER::Error>
@@ -52,7 +55,7 @@ where
 impl<T, N, U> Serialize for Vec<T, N, U>
 where
     T: Serialize,
-    N: ArrayLength<T>,
+    N: ArrayLength<T> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -72,7 +75,7 @@ where
 impl<K, V, N, S, U> Serialize for IndexMap<K, V, N, S, U>
 where
     K: Eq + Hash + Serialize,
-    N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>>,
+    N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
     S: BuildHasher,
     V: Serialize,
     U: MaxCapacity,
@@ -91,7 +94,7 @@ where
 
 impl<K, V, N, U> Serialize for LinearMap<K, V, N, U>
 where
-    N: ArrayLength<(K, V)>,
+    N: ArrayLength<(K, V)> + IsLess<U::Cap>,
     K: Eq + Serialize,
     V: Serialize,
     U: MaxCapacity,
@@ -112,7 +115,7 @@ where
 
 impl<N, U> Serialize for String<N, U>
 where
-    N: ArrayLength<u8>,
+    N: ArrayLength<u8> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -1,5 +1,5 @@
 use generic_array::{
-    typenum::{IsLess, PowerOfTwo},
+    typenum::{IsLess, NonZero, PowerOfTwo},
     ArrayLength,
 };
 use hash32::{BuildHasher, Hash};
@@ -18,6 +18,7 @@ impl<T, N, KIND, U> Serialize for BinaryHeap<T, N, KIND, U>
 where
     T: Ord + Serialize,
     N: ArrayLength<T> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     KIND: BinaryHeapKind,
     U: MaxCapacity,
 {
@@ -38,6 +39,7 @@ where
     T: Eq + Hash + Serialize,
     S: BuildHasher,
     N: ArrayLength<Bucket<T, ()>> + ArrayLength<Option<Pos>> + PowerOfTwo + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     fn serialize<SER>(&self, serializer: SER) -> Result<SER::Ok, SER::Error>
@@ -56,6 +58,7 @@ impl<T, N, U> Serialize for Vec<T, N, U>
 where
     T: Serialize,
     N: ArrayLength<T> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -76,6 +79,7 @@ impl<K, V, N, S, U> Serialize for IndexMap<K, V, N, S, U>
 where
     K: Eq + Hash + Serialize,
     N: ArrayLength<Bucket<K, V>> + ArrayLength<Option<Pos>> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     S: BuildHasher,
     V: Serialize,
     U: MaxCapacity,
@@ -95,6 +99,7 @@ where
 impl<K, V, N, U> Serialize for LinearMap<K, V, N, U>
 where
     N: ArrayLength<(K, V)> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     K: Eq + Serialize,
     V: Serialize,
     U: MaxCapacity,
@@ -116,6 +121,7 @@ where
 impl<N, U> Serialize for String<N, U>
 where
     N: ArrayLength<u8> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/src/string.rs
+++ b/src/string.rs
@@ -537,17 +537,18 @@ where
     }
 }
 
-impl<N1, N2, U> PartialEq<String<N2, U>> for String<N1, U>
+impl<N1, N2, U1, U2> PartialEq<String<N2, U2>> for String<N1, U1>
 where
-    N1: ArrayLength<u8> + IsLess<U::Cap>,
-    N2: ArrayLength<u8> + IsLess<U::Cap>,
-    U: MaxCapacity,
+    N1: ArrayLength<u8> + IsLess<U1::Cap>,
+    N2: ArrayLength<u8> + IsLess<U2::Cap>,
+    U1: MaxCapacity,
+    U2: MaxCapacity,
 {
-    fn eq(&self, rhs: &String<N2, U>) -> bool {
+    fn eq(&self, rhs: &String<N2, U2>) -> bool {
         str::eq(&**self, &**rhs)
     }
 
-    fn ne(&self, rhs: &String<N2, U>) -> bool {
+    fn ne(&self, rhs: &String<N2, U2>) -> bool {
         str::ne(&**self, &**rhs)
     }
 }

--- a/src/string.rs
+++ b/src/string.rs
@@ -8,7 +8,7 @@ use core::{
 };
 
 use generic_array::{
-    typenum::{consts::*, IsGreaterOrEqual},
+    typenum::{consts::*, IsGreaterOrEqual, IsLess},
     ArrayLength, GenericArray,
 };
 use hash32;
@@ -39,7 +39,7 @@ impl_new!(usize);
 
 impl<N, U> String<N, U>
 where
-    N: ArrayLength<u8>,
+    N: ArrayLength<u8> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     /// Constructs a new, empty `String` with a fixed capacity of `N`
@@ -391,7 +391,7 @@ where
 
 impl<N, U> Default for String<N, U>
 where
-    N: ArrayLength<u8>,
+    N: ArrayLength<u8> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     fn default() -> Self {
@@ -401,7 +401,7 @@ where
 
 impl<'a, N, U> From<&'a str> for String<N, U>
 where
-    N: ArrayLength<u8>,
+    N: ArrayLength<u8> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     fn from(s: &'a str) -> Self {
@@ -413,7 +413,7 @@ where
 
 impl<N, U> str::FromStr for String<N, U>
 where
-    N: ArrayLength<u8>,
+    N: ArrayLength<u8> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     type Err = ();
@@ -427,7 +427,7 @@ where
 
 impl<N, U> Clone for String<N, U>
 where
-    N: ArrayLength<u8>,
+    N: ArrayLength<u8> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     fn clone(&self) -> Self {
@@ -439,7 +439,7 @@ where
 
 impl<N, U> fmt::Debug for String<N, U>
 where
-    N: ArrayLength<u8>,
+    N: ArrayLength<u8> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -449,7 +449,7 @@ where
 
 impl<N, U> fmt::Display for String<N, U>
 where
-    N: ArrayLength<u8>,
+    N: ArrayLength<u8> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -459,7 +459,7 @@ where
 
 impl<N, U> hash::Hash for String<N, U>
 where
-    N: ArrayLength<u8>,
+    N: ArrayLength<u8> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     #[inline]
@@ -470,7 +470,7 @@ where
 
 impl<N, U> hash32::Hash for String<N, U>
 where
-    N: ArrayLength<u8>,
+    N: ArrayLength<u8> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     #[inline]
@@ -481,7 +481,7 @@ where
 
 impl<N, U> fmt::Write for String<N, U>
 where
-    N: ArrayLength<u8>,
+    N: ArrayLength<u8> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     fn write_str(&mut self, s: &str) -> Result<(), fmt::Error> {
@@ -495,7 +495,7 @@ where
 
 impl<N, U> ops::Deref for String<N, U>
 where
-    N: ArrayLength<u8>,
+    N: ArrayLength<u8> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     type Target = str;
@@ -507,7 +507,7 @@ where
 
 impl<N, U> ops::DerefMut for String<N, U>
 where
-    N: ArrayLength<u8>,
+    N: ArrayLength<u8> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     fn deref_mut(&mut self) -> &mut str {
@@ -517,7 +517,7 @@ where
 
 impl<N, U> AsRef<str> for String<N, U>
 where
-    N: ArrayLength<u8>,
+    N: ArrayLength<u8> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     #[inline]
@@ -528,7 +528,7 @@ where
 
 impl<N, U> AsRef<[u8]> for String<N, U>
 where
-    N: ArrayLength<u8>,
+    N: ArrayLength<u8> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     #[inline]
@@ -539,8 +539,8 @@ where
 
 impl<N1, N2, U> PartialEq<String<N2, U>> for String<N1, U>
 where
-    N1: ArrayLength<u8>,
-    N2: ArrayLength<u8>,
+    N1: ArrayLength<u8> + IsLess<U::Cap>,
+    N2: ArrayLength<u8> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     fn eq(&self, rhs: &String<N2, U>) -> bool {
@@ -556,7 +556,7 @@ macro_rules! impl_eq {
     ($lhs:ty, $rhs:ty) => {
         impl<'a, 'b, N, U> PartialEq<$rhs> for $lhs
         where
-            N: ArrayLength<u8>,
+            N: ArrayLength<u8> + IsLess<U::Cap>,
             U: MaxCapacity,
         {
             #[inline]
@@ -571,7 +571,7 @@ macro_rules! impl_eq {
 
         impl<'a, 'b, N, U> PartialEq<$lhs> for $rhs
         where
-            N: ArrayLength<u8>,
+            N: ArrayLength<u8> + IsLess<U::Cap>,
             U: MaxCapacity,
         {
             #[inline]
@@ -591,7 +591,7 @@ impl_eq! { String<N, U>, &'a str }
 
 impl<N, U> Eq for String<N, U>
 where
-    N: ArrayLength<u8>,
+    N: ArrayLength<u8> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
 }
@@ -600,7 +600,7 @@ macro_rules! impl_from_num {
     ($num:ty, $size:ty) => {
         impl<N, U> From<$num> for String<N, U>
         where
-            N: ArrayLength<u8> + IsGreaterOrEqual<$size, Output = True>,
+            N: ArrayLength<u8> + IsGreaterOrEqual<$size, Output = True> + IsLess<U::Cap>,
             U: MaxCapacity,
         {
             fn from(s: $num) -> Self {

--- a/src/string.rs
+++ b/src/string.rs
@@ -629,12 +629,12 @@ mod tests {
 
     #[test]
     fn static_new() {
-        static mut _S: String<U8, usize> = String(crate::i::String::new());
+        static mut _S: String<U8, usize> = String(crate::i::String::<_, usize>::new());
     }
 
     #[test]
     fn clone() {
-        let s1: String<U20> = String::from("abcd");
+        let s1: String<U20, u8> = String::from("abcd");
         let mut s2 = s1.clone();
         s2.push_str(" efgh").unwrap();
 
@@ -646,7 +646,7 @@ mod tests {
     fn debug() {
         use core::fmt::Write;
 
-        let s: String<U8> = String::from("abcd");
+        let s: String<U8, u8> = String::from("abcd");
         let mut std_s = std::string::String::new();
         write!(std_s, "{:?}", s).unwrap();
         assert_eq!("\"abcd\"", std_s);
@@ -656,7 +656,7 @@ mod tests {
     fn display() {
         use core::fmt::Write;
 
-        let s: String<U8> = String::from("abcd");
+        let s: String<U8, u8> = String::from("abcd");
         let mut std_s = std::string::String::new();
         write!(std_s, "{}", s).unwrap();
         assert_eq!("abcd", std_s);
@@ -664,7 +664,7 @@ mod tests {
 
     #[test]
     fn empty() {
-        let s: String<U4> = String::new();
+        let s: String<U4, u8> = String::new();
         assert!(s.capacity() == 4);
         assert_eq!(s, "");
         assert_eq!(s.len(), 0);
@@ -673,7 +673,7 @@ mod tests {
 
     #[test]
     fn from() {
-        let s: String<U4> = String::from("123");
+        let s: String<U4, u8> = String::from("123");
         assert!(s.len() == 3);
         assert_eq!(s, "123");
     }
@@ -682,23 +682,23 @@ mod tests {
     fn from_str() {
         use core::str::FromStr;
 
-        let s: String<U4> = String::<U4>::from_str("123").unwrap();
+        let s: String<U4, u8> = String::<U4, u8>::from_str("123").unwrap();
         assert!(s.len() == 3);
         assert_eq!(s, "123");
 
-        let e: () = String::<U2>::from_str("123").unwrap_err();
+        let e: () = String::<U2, u8>::from_str("123").unwrap_err();
         assert_eq!(e, ());
     }
 
     #[test]
     #[should_panic]
     fn from_panic() {
-        let _: String<U4> = String::from("12345");
+        let _: String<U4, u8> = String::from("12345");
     }
 
     #[test]
     fn from_utf8() {
-        let mut v: Vec<u8, U8> = Vec::new();
+        let mut v: Vec<u8, U8, u8> = Vec::new();
         v.push('a' as u8).unwrap();
         v.push('b' as u8).unwrap();
 
@@ -708,7 +708,7 @@ mod tests {
 
     #[test]
     fn from_utf8_uenc() {
-        let mut v: Vec<u8, U8> = Vec::new();
+        let mut v: Vec<u8, U8, u8> = Vec::new();
         v.push(240).unwrap();
         v.push(159).unwrap();
         v.push(146).unwrap();
@@ -719,7 +719,7 @@ mod tests {
 
     #[test]
     fn from_utf8_uenc_err() {
-        let mut v: Vec<u8, U8> = Vec::new();
+        let mut v: Vec<u8, U8, u8> = Vec::new();
         v.push(0).unwrap();
         v.push(159).unwrap();
         v.push(146).unwrap();
@@ -730,7 +730,7 @@ mod tests {
 
     #[test]
     fn from_utf8_unchecked() {
-        let mut v: Vec<u8, U8> = Vec::new();
+        let mut v: Vec<u8, U8, u8> = Vec::new();
         v.push(104).unwrap();
         v.push(101).unwrap();
         v.push(108).unwrap();
@@ -744,22 +744,22 @@ mod tests {
 
     #[test]
     fn from_num() {
-        let v = String::<U20>::from(18446744073709551615 as u64);
+        let v = String::<U20, u8>::from(18446744073709551615 as u64);
 
         assert_eq!(v, "18446744073709551615");
     }
 
     #[test]
     fn into_bytes() {
-        let s: String<U4> = String::from("ab");
-        let b: Vec<u8, U4> = s.into_bytes();
+        let s: String<U4, u8> = String::from("ab");
+        let b: Vec<u8, U4, u8> = s.into_bytes();
         assert_eq!(b.len(), 2);
         assert_eq!(&['a' as u8, 'b' as u8], &b[..]);
     }
 
     #[test]
     fn as_str() {
-        let s: String<U4> = String::from("ab");
+        let s: String<U4, u8> = String::from("ab");
 
         assert_eq!(s.as_str(), "ab");
         // should be moved to fail test
@@ -769,7 +769,7 @@ mod tests {
 
     #[test]
     fn as_mut_str() {
-        let mut s: String<U4> = String::from("ab");
+        let mut s: String<U4, u8> = String::from("ab");
         let s = s.as_mut_str();
         s.make_ascii_uppercase();
         assert_eq!(s, "AB");
@@ -777,7 +777,7 @@ mod tests {
 
     #[test]
     fn push_str() {
-        let mut s: String<U8> = String::from("foo");
+        let mut s: String<U8, u8> = String::from("foo");
         assert!(s.push_str("bar").is_ok());
         assert_eq!("foobar", s);
         assert!(s.push_str("tender").is_err());
@@ -786,7 +786,7 @@ mod tests {
 
     #[test]
     fn push() {
-        let mut s: String<U6> = String::from("abc");
+        let mut s: String<U6, u8> = String::from("abc");
         assert!(s.push('1').is_ok());
         assert!(s.push('2').is_ok());
         assert!(s.push('3').is_ok());
@@ -796,13 +796,13 @@ mod tests {
 
     #[test]
     fn as_bytes() {
-        let s: String<U8> = String::from("hello");
+        let s: String<U8, u8> = String::from("hello");
         assert_eq!(&[104, 101, 108, 108, 111], s.as_bytes());
     }
 
     #[test]
     fn truncate() {
-        let mut s: String<U8> = String::from("hello");
+        let mut s: String<U8, u8> = String::from("hello");
         s.truncate(6);
         assert_eq!(s.len(), 5);
         s.truncate(2);
@@ -813,7 +813,7 @@ mod tests {
 
     #[test]
     fn pop() {
-        let mut s: String<U8> = String::from("foo");
+        let mut s: String<U8, u8> = String::from("foo");
         assert_eq!(s.pop(), Some('o'));
         assert_eq!(s.pop(), Some('o'));
         assert_eq!(s.pop(), Some('f'));
@@ -822,7 +822,7 @@ mod tests {
 
     #[test]
     fn pop_uenc() {
-        let mut s: String<U8> = String::from("é");
+        let mut s: String<U8, u8> = String::from("é");
         assert_eq!(s.len(), 3);
         match s.pop() {
             Some(c) => {
@@ -836,7 +836,7 @@ mod tests {
 
     #[test]
     fn is_empty() {
-        let mut v: String<U8> = String::new();
+        let mut v: String<U8, u8> = String::new();
         assert!(v.is_empty());
         let _ = v.push('a');
         assert!(!v.is_empty());
@@ -844,7 +844,7 @@ mod tests {
 
     #[test]
     fn clear() {
-        let mut s: String<U8> = String::from("foo");
+        let mut s: String<U8, u8> = String::from("foo");
         s.clear();
         assert!(s.is_empty());
         assert_eq!(0, s.len());

--- a/src/string.rs
+++ b/src/string.rs
@@ -16,7 +16,7 @@ use hash32;
 use crate::{vec::MaxCapacity, Vec};
 
 /// A fixed capacity [`String`](https://doc.rust-lang.org/std/string/struct.String.html)
-pub struct String<N, U>(#[doc(hidden)] pub crate::i::String<GenericArray<u8, N>, U>)
+pub struct String<N, U = usize>(#[doc(hidden)] pub crate::i::String<GenericArray<u8, N>, U>)
 where
     N: ArrayLength<u8>;
 

--- a/src/string.rs
+++ b/src/string.rs
@@ -20,17 +20,22 @@ pub struct String<N, U>(#[doc(hidden)] pub crate::i::String<GenericArray<u8, N>,
 where
     N: ArrayLength<u8>;
 
-impl<A, U> crate::i::String<A, U>
-where
-    U: MaxCapacity,
-{
-    /// `String` `const` constructor; wrap the returned value in [`String`](../struct.String.html)
-    pub const fn new() -> Self {
-        Self {
-            vec: crate::i::Vec::new(),
+macro_rules! impl_new {
+    ($u:ident) => {
+        impl<A> crate::i::String<A, $u> {
+            /// `String` `const` constructor; wrap the returned value in [`String`](../struct.String.html)
+            pub const fn new() -> Self {
+                Self {
+                    vec: crate::i::Vec::<_, $u>::new(),
+                }
+            }
         }
-    }
+    };
 }
+
+impl_new!(u8);
+impl_new!(u16);
+impl_new!(usize);
 
 impl<N, U> String<N, U>
 where
@@ -55,7 +60,9 @@ where
     /// ```
     #[inline]
     pub fn new() -> Self {
-        String(crate::i::String::new())
+        String(crate::i::String {
+            vec: crate::i::Vec::new_nonconst(),
+        })
     }
 
     /// Converts a vector of bytes into a `String`.

--- a/src/string.rs
+++ b/src/string.rs
@@ -16,11 +16,11 @@ use hash32;
 use crate::Vec;
 
 /// A fixed capacity [`String`](https://doc.rust-lang.org/std/string/struct.String.html)
-pub struct String<N>(#[doc(hidden)] pub crate::i::String<GenericArray<u8, N>>)
+pub struct String<N, U>(#[doc(hidden)] pub crate::i::String<GenericArray<u8, N>, U>)
 where
     N: ArrayLength<u8>;
 
-impl<A> crate::i::String<A> {
+impl<A, U> crate::i::String<A, U> {
     /// `String` `const` constructor; wrap the returned value in [`String`](../struct.String.html)
     pub const fn new() -> Self {
         Self {
@@ -29,7 +29,7 @@ impl<A> crate::i::String<A> {
     }
 }
 
-impl<N> String<N>
+impl<N, U> String<N, U>
 where
     N: ArrayLength<u8>,
 {
@@ -96,7 +96,7 @@ where
     /// assert!(String::from_utf8(v).is_err());
     /// ```
     #[inline]
-    pub fn from_utf8(vec: Vec<u8, N>) -> Result<String<N>, Utf8Error> {
+    pub fn from_utf8(vec: Vec<u8, N, U>) -> Result<String<N, U>, Utf8Error> {
         // validate input
         str::from_utf8(&*vec)?;
 
@@ -108,7 +108,7 @@ where
     ///
     /// See the safe version, `from_utf8`, for more details.
     #[inline]
-    pub unsafe fn from_utf8_unchecked(mut vec: Vec<u8, N>) -> String<N> {
+    pub unsafe fn from_utf8_unchecked(mut vec: Vec<u8, N, U>) -> String<N, U> {
         // FIXME this may result in a memcpy at runtime
         let vec_ = mem::replace(&mut vec.0, MaybeUninit::uninit().assume_init());
         mem::forget(vec);
@@ -134,7 +134,7 @@ where
     /// assert_eq!(&['a' as u8, 'b' as u8], &b[..]);
     /// ```
     #[inline]
-    pub fn into_bytes(self) -> Vec<u8, N> {
+    pub fn into_bytes(self) -> Vec<u8, N, U> {
         Vec(self.0.vec)
     }
 
@@ -202,7 +202,7 @@ where
     /// }
     /// assert_eq!(s, "olleh");
     /// ```
-    pub unsafe fn as_mut_vec(&mut self) -> &mut Vec<u8, N> {
+    pub unsafe fn as_mut_vec(&mut self) -> &mut Vec<u8, N, U> {
         &mut *(&mut self.0.vec as *mut crate::i::Vec<GenericArray<u8, N>> as *mut Vec<u8, N>)
     }
 
@@ -378,7 +378,7 @@ where
     }
 }
 
-impl<N> Default for String<N>
+impl<N, U> Default for String<N, U>
 where
     N: ArrayLength<u8>,
 {
@@ -387,7 +387,7 @@ where
     }
 }
 
-impl<'a, N> From<&'a str> for String<N>
+impl<'a, N, U> From<&'a str> for String<N, U>
 where
     N: ArrayLength<u8>,
 {
@@ -398,7 +398,7 @@ where
     }
 }
 
-impl<N> str::FromStr for String<N>
+impl<N, U> str::FromStr for String<N, U>
 where
     N: ArrayLength<u8>,
 {
@@ -411,7 +411,7 @@ where
     }
 }
 
-impl<N> Clone for String<N>
+impl<N, U> Clone for String<N, U>
 where
     N: ArrayLength<u8>,
 {
@@ -422,7 +422,7 @@ where
     }
 }
 
-impl<N> fmt::Debug for String<N>
+impl<N, U> fmt::Debug for String<N, U>
 where
     N: ArrayLength<u8>,
 {
@@ -431,7 +431,7 @@ where
     }
 }
 
-impl<N> fmt::Display for String<N>
+impl<N, U> fmt::Display for String<N, U>
 where
     N: ArrayLength<u8>,
 {
@@ -440,7 +440,7 @@ where
     }
 }
 
-impl<N> hash::Hash for String<N>
+impl<N, U> hash::Hash for String<N, U>
 where
     N: ArrayLength<u8>,
 {
@@ -450,7 +450,7 @@ where
     }
 }
 
-impl<N> hash32::Hash for String<N>
+impl<N, U> hash32::Hash for String<N, U>
 where
     N: ArrayLength<u8>,
 {
@@ -460,7 +460,7 @@ where
     }
 }
 
-impl<N> fmt::Write for String<N>
+impl<N, U> fmt::Write for String<N, U>
 where
     N: ArrayLength<u8>,
 {
@@ -473,7 +473,7 @@ where
     }
 }
 
-impl<N> ops::Deref for String<N>
+impl<N, U> ops::Deref for String<N, U>
 where
     N: ArrayLength<u8>,
 {
@@ -484,7 +484,7 @@ where
     }
 }
 
-impl<N> ops::DerefMut for String<N>
+impl<N, U> ops::DerefMut for String<N, U>
 where
     N: ArrayLength<u8>,
 {
@@ -493,7 +493,7 @@ where
     }
 }
 
-impl<N> AsRef<str> for String<N>
+impl<N, U> AsRef<str> for String<N, U>
 where
     N: ArrayLength<u8>,
 {
@@ -503,7 +503,7 @@ where
     }
 }
 
-impl<N> AsRef<[u8]> for String<N>
+impl<N, U> AsRef<[u8]> for String<N, U>
 where
     N: ArrayLength<u8>,
 {
@@ -513,23 +513,23 @@ where
     }
 }
 
-impl<N1, N2> PartialEq<String<N2>> for String<N1>
+impl<N1, N2, U> PartialEq<String<N2, U>> for String<N1, U>
 where
     N1: ArrayLength<u8>,
     N2: ArrayLength<u8>,
 {
-    fn eq(&self, rhs: &String<N2>) -> bool {
+    fn eq(&self, rhs: &String<N2, U>) -> bool {
         str::eq(&**self, &**rhs)
     }
 
-    fn ne(&self, rhs: &String<N2>) -> bool {
+    fn ne(&self, rhs: &String<N2, U>) -> bool {
         str::ne(&**self, &**rhs)
     }
 }
 
 macro_rules! impl_eq {
     ($lhs:ty, $rhs:ty) => {
-        impl<'a, 'b, N> PartialEq<$rhs> for $lhs
+        impl<'a, 'b, N, U> PartialEq<$rhs> for $lhs
         where
             N: ArrayLength<u8>,
         {
@@ -543,7 +543,7 @@ macro_rules! impl_eq {
             }
         }
 
-        impl<'a, 'b, N> PartialEq<$lhs> for $rhs
+        impl<'a, 'b, N, U> PartialEq<$lhs> for $rhs
         where
             N: ArrayLength<u8>,
         {
@@ -559,14 +559,14 @@ macro_rules! impl_eq {
     };
 }
 
-impl_eq! { String<N>, str }
-impl_eq! { String<N>, &'a str }
+impl_eq! { String<N, U>, str }
+impl_eq! { String<N, U>, &'a str }
 
-impl<N> Eq for String<N> where N: ArrayLength<u8> {}
+impl<N, U> Eq for String<N, U> where N: ArrayLength<u8> {}
 
 macro_rules! impl_from_num {
     ($num:ty, $size:ty) => {
-        impl<N> From<$num> for String<N>
+        impl<N, U> From<$num> for String<N, U>
         where
             N: ArrayLength<u8> + IsGreaterOrEqual<$size, Output = True>,
         {
@@ -595,7 +595,7 @@ mod tests {
 
     #[test]
     fn static_new() {
-        static mut _S: String<U8> = String(crate::i::String::new());
+        static mut _S: String<U8, usize> = String(crate::i::String::new());
     }
 
     #[test]

--- a/src/string.rs
+++ b/src/string.rs
@@ -21,21 +21,22 @@ where
     N: ArrayLength<u8>;
 
 macro_rules! impl_new {
-    ($u:ident) => {
+    ($u:ident, $name:ident) => {
         impl<A> crate::i::String<A, $u> {
             /// `String` `const` constructor; wrap the returned value in [`String`](../struct.String.html)
-            pub const fn new() -> Self {
+            pub const fn $name() -> Self {
                 Self {
-                    vec: crate::i::Vec::<_, $u>::new(),
+                    vec: crate::i::Vec::<_, $u>::$name(),
                 }
             }
         }
     };
 }
 
-impl_new!(u8);
-impl_new!(u16);
-impl_new!(usize);
+impl_new!(u8, u8);
+impl_new!(u16, u16);
+impl_new!(usize, usize);
+impl_new!(usize, new);
 
 impl<N, U> String<N, U>
 where

--- a/src/string.rs
+++ b/src/string.rs
@@ -8,7 +8,7 @@ use core::{
 };
 
 use generic_array::{
-    typenum::{consts::*, IsGreaterOrEqual, IsLess},
+    typenum::{consts::*, IsGreaterOrEqual, IsLess, NonZero},
     ArrayLength, GenericArray,
 };
 use hash32;
@@ -41,6 +41,7 @@ impl_new!(usize, new);
 impl<N, U> String<N, U>
 where
     N: ArrayLength<u8> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     /// Constructs a new, empty `String` with a fixed capacity of `N`
@@ -393,6 +394,7 @@ where
 impl<N, U> Default for String<N, U>
 where
     N: ArrayLength<u8> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     fn default() -> Self {
@@ -403,6 +405,7 @@ where
 impl<'a, N, U> From<&'a str> for String<N, U>
 where
     N: ArrayLength<u8> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     fn from(s: &'a str) -> Self {
@@ -415,6 +418,7 @@ where
 impl<N, U> str::FromStr for String<N, U>
 where
     N: ArrayLength<u8> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     type Err = ();
@@ -429,6 +433,7 @@ where
 impl<N, U> Clone for String<N, U>
 where
     N: ArrayLength<u8> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     fn clone(&self) -> Self {
@@ -441,6 +446,7 @@ where
 impl<N, U> fmt::Debug for String<N, U>
 where
     N: ArrayLength<u8> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -451,6 +457,7 @@ where
 impl<N, U> fmt::Display for String<N, U>
 where
     N: ArrayLength<u8> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -461,6 +468,7 @@ where
 impl<N, U> hash::Hash for String<N, U>
 where
     N: ArrayLength<u8> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     #[inline]
@@ -472,6 +480,7 @@ where
 impl<N, U> hash32::Hash for String<N, U>
 where
     N: ArrayLength<u8> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     #[inline]
@@ -483,6 +492,7 @@ where
 impl<N, U> fmt::Write for String<N, U>
 where
     N: ArrayLength<u8> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     fn write_str(&mut self, s: &str) -> Result<(), fmt::Error> {
@@ -497,6 +507,7 @@ where
 impl<N, U> ops::Deref for String<N, U>
 where
     N: ArrayLength<u8> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     type Target = str;
@@ -509,6 +520,7 @@ where
 impl<N, U> ops::DerefMut for String<N, U>
 where
     N: ArrayLength<u8> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     fn deref_mut(&mut self) -> &mut str {
@@ -519,6 +531,7 @@ where
 impl<N, U> AsRef<str> for String<N, U>
 where
     N: ArrayLength<u8> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     #[inline]
@@ -530,6 +543,7 @@ where
 impl<N, U> AsRef<[u8]> for String<N, U>
 where
     N: ArrayLength<u8> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     #[inline]
@@ -541,7 +555,9 @@ where
 impl<N1, N2, U1, U2> PartialEq<String<N2, U2>> for String<N1, U1>
 where
     N1: ArrayLength<u8> + IsLess<U1::Cap>,
+    <N1 as IsLess<U1::Cap>>::Output: NonZero,
     N2: ArrayLength<u8> + IsLess<U2::Cap>,
+    <N2 as IsLess<U2::Cap>>::Output: NonZero,
     U1: MaxCapacity,
     U2: MaxCapacity,
 {
@@ -559,6 +575,7 @@ macro_rules! impl_eq {
         impl<'a, 'b, N, U> PartialEq<$rhs> for $lhs
         where
             N: ArrayLength<u8> + IsLess<U::Cap>,
+            <N as IsLess<U::Cap>>::Output: NonZero,
             U: MaxCapacity,
         {
             #[inline]
@@ -574,6 +591,7 @@ macro_rules! impl_eq {
         impl<'a, 'b, N, U> PartialEq<$lhs> for $rhs
         where
             N: ArrayLength<u8> + IsLess<U::Cap>,
+            <N as IsLess<U::Cap>>::Output: NonZero,
             U: MaxCapacity,
         {
             #[inline]
@@ -594,6 +612,7 @@ impl_eq! { String<N, U>, &'a str }
 impl<N, U> Eq for String<N, U>
 where
     N: ArrayLength<u8> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
 }
@@ -603,6 +622,7 @@ macro_rules! impl_from_num {
         impl<N, U> From<$num> for String<N, U>
         where
             N: ArrayLength<u8> + IsGreaterOrEqual<$size, Output = True> + IsLess<U::Cap>,
+            <N as IsLess<U::Cap>>::Output: NonZero,
             U: MaxCapacity,
         {
             fn from(s: $num) -> Self {

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -2,7 +2,7 @@ use core::ops::{AddAssign, SubAssign};
 use core::{fmt, hash, iter::FromIterator, mem::MaybeUninit, ops, ptr, slice};
 
 use crate::consts::*;
-use generic_array::{ArrayLength, GenericArray};
+use generic_array::{typenum::IsLess, ArrayLength, GenericArray};
 use hash32;
 
 pub trait MaxCapacity:
@@ -53,7 +53,7 @@ impl_new!(usize);
 
 impl<T, N, U> crate::i::Vec<GenericArray<T, N>, U>
 where
-    N: ArrayLength<T>,
+    N: ArrayLength<T> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     // Same behaviour as new(), except this is defined genericly
@@ -213,12 +213,12 @@ where
 #[repr(transparent)]
 pub struct Vec<T, N, U>(#[doc(hidden)] pub crate::i::Vec<GenericArray<T, N>, U>)
 where
-    N: ArrayLength<T>,
+    N: ArrayLength<T> + IsLess<U::Cap>,
     U: MaxCapacity;
 
 impl<T, N, U> Clone for Vec<T, N, U>
 where
-    N: ArrayLength<T>,
+    N: ArrayLength<T> + IsLess<U::Cap>,
     T: Clone,
     U: MaxCapacity,
 {
@@ -229,7 +229,7 @@ where
 
 impl<T, N, U> Vec<T, N, U>
 where
-    N: ArrayLength<T>,
+    N: ArrayLength<T> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     /* Constructors */
@@ -569,7 +569,7 @@ where
 
 impl<T, N, U> Default for Vec<T, N, U>
 where
-    N: ArrayLength<T>,
+    N: ArrayLength<T> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     fn default() -> Self {
@@ -580,7 +580,7 @@ where
 impl<T, N, U> fmt::Debug for Vec<T, N, U>
 where
     T: fmt::Debug,
-    N: ArrayLength<T>,
+    N: ArrayLength<T> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -590,7 +590,7 @@ where
 
 impl<N, U> fmt::Write for Vec<u8, N, U>
 where
-    N: ArrayLength<u8>,
+    N: ArrayLength<u8> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     fn write_str(&mut self, s: &str) -> fmt::Result {
@@ -603,7 +603,7 @@ where
 
 impl<T, N, U> Drop for Vec<T, N, U>
 where
-    N: ArrayLength<T>,
+    N: ArrayLength<T> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     fn drop(&mut self) {
@@ -613,7 +613,7 @@ where
 
 impl<T, N, U> Extend<T> for Vec<T, N, U>
 where
-    N: ArrayLength<T>,
+    N: ArrayLength<T> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     fn extend<I>(&mut self, iter: I)
@@ -627,7 +627,7 @@ where
 impl<'a, T, N, U> Extend<&'a T> for Vec<T, N, U>
 where
     T: 'a + Copy,
-    N: ArrayLength<T>,
+    N: ArrayLength<T> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     fn extend<I>(&mut self, iter: I)
@@ -641,7 +641,7 @@ where
 impl<T, N, U> hash::Hash for Vec<T, N, U>
 where
     T: core::hash::Hash,
-    N: ArrayLength<T>,
+    N: ArrayLength<T> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
@@ -652,7 +652,7 @@ where
 impl<T, N, U> hash32::Hash for Vec<T, N, U>
 where
     T: hash32::Hash,
-    N: ArrayLength<T>,
+    N: ArrayLength<T> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     fn hash<H: hash32::Hasher>(&self, state: &mut H) {
@@ -662,7 +662,7 @@ where
 
 impl<'a, T, N, U> IntoIterator for &'a Vec<T, N, U>
 where
-    N: ArrayLength<T>,
+    N: ArrayLength<T> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     type Item = &'a T;
@@ -675,7 +675,7 @@ where
 
 impl<'a, T, N, U> IntoIterator for &'a mut Vec<T, N, U>
 where
-    N: ArrayLength<T>,
+    N: ArrayLength<T> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     type Item = &'a mut T;
@@ -688,7 +688,7 @@ where
 
 impl<T, N, U> FromIterator<T> for Vec<T, N, U>
 where
-    N: ArrayLength<T>,
+    N: ArrayLength<T> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     fn from_iter<I>(iter: I) -> Self
@@ -711,7 +711,7 @@ where
 ///
 pub struct IntoIter<T, N, U>
 where
-    N: ArrayLength<T>,
+    N: ArrayLength<T> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     vec: Vec<T, N, U>,
@@ -720,7 +720,7 @@ where
 
 impl<T, N, U> Iterator for IntoIter<T, N, U>
 where
-    N: ArrayLength<T>,
+    N: ArrayLength<T> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     type Item = T;
@@ -742,7 +742,7 @@ where
 impl<T, N, U> Clone for IntoIter<T, N, U>
 where
     T: Clone,
-    N: ArrayLength<T>,
+    N: ArrayLength<T> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     fn clone(&self) -> Self {
@@ -764,7 +764,7 @@ where
 
 impl<T, N, U> Drop for IntoIter<T, N, U>
 where
-    N: ArrayLength<T>,
+    N: ArrayLength<T> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     fn drop(&mut self) {
@@ -779,7 +779,7 @@ where
 
 impl<T, N, U> IntoIterator for Vec<T, N, U>
 where
-    N: ArrayLength<T>,
+    N: ArrayLength<T> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     type Item = T;
@@ -792,8 +792,8 @@ where
 
 impl<A, B, N1, N2, U> PartialEq<Vec<B, N2, U>> for Vec<A, N1, U>
 where
-    N1: ArrayLength<A>,
-    N2: ArrayLength<B>,
+    N1: ArrayLength<A> + IsLess<U::Cap>,
+    N2: ArrayLength<B> + IsLess<U::Cap>,
     A: PartialEq<B>,
     U: MaxCapacity,
 {
@@ -807,7 +807,7 @@ macro_rules! eq {
         impl<'a, 'b, A, B, N, U> PartialEq<$Rhs> for $Lhs
         where
             A: PartialEq<B>,
-            N: ArrayLength<A>,
+            N: ArrayLength<A> + IsLess<U::Cap>,
             U: MaxCapacity,
         {
             fn eq(&self, other: &$Rhs) -> bool {
@@ -837,7 +837,7 @@ array!(
 
 impl<T, N, U> Eq for Vec<T, N, U>
 where
-    N: ArrayLength<T>,
+    N: ArrayLength<T> + IsLess<U::Cap>,
     T: Eq,
     U: MaxCapacity,
 {
@@ -845,7 +845,7 @@ where
 
 impl<T, N, U> ops::Deref for Vec<T, N, U>
 where
-    N: ArrayLength<T>,
+    N: ArrayLength<T> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     type Target = [T];
@@ -857,7 +857,7 @@ where
 
 impl<T, N, U> ops::DerefMut for Vec<T, N, U>
 where
-    N: ArrayLength<T>,
+    N: ArrayLength<T> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     fn deref_mut(&mut self) -> &mut [T] {
@@ -867,7 +867,7 @@ where
 
 impl<T, N, U> AsRef<Vec<T, N, U>> for Vec<T, N, U>
 where
-    N: ArrayLength<T>,
+    N: ArrayLength<T> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     #[inline]
@@ -878,7 +878,7 @@ where
 
 impl<T, N, U> AsMut<Vec<T, N, U>> for Vec<T, N, U>
 where
-    N: ArrayLength<T>,
+    N: ArrayLength<T> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     #[inline]
@@ -889,7 +889,7 @@ where
 
 impl<T, N, U> AsRef<[T]> for Vec<T, N, U>
 where
-    N: ArrayLength<T>,
+    N: ArrayLength<T> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     #[inline]
@@ -900,7 +900,7 @@ where
 
 impl<T, N, U> AsMut<[T]> for Vec<T, N, U>
 where
-    N: ArrayLength<T>,
+    N: ArrayLength<T> + IsLess<U::Cap>,
     U: MaxCapacity,
 {
     #[inline]

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -211,7 +211,7 @@ where
 /// ```
 // repr(transparent) is needed for [`String::as_mut_vec`]
 #[repr(transparent)]
-pub struct Vec<T, N, U>(#[doc(hidden)] pub crate::i::Vec<GenericArray<T, N>, U>)
+pub struct Vec<T, N, U = usize>(#[doc(hidden)] pub crate::i::Vec<GenericArray<T, N>, U>)
 where
     N: ArrayLength<T> + IsLess<U::Cap>,
     U: MaxCapacity;

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -34,10 +34,10 @@ impl MaxCapacity for usize {
 }
 
 macro_rules! impl_new {
-    ($u:ident) => {
+    ($u:ident, $name:ident) => {
         impl<A> crate::i::Vec<A, $u> {
             /// `Vec` `const` constructor; wrap the returned value in [`Vec`](../struct.Vec.html)
-            pub const fn new() -> Self {
+            pub const fn $name() -> Self {
                 Self {
                     buffer: MaybeUninit::uninit(),
                     len: 0,
@@ -47,9 +47,10 @@ macro_rules! impl_new {
     };
 }
 
-impl_new!(u8);
-impl_new!(u16);
-impl_new!(usize);
+impl_new!(u8, u8);
+impl_new!(u16, u16);
+impl_new!(usize, usize);
+impl_new!(usize, new);
 
 impl<T, N, U> crate::i::Vec<GenericArray<T, N>, U>
 where

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -790,14 +790,15 @@ where
     }
 }
 
-impl<A, B, N1, N2, U> PartialEq<Vec<B, N2, U>> for Vec<A, N1, U>
+impl<A, B, N1, N2, U1, U2> PartialEq<Vec<B, N2, U2>> for Vec<A, N1, U1>
 where
-    N1: ArrayLength<A> + IsLess<U::Cap>,
-    N2: ArrayLength<B> + IsLess<U::Cap>,
+    N1: ArrayLength<A> + IsLess<U1::Cap>,
+    N2: ArrayLength<B> + IsLess<U2::Cap>,
     A: PartialEq<B>,
-    U: MaxCapacity,
+    U1: MaxCapacity,
+    U2: MaxCapacity,
 {
-    fn eq(&self, other: &Vec<B, N2, U>) -> bool {
+    fn eq(&self, other: &Vec<B, N2, U2>) -> bool {
         <[A]>::eq(self, &**other)
     }
 }

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -772,7 +772,7 @@ where
             // Drop all the elements that have not been moved out of vec
             ptr::drop_in_place(&mut self.vec[self.next..]);
             // Prevent dropping of other elements
-            self.vec.0.len = U::convert(1);
+            self.vec.0.len = U::convert(0);
         }
     }
 }
@@ -918,7 +918,7 @@ mod tests {
 
     #[test]
     fn static_new() {
-        static mut _V: Vec<i32, U4, usize> = Vec(crate::i::Vec::new());
+        static mut _V: Vec<i32, U4, usize> = Vec(crate::i::Vec::<_, usize>::new());
     }
 
     macro_rules! droppable {
@@ -949,7 +949,7 @@ mod tests {
         droppable!();
 
         {
-            let mut v: Vec<Droppable, U2> = Vec::new();
+            let mut v: Vec<Droppable, U2, u8> = Vec::new();
             v.push(Droppable::new()).ok().unwrap();
             v.push(Droppable::new()).ok().unwrap();
             v.pop().unwrap();
@@ -958,7 +958,7 @@ mod tests {
         assert_eq!(unsafe { COUNT }, 0);
 
         {
-            let mut v: Vec<Droppable, U2> = Vec::new();
+            let mut v: Vec<Droppable, U2, u8> = Vec::new();
             v.push(Droppable::new()).ok().unwrap();
             v.push(Droppable::new()).ok().unwrap();
         }
@@ -968,8 +968,8 @@ mod tests {
 
     #[test]
     fn eq() {
-        let mut xs: Vec<i32, U4> = Vec::new();
-        let mut ys: Vec<i32, U8> = Vec::new();
+        let mut xs: Vec<i32, U4, u8> = Vec::new();
+        let mut ys: Vec<i32, U8, u8> = Vec::new();
 
         assert_eq!(xs, ys);
 
@@ -981,7 +981,7 @@ mod tests {
 
     #[test]
     fn full() {
-        let mut v: Vec<i32, U4> = Vec::new();
+        let mut v: Vec<i32, U4, u8> = Vec::new();
 
         v.push(0).unwrap();
         v.push(1).unwrap();
@@ -993,7 +993,7 @@ mod tests {
 
     #[test]
     fn iter() {
-        let mut v: Vec<i32, U4> = Vec::new();
+        let mut v: Vec<i32, U4, u8> = Vec::new();
 
         v.push(0).unwrap();
         v.push(1).unwrap();
@@ -1011,7 +1011,7 @@ mod tests {
 
     #[test]
     fn iter_mut() {
-        let mut v: Vec<i32, U4> = Vec::new();
+        let mut v: Vec<i32, U4, u8> = Vec::new();
 
         v.push(0).unwrap();
         v.push(1).unwrap();
@@ -1030,7 +1030,7 @@ mod tests {
     #[test]
     fn collect_from_iter() {
         let slice = &[1, 2, 3];
-        let vec = slice.iter().cloned().collect::<Vec<_, U4>>();
+        let vec = slice.iter().cloned().collect::<Vec<_, U4, u8>>();
         assert_eq!(vec, slice);
     }
 
@@ -1038,12 +1038,12 @@ mod tests {
     #[should_panic]
     fn collect_from_iter_overfull() {
         let slice = &[1, 2, 3];
-        let _vec = slice.iter().cloned().collect::<Vec<_, U2>>();
+        let _vec = slice.iter().cloned().collect::<Vec<_, U2, u8>>();
     }
 
     #[test]
     fn iter_move() {
-        let mut v: Vec<i32, U4> = Vec::new();
+        let mut v: Vec<i32, U4, u8> = Vec::new();
         v.push(0).unwrap();
         v.push(1).unwrap();
         v.push(2).unwrap();
@@ -1063,9 +1063,10 @@ mod tests {
         droppable!();
 
         {
-            let mut vec: Vec<Droppable, U2> = Vec::new();
+            let mut vec: Vec<Droppable, U2, usize> = Vec::new();
             vec.push(Droppable::new()).ok().unwrap();
             vec.push(Droppable::new()).ok().unwrap();
+            dbg!(vec.len());
             let mut items = vec.into_iter();
             // Move all
             let _ = items.next();
@@ -1075,7 +1076,7 @@ mod tests {
         assert_eq!(unsafe { COUNT }, 0);
 
         {
-            let mut vec: Vec<Droppable, U2> = Vec::new();
+            let mut vec: Vec<Droppable, U2, u8> = Vec::new();
             vec.push(Droppable::new()).ok().unwrap();
             vec.push(Droppable::new()).ok().unwrap();
             let _items = vec.into_iter();
@@ -1085,7 +1086,7 @@ mod tests {
         assert_eq!(unsafe { COUNT }, 0);
 
         {
-            let mut vec: Vec<Droppable, U2> = Vec::new();
+            let mut vec: Vec<Droppable, U2, u8> = Vec::new();
             vec.push(Droppable::new()).ok().unwrap();
             vec.push(Droppable::new()).ok().unwrap();
             let mut items = vec.into_iter();
@@ -1097,7 +1098,7 @@ mod tests {
 
     #[test]
     fn push_and_pop() {
-        let mut v: Vec<i32, U4> = Vec::new();
+        let mut v: Vec<i32, U4, u8> = Vec::new();
         assert_eq!(v.len(), 0);
 
         assert_eq!(v.pop(), None);
@@ -1115,7 +1116,7 @@ mod tests {
 
     #[test]
     fn resize_size_limit() {
-        let mut v: Vec<u8, U4> = Vec::new();
+        let mut v: Vec<u8, U4, u8> = Vec::new();
 
         v.resize(0, 0).unwrap();
         v.resize(4, 0).unwrap();
@@ -1124,7 +1125,7 @@ mod tests {
 
     #[test]
     fn resize_length_cases() {
-        let mut v: Vec<u8, U4> = Vec::new();
+        let mut v: Vec<u8, U4, u8> = Vec::new();
 
         assert_eq!(v.len(), 0);
 
@@ -1151,7 +1152,7 @@ mod tests {
 
     #[test]
     fn resize_contents() {
-        let mut v: Vec<u8, U4> = Vec::new();
+        let mut v: Vec<u8, U4, u8> = Vec::new();
 
         // New entries take supplied value when growing
         v.resize(1, 17).unwrap();
@@ -1174,7 +1175,7 @@ mod tests {
 
     #[test]
     fn resize_default() {
-        let mut v: Vec<u8, U4> = Vec::new();
+        let mut v: Vec<u8, U4, u8> = Vec::new();
 
         // resize_default is implemented using resize, so just check the
         // correct value is being written.
@@ -1184,14 +1185,14 @@ mod tests {
 
     #[test]
     fn write() {
-        let mut v: Vec<u8, U4> = Vec::new();
+        let mut v: Vec<u8, U4, u8> = Vec::new();
         write!(v, "{:x}", 1234).unwrap();
         assert_eq!(&v[..], b"4d2");
     }
 
     #[test]
     fn extend_from_slice() {
-        let mut v: Vec<u8, U4> = Vec::new();
+        let mut v: Vec<u8, U4, u8> = Vec::new();
         assert_eq!(v.len(), 0);
         v.extend_from_slice(&[1, 2]).unwrap();
         assert_eq!(v.len(), 2);
@@ -1207,17 +1208,17 @@ mod tests {
     #[test]
     fn from_slice() {
         // Successful construction
-        let v: Vec<u8, U4> = Vec::from_slice(&[1, 2, 3]).unwrap();
+        let v: Vec<u8, U4, u8> = Vec::from_slice(&[1, 2, 3]).unwrap();
         assert_eq!(v.len(), 3);
         assert_eq!(v.as_slice(), &[1, 2, 3]);
 
         // Slice too large
-        assert!(Vec::<u8, U2>::from_slice(&[1, 2, 3]).is_err());
+        assert!(Vec::<u8, U2, u8>::from_slice(&[1, 2, 3]).is_err());
     }
 
     #[test]
     fn starts_with() {
-        let v: Vec<_, U8> = Vec::from_slice(b"ab").unwrap();
+        let v: Vec<_, U8, u8> = Vec::from_slice(b"ab").unwrap();
         assert!(v.starts_with(&[]));
         assert!(v.starts_with(b""));
         assert!(v.starts_with(b"a"));
@@ -1229,7 +1230,7 @@ mod tests {
 
     #[test]
     fn ends_with() {
-        let v: Vec<_, U8> = Vec::from_slice(b"ab").unwrap();
+        let v: Vec<_, U8, u8> = Vec::from_slice(b"ab").unwrap();
         assert!(v.ends_with(&[]));
         assert!(v.ends_with(b""));
         assert!(v.ends_with(b"b"));

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -2,7 +2,10 @@ use core::ops::{AddAssign, SubAssign};
 use core::{fmt, hash, iter::FromIterator, mem::MaybeUninit, ops, ptr, slice};
 
 use crate::consts::*;
-use generic_array::{typenum::IsLess, ArrayLength, GenericArray};
+use generic_array::{
+    typenum::{IsLess, NonZero},
+    ArrayLength, GenericArray,
+};
 use hash32;
 
 pub trait MaxCapacity:
@@ -55,6 +58,7 @@ impl_new!(usize, new);
 impl<T, N, U> crate::i::Vec<GenericArray<T, N>, U>
 where
     N: ArrayLength<T> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     // Same behaviour as new(), except this is defined genericly
@@ -215,11 +219,13 @@ where
 pub struct Vec<T, N, U = usize>(#[doc(hidden)] pub crate::i::Vec<GenericArray<T, N>, U>)
 where
     N: ArrayLength<T> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity;
 
 impl<T, N, U> Clone for Vec<T, N, U>
 where
     N: ArrayLength<T> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     T: Clone,
     U: MaxCapacity,
 {
@@ -231,6 +237,7 @@ where
 impl<T, N, U> Vec<T, N, U>
 where
     N: ArrayLength<T> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     /* Constructors */
@@ -571,6 +578,7 @@ where
 impl<T, N, U> Default for Vec<T, N, U>
 where
     N: ArrayLength<T> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     fn default() -> Self {
@@ -582,6 +590,7 @@ impl<T, N, U> fmt::Debug for Vec<T, N, U>
 where
     T: fmt::Debug,
     N: ArrayLength<T> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -592,6 +601,7 @@ where
 impl<N, U> fmt::Write for Vec<u8, N, U>
 where
     N: ArrayLength<u8> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     fn write_str(&mut self, s: &str) -> fmt::Result {
@@ -605,6 +615,7 @@ where
 impl<T, N, U> Drop for Vec<T, N, U>
 where
     N: ArrayLength<T> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     fn drop(&mut self) {
@@ -615,6 +626,7 @@ where
 impl<T, N, U> Extend<T> for Vec<T, N, U>
 where
     N: ArrayLength<T> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     fn extend<I>(&mut self, iter: I)
@@ -629,6 +641,7 @@ impl<'a, T, N, U> Extend<&'a T> for Vec<T, N, U>
 where
     T: 'a + Copy,
     N: ArrayLength<T> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     fn extend<I>(&mut self, iter: I)
@@ -643,6 +656,7 @@ impl<T, N, U> hash::Hash for Vec<T, N, U>
 where
     T: core::hash::Hash,
     N: ArrayLength<T> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
@@ -654,6 +668,7 @@ impl<T, N, U> hash32::Hash for Vec<T, N, U>
 where
     T: hash32::Hash,
     N: ArrayLength<T> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     fn hash<H: hash32::Hasher>(&self, state: &mut H) {
@@ -664,6 +679,7 @@ where
 impl<'a, T, N, U> IntoIterator for &'a Vec<T, N, U>
 where
     N: ArrayLength<T> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     type Item = &'a T;
@@ -677,6 +693,7 @@ where
 impl<'a, T, N, U> IntoIterator for &'a mut Vec<T, N, U>
 where
     N: ArrayLength<T> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     type Item = &'a mut T;
@@ -690,6 +707,7 @@ where
 impl<T, N, U> FromIterator<T> for Vec<T, N, U>
 where
     N: ArrayLength<T> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     fn from_iter<I>(iter: I) -> Self
@@ -713,6 +731,7 @@ where
 pub struct IntoIter<T, N, U>
 where
     N: ArrayLength<T> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     vec: Vec<T, N, U>,
@@ -722,6 +741,7 @@ where
 impl<T, N, U> Iterator for IntoIter<T, N, U>
 where
     N: ArrayLength<T> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     type Item = T;
@@ -744,6 +764,7 @@ impl<T, N, U> Clone for IntoIter<T, N, U>
 where
     T: Clone,
     N: ArrayLength<T> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     fn clone(&self) -> Self {
@@ -766,6 +787,7 @@ where
 impl<T, N, U> Drop for IntoIter<T, N, U>
 where
     N: ArrayLength<T> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     fn drop(&mut self) {
@@ -781,6 +803,7 @@ where
 impl<T, N, U> IntoIterator for Vec<T, N, U>
 where
     N: ArrayLength<T> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     type Item = T;
@@ -794,7 +817,9 @@ where
 impl<A, B, N1, N2, U1, U2> PartialEq<Vec<B, N2, U2>> for Vec<A, N1, U1>
 where
     N1: ArrayLength<A> + IsLess<U1::Cap>,
+    <N1 as IsLess<U1::Cap>>::Output: NonZero,
     N2: ArrayLength<B> + IsLess<U2::Cap>,
+    <N2 as IsLess<U2::Cap>>::Output: NonZero,
     A: PartialEq<B>,
     U1: MaxCapacity,
     U2: MaxCapacity,
@@ -810,6 +835,7 @@ macro_rules! eq {
         where
             A: PartialEq<B>,
             N: ArrayLength<A> + IsLess<U::Cap>,
+            <N as IsLess<U::Cap>>::Output: NonZero,
             U: MaxCapacity,
         {
             fn eq(&self, other: &$Rhs) -> bool {
@@ -840,6 +866,7 @@ array!(
 impl<T, N, U> Eq for Vec<T, N, U>
 where
     N: ArrayLength<T> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     T: Eq,
     U: MaxCapacity,
 {
@@ -848,6 +875,7 @@ where
 impl<T, N, U> ops::Deref for Vec<T, N, U>
 where
     N: ArrayLength<T> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     type Target = [T];
@@ -860,6 +888,7 @@ where
 impl<T, N, U> ops::DerefMut for Vec<T, N, U>
 where
     N: ArrayLength<T> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     fn deref_mut(&mut self) -> &mut [T] {
@@ -870,6 +899,7 @@ where
 impl<T, N, U> AsRef<Vec<T, N, U>> for Vec<T, N, U>
 where
     N: ArrayLength<T> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     #[inline]
@@ -881,6 +911,7 @@ where
 impl<T, N, U> AsMut<Vec<T, N, U>> for Vec<T, N, U>
 where
     N: ArrayLength<T> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     #[inline]
@@ -892,6 +923,7 @@ where
 impl<T, N, U> AsRef<[T]> for Vec<T, N, U>
 where
     N: ArrayLength<T> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     #[inline]
@@ -903,6 +935,7 @@ where
 impl<T, N, U> AsMut<[T]> for Vec<T, N, U>
 where
     N: ArrayLength<T> + IsLess<U::Cap>,
+    <N as IsLess<U::Cap>>::Output: NonZero,
     U: MaxCapacity,
 {
     #[inline]

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -30,7 +30,8 @@ impl MaxCapacity for u16 {
 }
 
 impl MaxCapacity for usize {
-    type Cap = generic_array::typenum::op!(U10000000000000000000 * U2);
+    // Around half of u64::max, which is more than any computer can hold
+    type Cap = U10000000000000000000;
     fn convert(x: u8) -> Self {
         x as Self
     }

--- a/tests/cpass.rs
+++ b/tests/cpass.rs
@@ -1,13 +1,15 @@
-//! Collections of `Send`-able things are `Send`
+use std::marker::PhantomData;
 
+use generic_array::typenum::op;
 use heapless::{
-    consts,
+    consts::*,
     spsc::{Consumer, Producer, Queue},
     HistoryBuffer, Vec,
 };
 
 #[test]
 fn send() {
+    // Collections of `Send`-able things are `Send`
     struct IsSend;
 
     unsafe impl Send for IsSend {}
@@ -18,9 +20,20 @@ fn send() {
     {
     }
 
-    is_send::<Consumer<IsSend, consts::U4>>();
-    is_send::<Producer<IsSend, consts::U4>>();
-    is_send::<Queue<IsSend, consts::U4>>();
-    is_send::<Vec<IsSend, consts::U4>>();
-    is_send::<HistoryBuffer<IsSend, consts::U4>>();
+    is_send::<Consumer<IsSend, U4>>();
+    is_send::<Producer<IsSend, U4>>();
+    is_send::<Queue<IsSend, U4>>();
+    is_send::<Vec<IsSend, U4, u8>>();
+    is_send::<HistoryBuffer<IsSend, U4>>();
+}
+
+#[test]
+fn vec() {
+    // Vecs that are sized within the bounds of their length types
+    let _s: PhantomData<Vec<u8, U200, u8>>;
+    let _s: PhantomData<Vec<u8, U255, u8>>;
+    let _s: PhantomData<Vec<u8, U256, u16>>;
+    let _s: PhantomData<Vec<u8, op!(U65536 - U1), u16>>;
+    let _s: PhantomData<Vec<u8, U65536, usize>>;
+    let _s: PhantomData<Vec<u8, U100000, usize>>;
 }


### PR DESCRIPTION
I added a new type parameter for length to `Vec` and containers that use `Vec`. This allows `u8` and `u16` to be used for the length of `Vec` to save space, similar to the head and tail pointers of `Queue`. Additionally, the capacity of `Vec` is statically checked to be within the range of the length type using `typenum` trait bounds (for example, a `Vec` with length type of `u8` and capacity 256 is not allowed). Addresses #139.