### PR TITLE
Allow u8 and u16 to be used as the length of Vec-based containers (const generics edition)

### DIFF
--- a/cfail/ui/not-send.rs
+++ b/cfail/ui/not-send.rs
@@ -16,5 +16,5 @@ fn main() {
     is_send::<Consumer<NotSend, _, 4>>();
     is_send::<Producer<NotSend, _, 4>>();
     is_send::<Queue<NotSend, _, 4>>();
-    is_send::<heapless::Vec<NotSend, usize, 4>>();
+    is_send::<heapless::VecBase<NotSend, usize, 4>>();
 }

--- a/cfail/ui/not-send.rs
+++ b/cfail/ui/not-send.rs
@@ -2,9 +2,7 @@
 
 use core::marker::PhantomData;
 
-use heapless::{
-    spsc::{Consumer, Producer, Queue},
-};
+use heapless::spsc::{Consumer, Producer, Queue};
 
 type NotSend = PhantomData<*const ()>;
 
@@ -18,5 +16,5 @@ fn main() {
     is_send::<Consumer<NotSend, _, 4>>();
     is_send::<Producer<NotSend, _, 4>>();
     is_send::<Queue<NotSend, _, 4>>();
-    is_send::<heapless::Vec<NotSend, 4>>();
+    is_send::<heapless::Vec<NotSend, usize, 4>>();
 }

--- a/cfail/ui/not-send.stderr
+++ b/cfail/ui/not-send.stderr
@@ -1,13 +1,13 @@
 error[E0277]: `*const ()` cannot be sent between threads safely
-  --> $DIR/not-send.rs:18:5
+  --> $DIR/not-send.rs:16:5
    |
-11 | fn is_send<T>()
+9  | fn is_send<T>()
    |    ------- required by a bound in this
-12 | where
-13 |     T: Send,
+10 | where
+11 |     T: Send,
    |        ---- required by this bound in `is_send`
 ...
-18 |     is_send::<Consumer<NotSend, _, 4>>();
+16 |     is_send::<Consumer<NotSend, _, 4>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `*const ()` cannot be sent between threads safely
    |
    = help: within `PhantomData<*const ()>`, the trait `Send` is not implemented for `*const ()`
@@ -15,15 +15,15 @@ error[E0277]: `*const ()` cannot be sent between threads safely
    = note: required because of the requirements on the impl of `Send` for `Consumer<'_, PhantomData<*const ()>, _, 4_usize>`
 
 error[E0277]: `*const ()` cannot be sent between threads safely
-  --> $DIR/not-send.rs:19:5
+  --> $DIR/not-send.rs:17:5
    |
-11 | fn is_send<T>()
+9  | fn is_send<T>()
    |    ------- required by a bound in this
-12 | where
-13 |     T: Send,
+10 | where
+11 |     T: Send,
    |        ---- required by this bound in `is_send`
 ...
-19 |     is_send::<Producer<NotSend, _, 4>>();
+17 |     is_send::<Producer<NotSend, _, 4>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `*const ()` cannot be sent between threads safely
    |
    = help: within `PhantomData<*const ()>`, the trait `Send` is not implemented for `*const ()`
@@ -31,15 +31,15 @@ error[E0277]: `*const ()` cannot be sent between threads safely
    = note: required because of the requirements on the impl of `Send` for `Producer<'_, PhantomData<*const ()>, _, 4_usize>`
 
 error[E0277]: `*const ()` cannot be sent between threads safely
-  --> $DIR/not-send.rs:20:5
+  --> $DIR/not-send.rs:18:5
    |
-11 | fn is_send<T>()
+9  | fn is_send<T>()
    |    ------- required by a bound in this
-12 | where
-13 |     T: Send,
+10 | where
+11 |     T: Send,
    |        ---- required by this bound in `is_send`
 ...
-20 |     is_send::<Queue<NotSend, _, 4>>();
+18 |     is_send::<Queue<NotSend, _, 4>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `*const ()` cannot be sent between threads safely
    |
    = help: within `Queue<PhantomData<*const ()>, _, 4_usize>`, the trait `Send` is not implemented for `*const ()`
@@ -50,20 +50,20 @@ error[E0277]: `*const ()` cannot be sent between threads safely
    = note: required because it appears within the type `Queue<PhantomData<*const ()>, _, 4_usize>`
 
 error[E0277]: `*const ()` cannot be sent between threads safely
-  --> $DIR/not-send.rs:21:5
+  --> $DIR/not-send.rs:19:5
    |
-11 | fn is_send<T>()
+9  | fn is_send<T>()
    |    ------- required by a bound in this
-12 | where
-13 |     T: Send,
+10 | where
+11 |     T: Send,
    |        ---- required by this bound in `is_send`
 ...
-21 |     is_send::<heapless::Vec<NotSend, 4>>();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `*const ()` cannot be sent between threads safely
+19 |     is_send::<heapless::Vec<NotSend, usize, 4>>();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `*const ()` cannot be sent between threads safely
    |
-   = help: within `heapless::Vec<PhantomData<*const ()>, 4_usize>`, the trait `Send` is not implemented for `*const ()`
+   = help: within `heapless::Vec<PhantomData<*const ()>, usize, 4_usize>`, the trait `Send` is not implemented for `*const ()`
    = note: required because it appears within the type `PhantomData<*const ()>`
    = note: required because it appears within the type `[PhantomData<*const ()>; 4]`
    = note: required because it appears within the type `ManuallyDrop<[PhantomData<*const ()>; 4]>`
    = note: required because it appears within the type `MaybeUninit<[PhantomData<*const ()>; 4]>`
-   = note: required because it appears within the type `heapless::Vec<PhantomData<*const ()>, 4_usize>`
+   = note: required because it appears within the type `heapless::Vec<PhantomData<*const ()>, usize, 4_usize>`

--- a/cfail/ui/not-send.stderr
+++ b/cfail/ui/not-send.stderr
@@ -58,12 +58,12 @@ error[E0277]: `*const ()` cannot be sent between threads safely
 11 |     T: Send,
    |        ---- required by this bound in `is_send`
 ...
-19 |     is_send::<heapless::Vec<NotSend, usize, 4>>();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `*const ()` cannot be sent between threads safely
+19 |     is_send::<heapless::VecBase<NotSend, usize, 4>>();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `*const ()` cannot be sent between threads safely
    |
-   = help: within `heapless::Vec<PhantomData<*const ()>, usize, 4_usize>`, the trait `Send` is not implemented for `*const ()`
+   = help: within `VecBase<PhantomData<*const ()>, usize, 4_usize>`, the trait `Send` is not implemented for `*const ()`
    = note: required because it appears within the type `PhantomData<*const ()>`
    = note: required because it appears within the type `[PhantomData<*const ()>; 4]`
    = note: required because it appears within the type `ManuallyDrop<[PhantomData<*const ()>; 4]>`
    = note: required because it appears within the type `MaybeUninit<[PhantomData<*const ()>; 4]>`
-   = note: required because it appears within the type `heapless::Vec<PhantomData<*const ()>, usize, 4_usize>`
+   = note: required because it appears within the type `VecBase<PhantomData<*const ()>, usize, 4_usize>`

--- a/src/binary_heap.rs
+++ b/src/binary_heap.rs
@@ -17,7 +17,7 @@ use core::{
 };
 
 use crate::sealed::{binary_heap::Kind, spsc::Uxx};
-use crate::vec::Vec;
+use crate::vec::VecBase;
 
 /// Min-heap
 pub enum Min {}
@@ -72,20 +72,22 @@ pub enum Max {}
 /// assert!(heap.is_empty())
 /// ```
 
-pub struct BinaryHeap<T, K, U: Uxx, const N: usize> {
+pub struct BinaryHeapBase<T, K, U: Uxx, const N: usize> {
     pub(crate) _kind: PhantomData<K>,
-    pub(crate) data: Vec<T, U, N>,
+    pub(crate) data: VecBase<T, U, N>,
 }
+
+pub type BinaryHeap<T, K, const N: usize> = BinaryHeapBase<T, K, usize, N>;
 
 macro_rules! impl_new {
     ($Uxx:ident, $name:ident) => {
-        impl<T, K, const N: usize> BinaryHeap<T, K, $Uxx, N> {
+        impl<T, K, const N: usize> BinaryHeapBase<T, K, $Uxx, N> {
             /* Constructors */
             /// Creates an empty BinaryHeap as a $K-heap.
             pub const fn $name() -> Self {
                 Self {
                     _kind: PhantomData,
-                    data: Vec::$name(),
+                    data: VecBase::$name(),
                 }
             }
         }
@@ -96,7 +98,7 @@ impl_new!(u8, u8);
 impl_new!(u16, u16);
 impl_new!(usize, usize);
 
-impl<T, K, const N: usize> BinaryHeap<T, K, usize, N> {
+impl<T, K, const N: usize> BinaryHeap<T, K, N> {
     /* Constructors */
     /// Creates an empty BinaryHeap as a $K-heap.
     ///
@@ -113,12 +115,12 @@ impl<T, K, const N: usize> BinaryHeap<T, K, usize, N> {
     pub const fn new() -> Self {
         Self {
             _kind: PhantomData,
-            data: Vec::new(),
+            data: VecBase::new(),
         }
     }
 }
 
-impl<T, K, U: Uxx, const N: usize> BinaryHeap<T, K, U, N>
+impl<T, K, U: Uxx, const N: usize> BinaryHeapBase<T, K, U, N>
 where
     T: Ord,
     K: Kind,
@@ -441,7 +443,7 @@ where
     T: Ord,
     K: Kind,
 {
-    heap: &'a mut BinaryHeap<T, K, U, N>,
+    heap: &'a mut BinaryHeapBase<T, K, U, N>,
     sift: bool,
 }
 
@@ -506,20 +508,20 @@ impl<'a, T> Drop for Hole<'a, T> {
     }
 }
 
-impl<T, K, U: Uxx, const N: usize> Default for BinaryHeap<T, K, U, N>
+impl<T, K, U: Uxx, const N: usize> Default for BinaryHeapBase<T, K, U, N>
 where
     T: Ord,
     K: Kind,
 {
     fn default() -> Self {
-        BinaryHeap {
+        BinaryHeapBase {
             _kind: PhantomData,
-            data: Vec::default(),
+            data: VecBase::default(),
         }
     }
 }
 
-impl<T, K, U: Uxx, const N: usize> Clone for BinaryHeap<T, K, U, N>
+impl<T, K, U: Uxx, const N: usize> Clone for BinaryHeapBase<T, K, U, N>
 where
     K: Kind,
     T: Ord + Clone,
@@ -532,13 +534,13 @@ where
     }
 }
 
-impl<T, K, U: Uxx, const N: usize> Drop for BinaryHeap<T, K, U, N> {
+impl<T, K, U: Uxx, const N: usize> Drop for BinaryHeapBase<T, K, U, N> {
     fn drop(&mut self) {
         unsafe { ptr::drop_in_place(self.data.as_mut_slice()) }
     }
 }
 
-impl<T, K, U: Uxx, const N: usize> fmt::Debug for BinaryHeap<T, K, U, N>
+impl<T, K, U: Uxx, const N: usize> fmt::Debug for BinaryHeapBase<T, K, U, N>
 where
     K: Kind,
     T: Ord + fmt::Debug,
@@ -548,7 +550,7 @@ where
     }
 }
 
-impl<'a, T, K, U: Uxx, const N: usize> IntoIterator for &'a BinaryHeap<T, K, U, N>
+impl<'a, T, K, U: Uxx, const N: usize> IntoIterator for &'a BinaryHeapBase<T, K, U, N>
 where
     K: Kind,
     T: Ord,

--- a/src/binary_heap.rs
+++ b/src/binary_heap.rs
@@ -432,13 +432,13 @@ impl<'a, T> Hole<'a, T> {
 }
 
 /// Structure wrapping a mutable reference to the greatest item on a
-/// `BinaryHeap`.
+/// `BinaryHeapBase`.
 ///
-/// This `struct` is created by the [`peek_mut`] method on [`BinaryHeap`]. See
+/// This `struct` is created by the [`peek_mut`] method on [`BinaryHeapBase`]. See
 /// its documentation for more.
 ///
-/// [`peek_mut`]: struct.BinaryHeap.html#method.peek_mut
-/// [`BinaryHeap`]: struct.BinaryHeap.html
+/// [`peek_mut`]: struct.BinaryHeapBase.html#method.peek_mut
+/// [`BinaryHeap`]: struct.BinaryHeapBase.html
 pub struct PeekMut<'a, T, K, U: Uxx, const N: usize>
 where
     T: Ord,

--- a/src/binary_heap.rs
+++ b/src/binary_heap.rs
@@ -32,6 +32,13 @@ pub enum Max {}
 /// It is a logic error for an item to be modified in such a way that the item's ordering relative
 /// to any other item, as determined by the `Ord` trait, changes while it is in the heap. This is
 /// normally only possible through `Cell`, `RefCell`, global state, I/O, or unsafe code.
+
+pub struct BinaryHeapBase<T, K, U: Uxx, const N: usize> {
+    pub(crate) _kind: PhantomData<K>,
+    pub(crate) data: VecBase<T, U, N>,
+}
+
+/// A `BinaryHeapBase` with a length type of `usize`.
 ///
 /// ```
 /// use heapless::binary_heap::{BinaryHeap, Max};
@@ -71,12 +78,6 @@ pub enum Max {}
 /// // The heap should now be empty.
 /// assert!(heap.is_empty())
 /// ```
-
-pub struct BinaryHeapBase<T, K, U: Uxx, const N: usize> {
-    pub(crate) _kind: PhantomData<K>,
-    pub(crate) data: VecBase<T, U, N>,
-}
-
 pub type BinaryHeap<T, K, const N: usize> = BinaryHeapBase<T, K, usize, N>;
 
 macro_rules! impl_new {

--- a/src/binary_heap.rs
+++ b/src/binary_heap.rs
@@ -16,7 +16,7 @@ use core::{
     ptr, slice,
 };
 
-use crate::sealed::binary_heap::Kind;
+use crate::sealed::{binary_heap::Kind, spsc::Uxx};
 use crate::vec::Vec;
 
 /// Min-heap
@@ -72,12 +72,12 @@ pub enum Max {}
 /// assert!(heap.is_empty())
 /// ```
 
-pub struct BinaryHeap<T, K, const N: usize> {
+pub struct BinaryHeap<T, K, U: Uxx, const N: usize> {
     pub(crate) _kind: PhantomData<K>,
-    pub(crate) data: Vec<T, N>,
+    pub(crate) data: Vec<T, U, N>,
 }
 
-impl<T, K, const N: usize> BinaryHeap<T, K, N> {
+impl<T, K, U: Uxx, const N: usize> BinaryHeap<T, K, U, N> {
     /* Constructors */
     /// Creates an empty BinaryHeap as a $K-heap.
     ///
@@ -99,7 +99,7 @@ impl<T, K, const N: usize> BinaryHeap<T, K, N> {
     }
 }
 
-impl<T, K, const N: usize> BinaryHeap<T, K, N>
+impl<T, K, U: Uxx, const N: usize> BinaryHeap<T, K, U, N>
 where
     T: Ord,
     K: Kind,
@@ -236,7 +236,7 @@ where
     ///
     /// assert_eq!(heap.peek(), Some(&2));
     /// ```
-    pub fn peek_mut(&mut self) -> Option<PeekMut<'_, T, K, N>> {
+    pub fn peek_mut(&mut self) -> Option<PeekMut<'_, T, K, U, N>> {
         if self.is_empty() {
             None
         } else {
@@ -417,16 +417,16 @@ impl<'a, T> Hole<'a, T> {
 ///
 /// [`peek_mut`]: struct.BinaryHeap.html#method.peek_mut
 /// [`BinaryHeap`]: struct.BinaryHeap.html
-pub struct PeekMut<'a, T, K, const N: usize>
+pub struct PeekMut<'a, T, K, U: Uxx, const N: usize>
 where
     T: Ord,
     K: Kind,
 {
-    heap: &'a mut BinaryHeap<T, K, N>,
+    heap: &'a mut BinaryHeap<T, K, U, N>,
     sift: bool,
 }
 
-impl<T, K, const N: usize> Drop for PeekMut<'_, T, K, N>
+impl<T, K, U: Uxx, const N: usize> Drop for PeekMut<'_, T, K, U, N>
 where
     T: Ord,
     K: Kind,
@@ -438,7 +438,7 @@ where
     }
 }
 
-impl<T, K, const N: usize> Deref for PeekMut<'_, T, K, N>
+impl<T, K, U: Uxx, const N: usize> Deref for PeekMut<'_, T, K, U, N>
 where
     T: Ord,
     K: Kind,
@@ -451,7 +451,7 @@ where
     }
 }
 
-impl<T, K, const N: usize> DerefMut for PeekMut<'_, T, K, N>
+impl<T, K, U: Uxx, const N: usize> DerefMut for PeekMut<'_, T, K, U, N>
 where
     T: Ord,
     K: Kind,
@@ -463,13 +463,13 @@ where
     }
 }
 
-impl<'a, T, K, const N: usize> PeekMut<'a, T, K, N>
+impl<'a, T, K, U: Uxx, const N: usize> PeekMut<'a, T, K, U, N>
 where
     T: Ord,
     K: Kind,
 {
     /// Removes the peeked value from the heap and returns it.
-    pub fn pop(mut this: PeekMut<'a, T, K, N>) -> T {
+    pub fn pop(mut this: PeekMut<'a, T, K, U, N>) -> T {
         let value = this.heap.pop().unwrap();
         this.sift = false;
         value
@@ -487,7 +487,7 @@ impl<'a, T> Drop for Hole<'a, T> {
     }
 }
 
-impl<T, K, const N: usize> Default for BinaryHeap<T, K, N>
+impl<T, K, U: Uxx, const N: usize> Default for BinaryHeap<T, K, U, N>
 where
     T: Ord,
     K: Kind,
@@ -497,7 +497,7 @@ where
     }
 }
 
-impl<T, K, const N: usize> Clone for BinaryHeap<T, K, N>
+impl<T, K, U: Uxx, const N: usize> Clone for BinaryHeap<T, K, U, N>
 where
     K: Kind,
     T: Ord + Clone,
@@ -510,13 +510,13 @@ where
     }
 }
 
-impl<T, K, const N: usize> Drop for BinaryHeap<T, K, N> {
+impl<T, K, U: Uxx, const N: usize> Drop for BinaryHeap<T, K, U, N> {
     fn drop(&mut self) {
         unsafe { ptr::drop_in_place(self.data.as_mut_slice()) }
     }
 }
 
-impl<T, K, const N: usize> fmt::Debug for BinaryHeap<T, K, N>
+impl<T, K, U: Uxx, const N: usize> fmt::Debug for BinaryHeap<T, K, U, N>
 where
     K: Kind,
     T: Ord + fmt::Debug,
@@ -526,7 +526,7 @@ where
     }
 }
 
-impl<'a, T, K, const N: usize> IntoIterator for &'a BinaryHeap<T, K, N>
+impl<'a, T, K, U: Uxx, const N: usize> IntoIterator for &'a BinaryHeap<T, K, U, N>
 where
     K: Kind,
     T: Ord,

--- a/src/binary_heap.rs
+++ b/src/binary_heap.rs
@@ -77,27 +77,36 @@ pub struct BinaryHeap<T, K, U: Uxx, const N: usize> {
     pub(crate) data: Vec<T, U, N>,
 }
 
-impl<T, K, U: Uxx, const N: usize> BinaryHeap<T, K, U, N> {
-    /* Constructors */
-    /// Creates an empty BinaryHeap as a $K-heap.
-    ///
-    /// ```
-    /// use heapless::binary_heap::{BinaryHeap, Max};
-    ///
-    /// // allocate the binary heap on the stack
-    /// let mut heap: BinaryHeap<_, Max, 8> = BinaryHeap::new();
-    /// heap.push(4).unwrap();
-    ///
-    /// // allocate the binary heap in a static variable
-    /// static mut HEAP: BinaryHeap<i32, Max, 8> = BinaryHeap::new();
-    /// ```
-    pub const fn new() -> Self {
-        Self {
-            _kind: PhantomData,
-            data: Vec::new(),
+macro_rules! impl_new {
+    ($Uxx:ident, $name:ident) => {
+        impl<T, K, const N: usize> BinaryHeap<T, K, $Uxx, N> {
+            /* Constructors */
+            /// Creates an empty BinaryHeap as a $K-heap.
+            ///
+            /// ```
+            /// use heapless::binary_heap::{BinaryHeap, Max};
+            ///
+            /// // allocate the binary heap on the stack
+            /// let mut heap: BinaryHeap<_, Max, $Uxx, 8> = BinaryHeap::$name();
+            /// heap.push(4).unwrap();
+            ///
+            /// // allocate the binary heap in a static variable
+            /// static mut HEAP: BinaryHeap<i32, Max, $Uxx, 8> = BinaryHeap::$name();
+            /// ```
+            pub const fn $name() -> Self {
+                Self {
+                    _kind: PhantomData,
+                    data: Vec::$name(),
+                }
+            }
         }
-    }
+    };
 }
+
+impl_new!(u8, u8);
+impl_new!(u16, u16);
+impl_new!(usize, usize);
+impl_new!(usize, new);
 
 impl<T, K, U: Uxx, const N: usize> BinaryHeap<T, K, U, N>
 where
@@ -493,7 +502,10 @@ where
     K: Kind,
 {
     fn default() -> Self {
-        Self::new()
+        BinaryHeap {
+            _kind: PhantomData,
+            data: Vec::default(),
+        }
     }
 }
 

--- a/src/binary_heap.rs
+++ b/src/binary_heap.rs
@@ -36,7 +36,7 @@ pub enum Max {}
 /// ```
 /// use heapless::binary_heap::{BinaryHeap, Max};
 ///
-/// let mut heap: BinaryHeap<_, Max, usize, 8> = BinaryHeap::new();
+/// let mut heap: BinaryHeap<_, Max, 8> = BinaryHeap::new();
 ///
 /// // We can use peek to look at the next item in the heap. In this case,
 /// // there's no items in there yet so we get None.
@@ -134,7 +134,7 @@ where
     /// ```
     /// use heapless::binary_heap::{BinaryHeap, Max};
     ///
-    /// let mut heap: BinaryHeap<_, Max, usize, 8> = BinaryHeap::new();
+    /// let mut heap: BinaryHeap<_, Max, 8> = BinaryHeap::new();
     /// heap.push(1).unwrap();
     /// heap.push(3).unwrap();
     ///
@@ -153,7 +153,7 @@ where
     /// ```
     /// use heapless::binary_heap::{BinaryHeap, Max};
     ///
-    /// let mut heap: BinaryHeap<_, Max, usize, 8> = BinaryHeap::new();
+    /// let mut heap: BinaryHeap<_, Max, 8> = BinaryHeap::new();
     /// heap.push(1).unwrap();
     /// heap.push(3).unwrap();
     ///
@@ -168,7 +168,7 @@ where
     /// ```
     /// use heapless::binary_heap::{BinaryHeap, Max};
     ///
-    /// let mut heap: BinaryHeap<_, Max, usize, 8> = BinaryHeap::new();
+    /// let mut heap: BinaryHeap<_, Max, 8> = BinaryHeap::new();
     ///
     /// assert!(heap.is_empty());
     ///
@@ -187,7 +187,7 @@ where
     /// ```
     /// use heapless::binary_heap::{BinaryHeap, Max};
     ///
-    /// let mut heap: BinaryHeap<_, Max, usize, 8> = BinaryHeap::new();
+    /// let mut heap: BinaryHeap<_, Max, 8> = BinaryHeap::new();
     /// heap.push(1).unwrap();
     /// heap.push(2).unwrap();
     /// heap.push(3).unwrap();
@@ -217,7 +217,7 @@ where
     /// ```
     /// use heapless::binary_heap::{BinaryHeap, Max};
     ///
-    /// let mut heap: BinaryHeap<_, Max, usize, 8> = BinaryHeap::new();
+    /// let mut heap: BinaryHeap<_, Max, 8> = BinaryHeap::new();
     /// assert_eq!(heap.peek(), None);
     ///
     /// heap.push(1).unwrap();
@@ -242,7 +242,7 @@ where
     /// ```
     /// use heapless::binary_heap::{BinaryHeap, Max};
     ///
-    /// let mut heap: BinaryHeap<_, Max, usize, 8> = BinaryHeap::new();
+    /// let mut heap: BinaryHeap<_, Max, 8> = BinaryHeap::new();
     /// assert!(heap.peek_mut().is_none());
     ///
     /// heap.push(1);
@@ -272,7 +272,7 @@ where
     /// ```
     /// use heapless::binary_heap::{BinaryHeap, Max};
     ///
-    /// let mut heap: BinaryHeap<_, Max, usize, 8> = BinaryHeap::new();
+    /// let mut heap: BinaryHeap<_, Max, 8> = BinaryHeap::new();
     /// heap.push(1).unwrap();
     /// heap.push(3).unwrap();
     ///
@@ -305,7 +305,7 @@ where
     /// ```
     /// use heapless::binary_heap::{BinaryHeap, Max};
     ///
-    /// let mut heap: BinaryHeap<_, Max, usize, 8> = BinaryHeap::new();
+    /// let mut heap: BinaryHeap<_, Max, 8> = BinaryHeap::new();
     /// heap.push(3).unwrap();
     /// heap.push(5).unwrap();
     /// heap.push(1).unwrap();
@@ -569,12 +569,12 @@ mod tests {
 
     #[test]
     fn static_new() {
-        static mut _B: BinaryHeap<i32, Min, usize, 16> = BinaryHeap::new();
+        static mut _B: BinaryHeap<i32, Min, 16> = BinaryHeap::new();
     }
 
     #[test]
     fn min() {
-        let mut heap = BinaryHeap::<_, Min, usize, 16>::new();
+        let mut heap = BinaryHeap::<_, Min, 16>::new();
         heap.push(1).unwrap();
         heap.push(2).unwrap();
         heap.push(3).unwrap();
@@ -626,7 +626,7 @@ mod tests {
 
     #[test]
     fn max() {
-        let mut heap = BinaryHeap::<_, Max, usize, 16>::new();
+        let mut heap = BinaryHeap::<_, Max, 16>::new();
         heap.push(1).unwrap();
         heap.push(2).unwrap();
         heap.push(3).unwrap();

--- a/src/binary_heap.rs
+++ b/src/binary_heap.rs
@@ -82,17 +82,6 @@ macro_rules! impl_new {
         impl<T, K, const N: usize> BinaryHeap<T, K, $Uxx, N> {
             /* Constructors */
             /// Creates an empty BinaryHeap as a $K-heap.
-            ///
-            /// ```
-            /// use heapless::binary_heap::{BinaryHeap, Max};
-            ///
-            /// // allocate the binary heap on the stack
-            /// let mut heap: BinaryHeap<_, Max, $Uxx, 8> = BinaryHeap::$name();
-            /// heap.push(4).unwrap();
-            ///
-            /// // allocate the binary heap in a static variable
-            /// static mut HEAP: BinaryHeap<i32, Max, $Uxx, 8> = BinaryHeap::$name();
-            /// ```
             pub const fn $name() -> Self {
                 Self {
                     _kind: PhantomData,
@@ -106,7 +95,28 @@ macro_rules! impl_new {
 impl_new!(u8, u8);
 impl_new!(u16, u16);
 impl_new!(usize, usize);
-impl_new!(usize, new);
+
+impl<T, K, const N: usize> BinaryHeap<T, K, usize, N> {
+    /* Constructors */
+    /// Creates an empty BinaryHeap as a $K-heap.
+    ///
+    /// ```
+    /// use heapless::binary_heap::{BinaryHeap, Max};
+    ///
+    /// // allocate the binary heap on the stack
+    /// let mut heap: BinaryHeap<_, Max, _, 8> = BinaryHeap::new();
+    /// heap.push(4).unwrap();
+    ///
+    /// // allocate the binary heap in a static variable
+    /// static mut HEAP: BinaryHeap<i32, Max, usize, 8> = BinaryHeap::new();
+    /// ```
+    pub const fn new() -> Self {
+        Self {
+            _kind: PhantomData,
+            data: Vec::new(),
+        }
+    }
+}
 
 impl<T, K, U: Uxx, const N: usize> BinaryHeap<T, K, U, N>
 where

--- a/src/binary_heap.rs
+++ b/src/binary_heap.rs
@@ -107,11 +107,11 @@ impl<T, K, const N: usize> BinaryHeap<T, K, N> {
     /// use heapless::binary_heap::{BinaryHeap, Max};
     ///
     /// // allocate the binary heap on the stack
-    /// let mut heap: BinaryHeap<_, Max, _, 8> = BinaryHeap::new();
+    /// let mut heap: BinaryHeap<_, Max, 8> = BinaryHeap::new();
     /// heap.push(4).unwrap();
     ///
     /// // allocate the binary heap in a static variable
-    /// static mut HEAP: BinaryHeap<i32, Max, usize, 8> = BinaryHeap::new();
+    /// static mut HEAP: BinaryHeap<i32, Max, 8> = BinaryHeap::new();
     /// ```
     pub const fn new() -> Self {
         Self {

--- a/src/binary_heap.rs
+++ b/src/binary_heap.rs
@@ -36,7 +36,7 @@ pub enum Max {}
 /// ```
 /// use heapless::binary_heap::{BinaryHeap, Max};
 ///
-/// let mut heap: BinaryHeap<_, Max, 8> = BinaryHeap::new();
+/// let mut heap: BinaryHeap<_, Max, usize, 8> = BinaryHeap::new();
 ///
 /// // We can use peek to look at the next item in the heap. In this case,
 /// // there's no items in there yet so we get None.
@@ -124,7 +124,7 @@ where
     /// ```
     /// use heapless::binary_heap::{BinaryHeap, Max};
     ///
-    /// let mut heap: BinaryHeap<_, Max, 8> = BinaryHeap::new();
+    /// let mut heap: BinaryHeap<_, Max, usize, 8> = BinaryHeap::new();
     /// heap.push(1).unwrap();
     /// heap.push(3).unwrap();
     ///
@@ -143,7 +143,7 @@ where
     /// ```
     /// use heapless::binary_heap::{BinaryHeap, Max};
     ///
-    /// let mut heap: BinaryHeap<_, Max, 8> = BinaryHeap::new();
+    /// let mut heap: BinaryHeap<_, Max, usize, 8> = BinaryHeap::new();
     /// heap.push(1).unwrap();
     /// heap.push(3).unwrap();
     ///
@@ -158,7 +158,7 @@ where
     /// ```
     /// use heapless::binary_heap::{BinaryHeap, Max};
     ///
-    /// let mut heap: BinaryHeap<_, Max, 8> = BinaryHeap::new();
+    /// let mut heap: BinaryHeap<_, Max, usize, 8> = BinaryHeap::new();
     ///
     /// assert!(heap.is_empty());
     ///
@@ -177,7 +177,7 @@ where
     /// ```
     /// use heapless::binary_heap::{BinaryHeap, Max};
     ///
-    /// let mut heap: BinaryHeap<_, Max, 8> = BinaryHeap::new();
+    /// let mut heap: BinaryHeap<_, Max, usize, 8> = BinaryHeap::new();
     /// heap.push(1).unwrap();
     /// heap.push(2).unwrap();
     /// heap.push(3).unwrap();
@@ -207,7 +207,7 @@ where
     /// ```
     /// use heapless::binary_heap::{BinaryHeap, Max};
     ///
-    /// let mut heap: BinaryHeap<_, Max, 8> = BinaryHeap::new();
+    /// let mut heap: BinaryHeap<_, Max, usize, 8> = BinaryHeap::new();
     /// assert_eq!(heap.peek(), None);
     ///
     /// heap.push(1).unwrap();
@@ -232,7 +232,7 @@ where
     /// ```
     /// use heapless::binary_heap::{BinaryHeap, Max};
     ///
-    /// let mut heap: BinaryHeap<_, Max, 8> = BinaryHeap::new();
+    /// let mut heap: BinaryHeap<_, Max, usize, 8> = BinaryHeap::new();
     /// assert!(heap.peek_mut().is_none());
     ///
     /// heap.push(1);
@@ -262,7 +262,7 @@ where
     /// ```
     /// use heapless::binary_heap::{BinaryHeap, Max};
     ///
-    /// let mut heap: BinaryHeap<_, Max, 8> = BinaryHeap::new();
+    /// let mut heap: BinaryHeap<_, Max, usize, 8> = BinaryHeap::new();
     /// heap.push(1).unwrap();
     /// heap.push(3).unwrap();
     ///
@@ -295,7 +295,7 @@ where
     /// ```
     /// use heapless::binary_heap::{BinaryHeap, Max};
     ///
-    /// let mut heap: BinaryHeap<_, Max, 8> = BinaryHeap::new();
+    /// let mut heap: BinaryHeap<_, Max, usize, 8> = BinaryHeap::new();
     /// heap.push(3).unwrap();
     /// heap.push(5).unwrap();
     /// heap.push(1).unwrap();
@@ -559,12 +559,12 @@ mod tests {
 
     #[test]
     fn static_new() {
-        static mut _B: BinaryHeap<i32, Min, 16> = BinaryHeap::new();
+        static mut _B: BinaryHeap<i32, Min, usize, 16> = BinaryHeap::new();
     }
 
     #[test]
     fn min() {
-        let mut heap = BinaryHeap::<_, Min, 16>::new();
+        let mut heap = BinaryHeap::<_, Min, usize, 16>::new();
         heap.push(1).unwrap();
         heap.push(2).unwrap();
         heap.push(3).unwrap();
@@ -616,7 +616,7 @@ mod tests {
 
     #[test]
     fn max() {
-        let mut heap = BinaryHeap::<_, Max, 16>::new();
+        let mut heap = BinaryHeap::<_, Max, usize, 16>::new();
         heap.push(1).unwrap();
         heap.push(2).unwrap();
         heap.push(3).unwrap();

--- a/src/binary_heap.rs
+++ b/src/binary_heap.rs
@@ -81,10 +81,10 @@ pub struct BinaryHeapBase<T, K, U: Uxx, const N: usize> {
 pub type BinaryHeap<T, K, const N: usize> = BinaryHeapBase<T, K, usize, N>;
 
 macro_rules! impl_new {
-    ($Uxx:ident, $name:ident) => {
+    ($Uxx:ident, $name:ident, $doc:tt) => {
         impl<T, K, const N: usize> BinaryHeapBase<T, K, $Uxx, N> {
             /* Constructors */
-            /// Creates an empty BinaryHeap as a $K-heap.
+            #[doc = $doc]
             pub const fn $name() -> Self {
                 Self {
                     _kind: PhantomData,
@@ -95,9 +95,16 @@ macro_rules! impl_new {
     };
 }
 
-impl_new!(u8, u8);
-impl_new!(u16, u16);
-impl_new!(usize, usize);
+impl_new!(
+    u8,
+    u8,
+    "Creates an empty BinaryHeap as a $K-heap. **Safety**: Assumes `N <= u8::MAX`."
+);
+impl_new!(
+    u16,
+    u16,
+    "Creates an empty BinaryHeap as a $K-heap. **Safety**: Assumes `N <= u16::MAX`."
+);
 
 impl<T, K, const N: usize> BinaryHeap<T, K, N> {
     /* Constructors */

--- a/src/binary_heap.rs
+++ b/src/binary_heap.rs
@@ -116,7 +116,7 @@ where
     /* Public API */
     /// Returns the capacity of the binary heap.
     pub fn capacity(&self) -> usize {
-        self.data.capacity()
+        self.data.capacity_nonconst()
     }
 
     /// Drops all items from the binary heap.

--- a/src/de.rs
+++ b/src/de.rs
@@ -37,7 +37,7 @@ where
             where
                 A: SeqAccess<'de>,
             {
-                let mut values = BinaryHeap::new();
+                let mut values = BinaryHeap::default();
 
                 while let Some(value) = seq.next_element()? {
                     if values.push(value).is_err() {
@@ -118,7 +118,7 @@ where
             where
                 A: SeqAccess<'de>,
             {
-                let mut values = Vec::new();
+                let mut values = Vec::default();
 
                 while let Some(value) = seq.next_element()? {
                     if values.push(value).is_err() {
@@ -207,7 +207,7 @@ where
             where
                 A: MapAccess<'de>,
             {
-                let mut values = LinearMap::new();
+                let mut values = LinearMap::default();
 
                 while let Some((key, value)) = map.next_entry()? {
                     if values.insert(key, value).is_err() {
@@ -242,7 +242,7 @@ impl<'de, U: Uxx, const N: usize> Deserialize<'de> for String<U, N> {
             where
                 E: de::Error,
             {
-                let mut s = String::new();
+                let mut s = String::default();
                 s.push_str(v)
                     .map_err(|_| E::invalid_length(v.len(), &self))?;
                 Ok(s)
@@ -252,7 +252,7 @@ impl<'de, U: Uxx, const N: usize> Deserialize<'de> for String<U, N> {
             where
                 E: de::Error,
             {
-                let mut s = String::new();
+                let mut s = String::default();
 
                 s.push_str(
                     core::str::from_utf8(v)

--- a/src/de.rs
+++ b/src/de.rs
@@ -1,6 +1,6 @@
 use crate::{
     sealed::{binary_heap::Kind as BinaryHeapKind, spsc::Uxx},
-    BinaryHeap, IndexMap, IndexSet, LinearMap, String, Vec,
+    BinaryHeapBase, IndexMapBase, IndexSetBase, LinearMapBase, StringBase, VecBase,
 };
 use core::{fmt, marker::PhantomData};
 use hash32::{BuildHasherDefault, Hash, Hasher};
@@ -8,7 +8,7 @@ use serde::de::{self, Deserialize, Deserializer, Error, MapAccess, SeqAccess};
 
 // Sequential containers
 
-impl<'de, T, KIND, U: Uxx, const N: usize> Deserialize<'de> for BinaryHeap<T, KIND, U, N>
+impl<'de, T, KIND, U: Uxx, const N: usize> Deserialize<'de> for BinaryHeapBase<T, KIND, U, N>
 where
     T: Ord + Deserialize<'de>,
 
@@ -27,7 +27,7 @@ where
             T: Ord + Deserialize<'de>,
             KIND: BinaryHeapKind,
         {
-            type Value = BinaryHeap<T, KIND, U, N>;
+            type Value = BinaryHeapBase<T, KIND, U, N>;
 
             fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                 formatter.write_str("a sequence")
@@ -37,7 +37,7 @@ where
             where
                 A: SeqAccess<'de>,
             {
-                let mut values = BinaryHeap::default();
+                let mut values = BinaryHeapBase::default();
 
                 while let Some(value) = seq.next_element()? {
                     if values.push(value).is_err() {
@@ -53,7 +53,7 @@ where
 }
 
 impl<'de, T, S, U: Uxx, const N: usize> Deserialize<'de>
-    for IndexSet<T, BuildHasherDefault<S>, U, N>
+    for IndexSetBase<T, BuildHasherDefault<S>, U, N>
 where
     T: Eq + Hash + Deserialize<'de>,
     S: Hasher + Default,
@@ -69,7 +69,7 @@ where
             T: Eq + Hash + Deserialize<'de>,
             S: Hasher + Default,
         {
-            type Value = IndexSet<T, BuildHasherDefault<S>, U, N>;
+            type Value = IndexSetBase<T, BuildHasherDefault<S>, U, N>;
 
             fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                 formatter.write_str("a sequence")
@@ -79,7 +79,7 @@ where
             where
                 A: SeqAccess<'de>,
             {
-                let mut values = IndexSet::new();
+                let mut values = IndexSetBase::new();
 
                 while let Some(value) = seq.next_element()? {
                     if values.insert(value).is_err() {
@@ -94,7 +94,7 @@ where
     }
 }
 
-impl<'de, T, U: Uxx, const N: usize> Deserialize<'de> for Vec<T, U, N>
+impl<'de, T, U: Uxx, const N: usize> Deserialize<'de> for VecBase<T, U, N>
 where
     T: Deserialize<'de>,
 {
@@ -108,7 +108,7 @@ where
         where
             T: Deserialize<'de>,
         {
-            type Value = Vec<T, U, N>;
+            type Value = VecBase<T, U, N>;
 
             fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                 formatter.write_str("a sequence")
@@ -118,7 +118,7 @@ where
             where
                 A: SeqAccess<'de>,
             {
-                let mut values = Vec::default();
+                let mut values = VecBase::default();
 
                 while let Some(value) = seq.next_element()? {
                     if values.push(value).is_err() {
@@ -139,7 +139,7 @@ where
 // Dictionaries
 
 impl<'de, K, V, S, U: Uxx, const N: usize> Deserialize<'de>
-    for IndexMap<K, V, BuildHasherDefault<S>, U, N>
+    for IndexMapBase<K, V, BuildHasherDefault<S>, U, N>
 where
     K: Eq + Hash + Deserialize<'de>,
     V: Deserialize<'de>,
@@ -159,7 +159,7 @@ where
             V: Deserialize<'de>,
             S: Default + Hasher,
         {
-            type Value = IndexMap<K, V, BuildHasherDefault<S>, U, N>;
+            type Value = IndexMapBase<K, V, BuildHasherDefault<S>, U, N>;
 
             fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                 formatter.write_str("a map")
@@ -169,7 +169,7 @@ where
             where
                 A: MapAccess<'de>,
             {
-                let mut values = IndexMap::new();
+                let mut values = IndexMapBase::new();
 
                 while let Some((key, value)) = map.next_entry()? {
                     if values.insert(key, value).is_err() {
@@ -184,7 +184,7 @@ where
     }
 }
 
-impl<'de, K, V, U: Uxx, const N: usize> Deserialize<'de> for LinearMap<K, V, U, N>
+impl<'de, K, V, U: Uxx, const N: usize> Deserialize<'de> for LinearMapBase<K, V, U, N>
 where
     K: Eq + Deserialize<'de>,
     V: Deserialize<'de>,
@@ -200,7 +200,7 @@ where
             K: Eq + Deserialize<'de>,
             V: Deserialize<'de>,
         {
-            type Value = LinearMap<K, V, U, N>;
+            type Value = LinearMapBase<K, V, U, N>;
 
             fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                 formatter.write_str("a map")
@@ -210,7 +210,7 @@ where
             where
                 A: MapAccess<'de>,
             {
-                let mut values = LinearMap::default();
+                let mut values = LinearMapBase::default();
 
                 while let Some((key, value)) = map.next_entry()? {
                     if values.insert(key, value).is_err() {
@@ -227,7 +227,7 @@ where
 
 // String containers
 
-impl<'de, U: Uxx, const N: usize> Deserialize<'de> for String<U, N> {
+impl<'de, U: Uxx, const N: usize> Deserialize<'de> for StringBase<U, N> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
@@ -235,7 +235,7 @@ impl<'de, U: Uxx, const N: usize> Deserialize<'de> for String<U, N> {
         struct ValueVisitor<'de, U: Uxx, const N: usize>(PhantomData<(&'de (), U)>);
 
         impl<'de, U: Uxx, const N: usize> de::Visitor<'de> for ValueVisitor<'de, U, N> {
-            type Value = String<U, N>;
+            type Value = StringBase<U, N>;
 
             fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                 write!(formatter, "a string no more than {} bytes long", N as u64)
@@ -245,7 +245,7 @@ impl<'de, U: Uxx, const N: usize> Deserialize<'de> for String<U, N> {
             where
                 E: de::Error,
             {
-                let mut s = String::default();
+                let mut s = StringBase::default();
                 s.push_str(v)
                     .map_err(|_| E::invalid_length(v.len(), &self))?;
                 Ok(s)
@@ -255,7 +255,7 @@ impl<'de, U: Uxx, const N: usize> Deserialize<'de> for String<U, N> {
             where
                 E: de::Error,
             {
-                let mut s = String::default();
+                let mut s = StringBase::default();
 
                 s.push_str(
                     core::str::from_utf8(v)

--- a/src/de.rs
+++ b/src/de.rs
@@ -122,7 +122,10 @@ where
 
                 while let Some(value) = seq.next_element()? {
                     if values.push(value).is_err() {
-                        return Err(A::Error::invalid_length(values.capacity() + 1, &self))?;
+                        return Err(A::Error::invalid_length(
+                            values.capacity_nonconst() + 1,
+                            &self,
+                        ))?;
                     }
                 }
 

--- a/src/indexmap.rs
+++ b/src/indexmap.rs
@@ -45,8 +45,7 @@ use crate::{sealed::spsc::Uxx, Vec};
 ///     println!("{}: \"{}\"", book, review);
 /// }
 /// ```
-pub type FnvIndexMap<K, V, U: Uxx, const N: usize> =
-    IndexMap<K, V, BuildHasherDefault<FnvHasher>, U, N>;
+pub type FnvIndexMap<K, V, U, const N: usize> = IndexMap<K, V, BuildHasherDefault<FnvHasher>, U, N>;
 
 #[derive(Clone, Copy, Eq, PartialEq)]
 struct HashValue(u16);
@@ -122,26 +121,6 @@ struct CoreMap<K, V, U: Uxx, const N: usize> {
     entries: Vec<Bucket<K, V>, U, N>,
     indices: [Option<Pos>; N],
 }
-
-macro_rules! impl_new {
-    ($Uxx:ident, $name:ident) => {
-        impl<K, V, const N: usize> CoreMap<K, V, $Uxx, N> {
-            const fn $name() -> Self {
-                const INIT: Option<Pos> = None;
-
-                CoreMap {
-                    entries: Vec::$name(),
-                    indices: [INIT; N],
-                }
-            }
-        }
-    };
-}
-
-impl_new!(u8, u8);
-impl_new!(u16, u16);
-impl_new!(usize, usize);
-impl_new!(usize, new);
 
 impl<K, V, U: Uxx, const N: usize> CoreMap<K, V, U, N>
 where

--- a/src/indexmap.rs
+++ b/src/indexmap.rs
@@ -14,7 +14,7 @@ use crate::{sealed::spsc::Uxx, Vec};
 /// use heapless::FnvIndexMap;
 ///
 /// // A hash map with a capacity of 16 key-value pairs allocated on the stack
-/// let mut book_reviews = FnvIndexMap::<_, _, usize, 16>::new();
+/// let mut book_reviews = FnvIndexMap::<_, _, 16>::new();
 ///
 /// // review some books.
 /// book_reviews.insert("Adventures of Huckleberry Finn",    "My favorite book.").unwrap();
@@ -327,7 +327,7 @@ where
 /// use heapless::FnvIndexMap;
 ///
 /// // A hash map with a capacity of 16 key-value pairs allocated on the stack
-/// let mut book_reviews = FnvIndexMap::<_, _, usize, 16>::new();
+/// let mut book_reviews = FnvIndexMap::<_, _, 16>::new();
 ///
 /// // review some books.
 /// book_reviews.insert("Adventures of Huckleberry Finn",    "My favorite book.").unwrap();
@@ -398,7 +398,7 @@ where
     /// ```
     /// use heapless::FnvIndexMap;
     ///
-    /// let mut map = FnvIndexMap::<_, _, usize, 16>::new();
+    /// let mut map = FnvIndexMap::<_, _, 16>::new();
     /// map.insert("a", 1).unwrap();
     /// map.insert("b", 2).unwrap();
     /// map.insert("c", 3).unwrap();
@@ -416,7 +416,7 @@ where
     /// ```
     /// use heapless::FnvIndexMap;
     ///
-    /// let mut map = FnvIndexMap::<_, _, usize, 16>::new();
+    /// let mut map = FnvIndexMap::<_, _, 16>::new();
     /// map.insert("a", 1).unwrap();
     /// map.insert("b", 2).unwrap();
     /// map.insert("c", 3).unwrap();
@@ -434,7 +434,7 @@ where
     /// ```
     /// use heapless::FnvIndexMap;
     ///
-    /// let mut map = FnvIndexMap::<_, _, usize, 16>::new();
+    /// let mut map = FnvIndexMap::<_, _, 16>::new();
     /// map.insert("a", 1).unwrap();
     /// map.insert("b", 2).unwrap();
     /// map.insert("c", 3).unwrap();
@@ -456,7 +456,7 @@ where
     /// ```
     /// use heapless::FnvIndexMap;
     ///
-    /// let mut map = FnvIndexMap::<_, _, usize, 16>::new();
+    /// let mut map = FnvIndexMap::<_, _, 16>::new();
     /// map.insert("a", 1).unwrap();
     /// map.insert("b", 2).unwrap();
     /// map.insert("c", 3).unwrap();
@@ -476,7 +476,7 @@ where
     /// ```
     /// use heapless::FnvIndexMap;
     ///
-    /// let mut map = FnvIndexMap::<_, _, usize, 16>::new();
+    /// let mut map = FnvIndexMap::<_, _, 16>::new();
     /// map.insert("a", 1).unwrap();
     /// map.insert("b", 2).unwrap();
     /// map.insert("c", 3).unwrap();
@@ -505,7 +505,7 @@ where
     /// ```
     /// use heapless::FnvIndexMap;
     ///
-    /// let mut a = FnvIndexMap::<_, _, usize, 16>::new();
+    /// let mut a = FnvIndexMap::<_, _, 16>::new();
     /// assert_eq!(a.len(), 0);
     /// a.insert(1, "a").unwrap();
     /// assert_eq!(a.len(), 1);
@@ -521,7 +521,7 @@ where
     /// ```
     /// use heapless::FnvIndexMap;
     ///
-    /// let mut a = FnvIndexMap::<_, _, usize, 16>::new();
+    /// let mut a = FnvIndexMap::<_, _, 16>::new();
     /// assert!(a.is_empty());
     /// a.insert(1, "a");
     /// assert!(!a.is_empty());
@@ -537,7 +537,7 @@ where
     /// ```
     /// use heapless::FnvIndexMap;
     ///
-    /// let mut a = FnvIndexMap::<_, _, usize, 16>::new();
+    /// let mut a = FnvIndexMap::<_, _, 16>::new();
     /// a.insert(1, "a");
     /// a.clear();
     /// assert!(a.is_empty());
@@ -559,7 +559,7 @@ where
     /// ```
     /// use heapless::FnvIndexMap;
     ///
-    /// let mut map = FnvIndexMap::<_, _, usize, 16>::new();
+    /// let mut map = FnvIndexMap::<_, _, 16>::new();
     /// map.insert(1, "a").unwrap();
     /// assert_eq!(map.get(&1), Some(&"a"));
     /// assert_eq!(map.get(&2), None);
@@ -585,7 +585,7 @@ where
     /// ```
     /// use heapless::FnvIndexMap;
     ///
-    /// let mut map = FnvIndexMap::<_, _, usize, 8>::new();
+    /// let mut map = FnvIndexMap::<_, _, 8>::new();
     /// map.insert(1, "a").unwrap();
     /// assert_eq!(map.contains_key(&1), true);
     /// assert_eq!(map.contains_key(&2), false);
@@ -610,7 +610,7 @@ where
     /// ```
     /// use heapless::FnvIndexMap;
     ///
-    /// let mut map = FnvIndexMap::<_, _, usize, 8>::new();
+    /// let mut map = FnvIndexMap::<_, _, 8>::new();
     /// map.insert(1, "a").unwrap();
     /// if let Some(x) = map.get_mut(&1) {
     ///     *x = "b";
@@ -648,7 +648,7 @@ where
     /// ```
     /// use heapless::FnvIndexMap;
     ///
-    /// let mut map = FnvIndexMap::<_, _, usize, 8>::new();
+    /// let mut map = FnvIndexMap::<_, _, 8>::new();
     /// assert_eq!(map.insert(37, "a"), Ok(None));
     /// assert_eq!(map.is_empty(), false);
     ///
@@ -680,7 +680,7 @@ where
     /// ```
     /// use heapless::FnvIndexMap;
     ///
-    /// let mut map = FnvIndexMap::<_, _, usize, 8>::new();
+    /// let mut map = FnvIndexMap::<_, _, 8>::new();
     /// map.insert(1, "a").unwrap();
     /// assert_eq!(map.remove(&1), Some("a"));
     /// assert_eq!(map.remove(&1), None);
@@ -944,7 +944,7 @@ mod tests {
     fn size() {
         const CAP: usize = 4;
         assert_eq!(
-            mem::size_of::<FnvIndexMap<i16, u16, usize, CAP>>(),
+            mem::size_of::<FnvIndexMap<i16, u16, CAP>>(),
             CAP * mem::size_of::<u32>() + // indices
                 CAP * (mem::size_of::<i16>() + // key
                      mem::size_of::<u16>() + // value
@@ -957,10 +957,10 @@ mod tests {
     #[test]
     fn partial_eq() {
         {
-            let mut a: FnvIndexMap<_, _, usize, 4> = FnvIndexMap::new();
+            let mut a: FnvIndexMap<_, _, 4> = FnvIndexMap::new();
             a.insert("k1", "v1").unwrap();
 
-            let mut b: FnvIndexMap<_, _, usize, 4> = FnvIndexMap::new();
+            let mut b: FnvIndexMap<_, _, 4> = FnvIndexMap::new();
             b.insert("k1", "v1").unwrap();
 
             assert!(a == b);
@@ -971,11 +971,11 @@ mod tests {
         }
 
         {
-            let mut a: FnvIndexMap<_, _, usize, 4> = FnvIndexMap::new();
+            let mut a: FnvIndexMap<_, _, 4> = FnvIndexMap::new();
             a.insert("k1", "v1").unwrap();
             a.insert("k2", "v2").unwrap();
 
-            let mut b: FnvIndexMap<_, _, usize, 4> = FnvIndexMap::new();
+            let mut b: FnvIndexMap<_, _, 4> = FnvIndexMap::new();
             b.insert("k2", "v2").unwrap();
             b.insert("k1", "v1").unwrap();
 

--- a/src/indexmap.rs
+++ b/src/indexmap.rs
@@ -4,7 +4,7 @@ use hash32::{BuildHasher, BuildHasherDefault, FnvHasher, Hash, Hasher};
 
 use crate::{sealed::spsc::Uxx, VecBase};
 
-/// A [`heapless::IndexMapBase`](./struct.IndexMap.html) using the default FNV hasher
+/// A [`heapless::IndexMapBase`](./struct.IndexMapBase.html) using the default FNV hasher
 ///
 /// A list of all Methods and Traits available for `FnvIndexMapBase` can be found in
 /// the [`heapless::IndexMapBase`](./struct.IndexMapBase.html) documentation.
@@ -679,7 +679,7 @@ where
         }
     }
 
-    /// Same as [`swap_remove`](struct.IndexMap.html#method.swap_remove)
+    /// Same as [`swap_remove`](struct.IndexMapBase.html#method.swap_remove)
     ///
     /// Computes in **O(1)** time (average).
     ///

--- a/src/indexmap.rs
+++ b/src/indexmap.rs
@@ -14,7 +14,7 @@ use crate::{sealed::spsc::Uxx, Vec};
 /// use heapless::FnvIndexMap;
 ///
 /// // A hash map with a capacity of 16 key-value pairs allocated on the stack
-/// let mut book_reviews = FnvIndexMap::<_, _, 16>::new();
+/// let mut book_reviews = FnvIndexMap::<_, _, usize, 16>::new();
 ///
 /// // review some books.
 /// book_reviews.insert("Adventures of Huckleberry Finn",    "My favorite book.").unwrap();
@@ -327,7 +327,7 @@ where
 /// use heapless::FnvIndexMap;
 ///
 /// // A hash map with a capacity of 16 key-value pairs allocated on the stack
-/// let mut book_reviews = FnvIndexMap::<_, _, 16>::new();
+/// let mut book_reviews = FnvIndexMap::<_, _, usize, 16>::new();
 ///
 /// // review some books.
 /// book_reviews.insert("Adventures of Huckleberry Finn",    "My favorite book.").unwrap();
@@ -398,7 +398,7 @@ where
     /// ```
     /// use heapless::FnvIndexMap;
     ///
-    /// let mut map = FnvIndexMap::<_, _, 16>::new();
+    /// let mut map = FnvIndexMap::<_, _, usize, 16>::new();
     /// map.insert("a", 1).unwrap();
     /// map.insert("b", 2).unwrap();
     /// map.insert("c", 3).unwrap();
@@ -416,7 +416,7 @@ where
     /// ```
     /// use heapless::FnvIndexMap;
     ///
-    /// let mut map = FnvIndexMap::<_, _, 16>::new();
+    /// let mut map = FnvIndexMap::<_, _, usize, 16>::new();
     /// map.insert("a", 1).unwrap();
     /// map.insert("b", 2).unwrap();
     /// map.insert("c", 3).unwrap();
@@ -434,7 +434,7 @@ where
     /// ```
     /// use heapless::FnvIndexMap;
     ///
-    /// let mut map = FnvIndexMap::<_, _, 16>::new();
+    /// let mut map = FnvIndexMap::<_, _, usize, 16>::new();
     /// map.insert("a", 1).unwrap();
     /// map.insert("b", 2).unwrap();
     /// map.insert("c", 3).unwrap();
@@ -456,7 +456,7 @@ where
     /// ```
     /// use heapless::FnvIndexMap;
     ///
-    /// let mut map = FnvIndexMap::<_, _, 16>::new();
+    /// let mut map = FnvIndexMap::<_, _, usize, 16>::new();
     /// map.insert("a", 1).unwrap();
     /// map.insert("b", 2).unwrap();
     /// map.insert("c", 3).unwrap();
@@ -476,7 +476,7 @@ where
     /// ```
     /// use heapless::FnvIndexMap;
     ///
-    /// let mut map = FnvIndexMap::<_, _, 16>::new();
+    /// let mut map = FnvIndexMap::<_, _, usize, 16>::new();
     /// map.insert("a", 1).unwrap();
     /// map.insert("b", 2).unwrap();
     /// map.insert("c", 3).unwrap();
@@ -505,7 +505,7 @@ where
     /// ```
     /// use heapless::FnvIndexMap;
     ///
-    /// let mut a = FnvIndexMap::<_, _, 16>::new();
+    /// let mut a = FnvIndexMap::<_, _, usize, 16>::new();
     /// assert_eq!(a.len(), 0);
     /// a.insert(1, "a").unwrap();
     /// assert_eq!(a.len(), 1);
@@ -521,7 +521,7 @@ where
     /// ```
     /// use heapless::FnvIndexMap;
     ///
-    /// let mut a = FnvIndexMap::<_, _, 16>::new();
+    /// let mut a = FnvIndexMap::<_, _, usize, 16>::new();
     /// assert!(a.is_empty());
     /// a.insert(1, "a");
     /// assert!(!a.is_empty());
@@ -537,7 +537,7 @@ where
     /// ```
     /// use heapless::FnvIndexMap;
     ///
-    /// let mut a = FnvIndexMap::<_, _, 16>::new();
+    /// let mut a = FnvIndexMap::<_, _, usize, 16>::new();
     /// a.insert(1, "a");
     /// a.clear();
     /// assert!(a.is_empty());
@@ -559,7 +559,7 @@ where
     /// ```
     /// use heapless::FnvIndexMap;
     ///
-    /// let mut map = FnvIndexMap::<_, _, 16>::new();
+    /// let mut map = FnvIndexMap::<_, _, usize, 16>::new();
     /// map.insert(1, "a").unwrap();
     /// assert_eq!(map.get(&1), Some(&"a"));
     /// assert_eq!(map.get(&2), None);
@@ -585,7 +585,7 @@ where
     /// ```
     /// use heapless::FnvIndexMap;
     ///
-    /// let mut map = FnvIndexMap::<_, _, 8>::new();
+    /// let mut map = FnvIndexMap::<_, _, usize, 8>::new();
     /// map.insert(1, "a").unwrap();
     /// assert_eq!(map.contains_key(&1), true);
     /// assert_eq!(map.contains_key(&2), false);
@@ -610,7 +610,7 @@ where
     /// ```
     /// use heapless::FnvIndexMap;
     ///
-    /// let mut map = FnvIndexMap::<_, _, 8>::new();
+    /// let mut map = FnvIndexMap::<_, _, usize, 8>::new();
     /// map.insert(1, "a").unwrap();
     /// if let Some(x) = map.get_mut(&1) {
     ///     *x = "b";
@@ -648,7 +648,7 @@ where
     /// ```
     /// use heapless::FnvIndexMap;
     ///
-    /// let mut map = FnvIndexMap::<_, _, 8>::new();
+    /// let mut map = FnvIndexMap::<_, _, usize, 8>::new();
     /// assert_eq!(map.insert(37, "a"), Ok(None));
     /// assert_eq!(map.is_empty(), false);
     ///
@@ -680,7 +680,7 @@ where
     /// ```
     /// use heapless::FnvIndexMap;
     ///
-    /// let mut map = FnvIndexMap::<_, _, 8>::new();
+    /// let mut map = FnvIndexMap::<_, _, usize, 8>::new();
     /// map.insert(1, "a").unwrap();
     /// assert_eq!(map.remove(&1), Some("a"));
     /// assert_eq!(map.remove(&1), None);
@@ -944,7 +944,7 @@ mod tests {
     fn size() {
         const CAP: usize = 4;
         assert_eq!(
-            mem::size_of::<FnvIndexMap<i16, u16, CAP>>(),
+            mem::size_of::<FnvIndexMap<i16, u16, usize, CAP>>(),
             CAP * mem::size_of::<u32>() + // indices
                 CAP * (mem::size_of::<i16>() + // key
                      mem::size_of::<u16>() + // value
@@ -957,10 +957,10 @@ mod tests {
     #[test]
     fn partial_eq() {
         {
-            let mut a: FnvIndexMap<_, _, 4> = FnvIndexMap::new();
+            let mut a: FnvIndexMap<_, _, usize, 4> = FnvIndexMap::new();
             a.insert("k1", "v1").unwrap();
 
-            let mut b: FnvIndexMap<_, _, 4> = FnvIndexMap::new();
+            let mut b: FnvIndexMap<_, _, usize, 4> = FnvIndexMap::new();
             b.insert("k1", "v1").unwrap();
 
             assert!(a == b);
@@ -971,11 +971,11 @@ mod tests {
         }
 
         {
-            let mut a: FnvIndexMap<_, _, 4> = FnvIndexMap::new();
+            let mut a: FnvIndexMap<_, _, usize, 4> = FnvIndexMap::new();
             a.insert("k1", "v1").unwrap();
             a.insert("k2", "v2").unwrap();
 
-            let mut b: FnvIndexMap<_, _, 4> = FnvIndexMap::new();
+            let mut b: FnvIndexMap<_, _, usize, 4> = FnvIndexMap::new();
             b.insert("k2", "v2").unwrap();
             b.insert("k1", "v1").unwrap();
 

--- a/src/indexmap.rs
+++ b/src/indexmap.rs
@@ -123,21 +123,39 @@ struct CoreMap<K, V, U: Uxx, const N: usize> {
     indices: [Option<Pos>; N],
 }
 
-impl<K, V, U: Uxx, const N: usize> CoreMap<K, V, U, N> {
-    const fn new() -> Self {
-        const INIT: Option<Pos> = None;
+macro_rules! impl_new {
+    ($Uxx:ident, $name:ident) => {
+        impl<K, V, const N: usize> CoreMap<K, V, $Uxx, N> {
+            const fn $name() -> Self {
+                const INIT: Option<Pos> = None;
 
-        CoreMap {
-            entries: Vec::new(),
-            indices: [INIT; N],
+                CoreMap {
+                    entries: Vec::$name(),
+                    indices: [INIT; N],
+                }
+            }
         }
-    }
+    };
 }
+
+impl_new!(u8, u8);
+impl_new!(u16, u16);
+impl_new!(usize, usize);
+impl_new!(usize, new);
 
 impl<K, V, U: Uxx, const N: usize> CoreMap<K, V, U, N>
 where
     K: Eq + Hash,
 {
+    fn new_nonconst() -> Self {
+        const INIT: Option<Pos> = None;
+
+        CoreMap {
+            entries: Vec::default(),
+            indices: [INIT; N],
+        }
+    }
+
     fn capacity() -> usize {
         N
     }
@@ -380,7 +398,7 @@ where
     pub fn new() -> Self {
         IndexMap {
             build_hasher: BuildHasherDefault::default(),
-            core: CoreMap::new(),
+            core: CoreMap::new_nonconst(),
         }
     }
 }
@@ -795,7 +813,7 @@ where
     fn default() -> Self {
         IndexMap {
             build_hasher: <_>::default(),
-            core: CoreMap::new(),
+            core: CoreMap::new_nonconst(),
         }
     }
 }

--- a/src/indexmap.rs
+++ b/src/indexmap.rs
@@ -4,10 +4,15 @@ use hash32::{BuildHasher, BuildHasherDefault, FnvHasher, Hash, Hasher};
 
 use crate::{sealed::spsc::Uxx, VecBase};
 
-/// A [`heapless::IndexMap`](./struct.IndexMap.html) using the default FNV hasher
+/// A [`heapless::IndexMapBase`](./struct.IndexMap.html) using the default FNV hasher
 ///
-/// A list of all Methods and Traits available for `FnvIndexMap` can be found in
-/// the [`heapless::IndexMap`](./struct.IndexMap.html) documentation.
+/// A list of all Methods and Traits available for `FnvIndexMapBase` can be found in
+/// the [`heapless::IndexMapBase`](./struct.IndexMapBase.html) documentation.
+///
+pub type FnvIndexMapBase<K, V, U, const N: usize> =
+    IndexMapBase<K, V, BuildHasherDefault<FnvHasher>, U, N>;
+
+/// A `FnvIndexMapBase` with a length type of `usize`.
 ///
 /// # Examples
 /// ```
@@ -45,9 +50,6 @@ use crate::{sealed::spsc::Uxx, VecBase};
 ///     println!("{}: \"{}\"", book, review);
 /// }
 /// ```
-pub type FnvIndexMapBase<K, V, U, const N: usize> =
-    IndexMapBase<K, V, BuildHasherDefault<FnvHasher>, U, N>;
-
 pub type FnvIndexMap<K, V, const N: usize> = FnvIndexMapBase<K, V, usize, N>;
 
 #[derive(Clone, Copy, Eq, PartialEq)]
@@ -316,11 +318,20 @@ where
 
 /// Fixed capacity [`IndexMap`](https://docs.rs/indexmap/1/indexmap/map/struct.IndexMap.html)
 ///
-/// Note that you cannot use `IndexMap` directly, since it is generic around the hashing algorithm
-/// in use. Pick a concrete instantiation like [`FnvIndexMap`](./type.FnvIndexMap.html) instead
+/// Note that you cannot use `IndexMapBase` directly, since it is generic around the hashing algorithm
+/// in use. Pick a concrete instantiation like [`FnvIndexMapBase`](./type.FnvIndexMap.html) instead
 /// or create your own.
 ///
-/// Note that the capacity of the `IndexMap` must be a power of 2.
+/// Note that the capacity of the `IndexMapBase` must be a power of 2.
+pub struct IndexMapBase<K, V, S, U: Uxx, const N: usize>
+where
+    K: Eq + Hash,
+{
+    core: CoreMap<K, V, U, N>,
+    build_hasher: S,
+}
+
+/// An `IndexMapBase` with a length type of `usize`.
 ///
 /// # Examples
 /// Since `IndexMap` cannot be used directly, we're using its `FnvIndexMap` instantiation
@@ -361,14 +372,6 @@ where
 ///     println!("{}: \"{}\"", book, review);
 /// }
 /// ```
-pub struct IndexMapBase<K, V, S, U: Uxx, const N: usize>
-where
-    K: Eq + Hash,
-{
-    core: CoreMap<K, V, U, N>,
-    build_hasher: S,
-}
-
 pub type IndexMap<K, V, S, const N: usize> = IndexMapBase<K, V, S, usize, N>;
 
 impl<K, V, S, U: Uxx, const N: usize> IndexMapBase<K, V, BuildHasherDefault<S>, U, N>

--- a/src/indexset.rs
+++ b/src/indexset.rs
@@ -5,10 +5,14 @@ use crate::{
 use core::{borrow::Borrow, fmt, iter::FromIterator};
 use hash32::{BuildHasher, BuildHasherDefault, FnvHasher, Hash, Hasher};
 
-/// A [`heapless::IndexSet`](./struct.IndexSet.html) using the
+/// A [`heapless::IndexSetBase`](./struct.IndexSetBase.html) using the
 /// default FNV hasher.
-/// A list of all Methods and Traits available for `FnvIndexSet` can be found in
-/// the [`heapless::IndexSet`](./struct.IndexSet.html) documentation.
+/// A list of all Methods and Traits available for `FnvIndexSetBase` can be found in
+/// the [`heapless::IndexSetBase`](./struct.IndexSetBase.html) documentation.
+pub type FnvIndexSetBase<T, U, const N: usize> =
+    IndexSetBase<T, BuildHasherDefault<FnvHasher>, U, N>;
+
+/// A `FnvIndexSetBase` with a length type of `usize`.
 ///
 /// # Examples
 /// ```
@@ -37,18 +41,24 @@ use hash32::{BuildHasher, BuildHasherDefault, FnvHasher, Hash, Hasher};
 ///     println!("{}", book);
 /// }
 /// ```
-pub type FnvIndexSetBase<T, U, const N: usize> =
-    IndexSetBase<T, BuildHasherDefault<FnvHasher>, U, N>;
-
 pub type FnvIndexSet<T, const N: usize> = FnvIndexSetBase<T, usize, N>;
 
 /// Fixed capacity [`IndexSet`](https://docs.rs/indexmap/1/indexmap/set/struct.IndexSet.html).
 ///
 /// Note that you cannot use `IndexSet` directly, since it is generic around the hashing algorithm
-/// in use. Pick a concrete instantiation like [`FnvIndexSet`](./type.FnvIndexSet.html) instead
+/// in use. Pick a concrete instantiation like [`FnvIndexSetBase`](./type.FnvIndexSetBase.html) instead
 /// or create your own.
 ///
-/// Note that the capacity of the `IndexSet` must be a power of 2.
+/// Note that the capacity of the `IndexSetBase` must be a power of 2.
+///
+pub struct IndexSetBase<T, S, U: Uxx, const N: usize>
+where
+    T: Eq + Hash,
+{
+    map: IndexMapBase<T, (), S, U, N>,
+}
+
+/// An `IndexSetBase` with a length type of `usize`.
 ///
 /// # Examples
 /// Since `IndexSet` cannot be used directly, we're using its `FnvIndexSet` instantiation
@@ -80,13 +90,6 @@ pub type FnvIndexSet<T, const N: usize> = FnvIndexSetBase<T, usize, N>;
 ///     println!("{}", book);
 /// }
 /// ```
-pub struct IndexSetBase<T, S, U: Uxx, const N: usize>
-where
-    T: Eq + Hash,
-{
-    map: IndexMapBase<T, (), S, U, N>,
-}
-
 pub type IndexSet<T, S, const N: usize> = IndexSetBase<T, S, usize, N>;
 
 impl<T, S, U: Uxx, const N: usize> IndexSetBase<T, BuildHasherDefault<S>, U, N>

--- a/src/indexset.rs
+++ b/src/indexset.rs
@@ -37,7 +37,7 @@ use hash32::{BuildHasher, BuildHasherDefault, FnvHasher, Hash, Hasher};
 ///     println!("{}", book);
 /// }
 /// ```
-pub type FnvIndexSet<T, U: Uxx, const N: usize> = IndexSet<T, BuildHasherDefault<FnvHasher>, U, N>;
+pub type FnvIndexSet<T, U, const N: usize> = IndexSet<T, BuildHasherDefault<FnvHasher>, U, N>;
 
 /// Fixed capacity [`IndexSet`](https://docs.rs/indexmap/1/indexmap/set/struct.IndexSet.html).
 ///

--- a/src/indexset.rs
+++ b/src/indexset.rs
@@ -15,7 +15,7 @@ use hash32::{BuildHasher, BuildHasherDefault, FnvHasher, Hash, Hasher};
 /// use heapless::FnvIndexSet;
 ///
 /// // A hash set with a capacity of 16 elements allocated on the stack
-/// let mut books = FnvIndexSet::<_, usize, 16>::new();
+/// let mut books = FnvIndexSet::<_, 16>::new();
 ///
 /// // Add some books.
 /// books.insert("A Dance With Dragons").unwrap();
@@ -55,7 +55,7 @@ pub type FnvIndexSet<T, U, const N: usize> = IndexSet<T, BuildHasherDefault<FnvH
 /// use heapless::FnvIndexSet;
 ///
 /// // A hash set with a capacity of 16 elements allocated on the stack
-/// let mut books = FnvIndexSet::<_, usize, 16>::new();
+/// let mut books = FnvIndexSet::<_, 16>::new();
 ///
 /// // Add some books.
 /// books.insert("A Dance With Dragons").unwrap();
@@ -111,7 +111,7 @@ where
     /// ```
     /// use heapless::FnvIndexSet;
     ///
-    /// let set = FnvIndexSet::<i32, usize, 16>::new();
+    /// let set = FnvIndexSet::<i32, 16>::new();
     /// assert_eq!(set.capacity(), 16);
     /// ```
     pub fn capacity(&self) -> usize {
@@ -125,7 +125,7 @@ where
     /// ```
     /// use heapless::FnvIndexSet;
     ///
-    /// let mut set = FnvIndexSet::<_, usize, 16>::new();
+    /// let mut set = FnvIndexSet::<_, 16>::new();
     /// set.insert("a").unwrap();
     /// set.insert("b").unwrap();
     ///
@@ -148,21 +148,21 @@ where
     /// ```
     /// use heapless::FnvIndexSet;
     ///
-    /// let mut a: FnvIndexSet<_, usize, 16> = [1, 2, 3].iter().cloned().collect();
-    /// let mut b: FnvIndexSet<_, usize, 16> = [4, 2, 3, 4].iter().cloned().collect();
+    /// let mut a: FnvIndexSet<_, 16> = [1, 2, 3].iter().cloned().collect();
+    /// let mut b: FnvIndexSet<_, 16> = [4, 2, 3, 4].iter().cloned().collect();
     ///
     /// // Can be seen as `a - b`.
     /// for x in a.difference(&b) {
     ///     println!("{}", x); // Print 1
     /// }
     ///
-    /// let diff: FnvIndexSet<_, usize, 16> = a.difference(&b).collect();
-    /// assert_eq!(diff, [1].iter().collect::<FnvIndexSet<_, usize, 16>>());
+    /// let diff: FnvIndexSet<_, 16> = a.difference(&b).collect();
+    /// assert_eq!(diff, [1].iter().collect::<FnvIndexSet<_, 16>>());
     ///
     /// // Note that difference is not symmetric,
     /// // and `b - a` means something else:
-    /// let diff: FnvIndexSet<_, usize, 16> = b.difference(&a).collect();
-    /// assert_eq!(diff, [4].iter().collect::<FnvIndexSet<_, usize, 16>>());
+    /// let diff: FnvIndexSet<_, 16> = b.difference(&a).collect();
+    /// assert_eq!(diff, [4].iter().collect::<FnvIndexSet<_, 16>>());
     /// ```
     pub fn difference<'a, S2, U2: Uxx, const N2: usize>(
         &'a self,
@@ -185,19 +185,19 @@ where
     /// ```
     /// use heapless::FnvIndexSet;
     ///
-    /// let mut a: FnvIndexSet<_, usize, 16> = [1, 2, 3].iter().cloned().collect();
-    /// let mut b: FnvIndexSet<_, usize, 16> = [4, 2, 3, 4].iter().cloned().collect();
+    /// let mut a: FnvIndexSet<_, 16> = [1, 2, 3].iter().cloned().collect();
+    /// let mut b: FnvIndexSet<_, 16> = [4, 2, 3, 4].iter().cloned().collect();
     ///
     /// // Print 1, 4 in that order order.
     /// for x in a.symmetric_difference(&b) {
     ///     println!("{}", x);
     /// }
     ///
-    /// let diff1: FnvIndexSet<_, usize, 16> = a.symmetric_difference(&b).collect();
-    /// let diff2: FnvIndexSet<_, usize, 16> = b.symmetric_difference(&a).collect();
+    /// let diff1: FnvIndexSet<_, 16> = a.symmetric_difference(&b).collect();
+    /// let diff2: FnvIndexSet<_, 16> = b.symmetric_difference(&a).collect();
     ///
     /// assert_eq!(diff1, diff2);
-    /// assert_eq!(diff1, [1, 4].iter().collect::<FnvIndexSet<_, usize, 16>>());
+    /// assert_eq!(diff1, [1, 4].iter().collect::<FnvIndexSet<_, 16>>());
     /// ```
     pub fn symmetric_difference<'a, S2, U2: Uxx, const N2: usize>(
         &'a self,
@@ -217,16 +217,16 @@ where
     /// ```
     /// use heapless::FnvIndexSet;
     ///
-    /// let mut a: FnvIndexSet<_, usize, 16> = [1, 2, 3].iter().cloned().collect();
-    /// let mut b: FnvIndexSet<_, usize, 16> = [4, 2, 3, 4].iter().cloned().collect();
+    /// let mut a: FnvIndexSet<_, 16> = [1, 2, 3].iter().cloned().collect();
+    /// let mut b: FnvIndexSet<_, 16> = [4, 2, 3, 4].iter().cloned().collect();
     ///
     /// // Print 2, 3 in that order.
     /// for x in a.intersection(&b) {
     ///     println!("{}", x);
     /// }
     ///
-    /// let intersection: FnvIndexSet<_, usize, 16> = a.intersection(&b).collect();
-    /// assert_eq!(intersection, [2, 3].iter().collect::<FnvIndexSet<_, usize, 16>>());
+    /// let intersection: FnvIndexSet<_, 16> = a.intersection(&b).collect();
+    /// assert_eq!(intersection, [2, 3].iter().collect::<FnvIndexSet<_, 16>>());
     /// ```
     pub fn intersection<'a, S2, U2: Uxx, const N2: usize>(
         &'a self,
@@ -249,16 +249,16 @@ where
     /// ```
     /// use heapless::FnvIndexSet;
     ///
-    /// let mut a: FnvIndexSet<_, usize, 16> = [1, 2, 3].iter().cloned().collect();
-    /// let mut b: FnvIndexSet<_, usize, 16> = [4, 2, 3, 4].iter().cloned().collect();
+    /// let mut a: FnvIndexSet<_, 16> = [1, 2, 3].iter().cloned().collect();
+    /// let mut b: FnvIndexSet<_, 16> = [4, 2, 3, 4].iter().cloned().collect();
     ///
     /// // Print 1, 2, 3, 4 in that order.
     /// for x in a.union(&b) {
     ///     println!("{}", x);
     /// }
     ///
-    /// let union: FnvIndexSet<_, usize, 16> = a.union(&b).collect();
-    /// assert_eq!(union, [1, 2, 3, 4].iter().collect::<FnvIndexSet<_, usize, 16>>());
+    /// let union: FnvIndexSet<_, 16> = a.union(&b).collect();
+    /// assert_eq!(union, [1, 2, 3, 4].iter().collect::<FnvIndexSet<_, 16>>());
     /// ```
     pub fn union<'a, S2, U2: Uxx, const N2: usize>(
         &'a self,
@@ -277,7 +277,7 @@ where
     /// ```
     /// use heapless::FnvIndexSet;
     ///
-    /// let mut v: FnvIndexSet<_, usize, 16> = FnvIndexSet::new();
+    /// let mut v: FnvIndexSet<_, 16> = FnvIndexSet::new();
     /// assert_eq!(v.len(), 0);
     /// v.insert(1).unwrap();
     /// assert_eq!(v.len(), 1);
@@ -293,7 +293,7 @@ where
     /// ```
     /// use heapless::FnvIndexSet;
     ///
-    /// let mut v: FnvIndexSet<_, usize, 16> = FnvIndexSet::new();
+    /// let mut v: FnvIndexSet<_, 16> = FnvIndexSet::new();
     /// assert!(v.is_empty());
     /// v.insert(1).unwrap();
     /// assert!(!v.is_empty());
@@ -309,7 +309,7 @@ where
     /// ```
     /// use heapless::FnvIndexSet;
     ///
-    /// let mut v: FnvIndexSet<_, usize, 16> = FnvIndexSet::new();
+    /// let mut v: FnvIndexSet<_, 16> = FnvIndexSet::new();
     /// v.insert(1).unwrap();
     /// v.clear();
     /// assert!(v.is_empty());
@@ -328,7 +328,7 @@ where
     /// ```
     /// use heapless::FnvIndexSet;
     ///
-    /// let set: FnvIndexSet<_, usize, 16> = [1, 2, 3].iter().cloned().collect();
+    /// let set: FnvIndexSet<_, 16> = [1, 2, 3].iter().cloned().collect();
     /// assert_eq!(set.contains(&1), true);
     /// assert_eq!(set.contains(&4), false);
     /// ```
@@ -348,8 +348,8 @@ where
     /// ```
     /// use heapless::FnvIndexSet;
     ///
-    /// let a: FnvIndexSet<_, usize, 16> = [1, 2, 3].iter().cloned().collect();
-    /// let mut b = FnvIndexSet::<_, usize, 16>::new();
+    /// let a: FnvIndexSet<_, 16> = [1, 2, 3].iter().cloned().collect();
+    /// let mut b = FnvIndexSet::<_, 16>::new();
     ///
     /// assert_eq!(a.is_disjoint(&b), true);
     /// b.insert(4).unwrap();
@@ -372,8 +372,8 @@ where
     /// ```
     /// use heapless::FnvIndexSet;
     ///
-    /// let sup: FnvIndexSet<_, usize, 16> = [1, 2, 3].iter().cloned().collect();
-    /// let mut set = FnvIndexSet::<_, usize, 16>::new();
+    /// let sup: FnvIndexSet<_, 16> = [1, 2, 3].iter().cloned().collect();
+    /// let mut set = FnvIndexSet::<_, 16>::new();
     ///
     /// assert_eq!(set.is_subset(&sup), true);
     /// set.insert(2).unwrap();
@@ -396,8 +396,8 @@ where
     /// ```
     /// use heapless::FnvIndexSet;
     ///
-    /// let sub: FnvIndexSet<_, usize, 16> = [1, 2].iter().cloned().collect();
-    /// let mut set = FnvIndexSet::<_, usize, 16>::new();
+    /// let sub: FnvIndexSet<_, 16> = [1, 2].iter().cloned().collect();
+    /// let mut set = FnvIndexSet::<_, 16>::new();
     ///
     /// assert_eq!(set.is_superset(&sub), false);
     ///
@@ -426,7 +426,7 @@ where
     /// ```
     /// use heapless::FnvIndexSet;
     ///
-    /// let mut set = FnvIndexSet::<_, usize, 16>::new();
+    /// let mut set = FnvIndexSet::<_, 16>::new();
     ///
     /// assert_eq!(set.insert(2).unwrap(), true);
     /// assert_eq!(set.insert(2).unwrap(), false);
@@ -449,7 +449,7 @@ where
     /// ```
     /// use heapless::FnvIndexSet;
     ///
-    /// let mut set = FnvIndexSet::<_, usize, 16>::new();
+    /// let mut set = FnvIndexSet::<_, 16>::new();
     ///
     /// set.insert(2).unwrap();
     /// assert_eq!(set.remove(&2), true);

--- a/src/indexset.rs
+++ b/src/indexset.rs
@@ -15,7 +15,7 @@ use hash32::{BuildHasher, BuildHasherDefault, FnvHasher, Hash, Hasher};
 /// use heapless::FnvIndexSet;
 ///
 /// // A hash set with a capacity of 16 elements allocated on the stack
-/// let mut books = FnvIndexSet::<_, 16>::new();
+/// let mut books = FnvIndexSet::<_, usize, 16>::new();
 ///
 /// // Add some books.
 /// books.insert("A Dance With Dragons").unwrap();
@@ -55,7 +55,7 @@ pub type FnvIndexSet<T, U, const N: usize> = IndexSet<T, BuildHasherDefault<FnvH
 /// use heapless::FnvIndexSet;
 ///
 /// // A hash set with a capacity of 16 elements allocated on the stack
-/// let mut books = FnvIndexSet::<_, 16>::new();
+/// let mut books = FnvIndexSet::<_, usize, 16>::new();
 ///
 /// // Add some books.
 /// books.insert("A Dance With Dragons").unwrap();
@@ -111,7 +111,7 @@ where
     /// ```
     /// use heapless::FnvIndexSet;
     ///
-    /// let set = FnvIndexSet::<i32, 16>::new();
+    /// let set = FnvIndexSet::<i32, usize, 16>::new();
     /// assert_eq!(set.capacity(), 16);
     /// ```
     pub fn capacity(&self) -> usize {
@@ -125,7 +125,7 @@ where
     /// ```
     /// use heapless::FnvIndexSet;
     ///
-    /// let mut set = FnvIndexSet::<_, 16>::new();
+    /// let mut set = FnvIndexSet::<_, usize, 16>::new();
     /// set.insert("a").unwrap();
     /// set.insert("b").unwrap();
     ///
@@ -148,21 +148,21 @@ where
     /// ```
     /// use heapless::FnvIndexSet;
     ///
-    /// let mut a: FnvIndexSet<_, 16> = [1, 2, 3].iter().cloned().collect();
-    /// let mut b: FnvIndexSet<_, 16> = [4, 2, 3, 4].iter().cloned().collect();
+    /// let mut a: FnvIndexSet<_, usize, 16> = [1, 2, 3].iter().cloned().collect();
+    /// let mut b: FnvIndexSet<_, usize, 16> = [4, 2, 3, 4].iter().cloned().collect();
     ///
     /// // Can be seen as `a - b`.
     /// for x in a.difference(&b) {
     ///     println!("{}", x); // Print 1
     /// }
     ///
-    /// let diff: FnvIndexSet<_, 16> = a.difference(&b).collect();
-    /// assert_eq!(diff, [1].iter().collect::<FnvIndexSet<_, 16>>());
+    /// let diff: FnvIndexSet<_, usize, 16> = a.difference(&b).collect();
+    /// assert_eq!(diff, [1].iter().collect::<FnvIndexSet<_, usize, 16>>());
     ///
     /// // Note that difference is not symmetric,
     /// // and `b - a` means something else:
-    /// let diff: FnvIndexSet<_, 16> = b.difference(&a).collect();
-    /// assert_eq!(diff, [4].iter().collect::<FnvIndexSet<_, 16>>());
+    /// let diff: FnvIndexSet<_, usize, 16> = b.difference(&a).collect();
+    /// assert_eq!(diff, [4].iter().collect::<FnvIndexSet<_, usize, 16>>());
     /// ```
     pub fn difference<'a, S2, U2: Uxx, const N2: usize>(
         &'a self,
@@ -185,19 +185,19 @@ where
     /// ```
     /// use heapless::FnvIndexSet;
     ///
-    /// let mut a: FnvIndexSet<_, 16> = [1, 2, 3].iter().cloned().collect();
-    /// let mut b: FnvIndexSet<_, 16> = [4, 2, 3, 4].iter().cloned().collect();
+    /// let mut a: FnvIndexSet<_, usize, 16> = [1, 2, 3].iter().cloned().collect();
+    /// let mut b: FnvIndexSet<_, usize, 16> = [4, 2, 3, 4].iter().cloned().collect();
     ///
     /// // Print 1, 4 in that order order.
     /// for x in a.symmetric_difference(&b) {
     ///     println!("{}", x);
     /// }
     ///
-    /// let diff1: FnvIndexSet<_, 16> = a.symmetric_difference(&b).collect();
-    /// let diff2: FnvIndexSet<_, 16> = b.symmetric_difference(&a).collect();
+    /// let diff1: FnvIndexSet<_, usize, 16> = a.symmetric_difference(&b).collect();
+    /// let diff2: FnvIndexSet<_, usize, 16> = b.symmetric_difference(&a).collect();
     ///
     /// assert_eq!(diff1, diff2);
-    /// assert_eq!(diff1, [1, 4].iter().collect::<FnvIndexSet<_, 16>>());
+    /// assert_eq!(diff1, [1, 4].iter().collect::<FnvIndexSet<_, usize, 16>>());
     /// ```
     pub fn symmetric_difference<'a, S2, U2: Uxx, const N2: usize>(
         &'a self,
@@ -217,16 +217,16 @@ where
     /// ```
     /// use heapless::FnvIndexSet;
     ///
-    /// let mut a: FnvIndexSet<_, 16> = [1, 2, 3].iter().cloned().collect();
-    /// let mut b: FnvIndexSet<_, 16> = [4, 2, 3, 4].iter().cloned().collect();
+    /// let mut a: FnvIndexSet<_, usize, 16> = [1, 2, 3].iter().cloned().collect();
+    /// let mut b: FnvIndexSet<_, usize, 16> = [4, 2, 3, 4].iter().cloned().collect();
     ///
     /// // Print 2, 3 in that order.
     /// for x in a.intersection(&b) {
     ///     println!("{}", x);
     /// }
     ///
-    /// let intersection: FnvIndexSet<_, 16> = a.intersection(&b).collect();
-    /// assert_eq!(intersection, [2, 3].iter().collect::<FnvIndexSet<_, 16>>());
+    /// let intersection: FnvIndexSet<_, usize, 16> = a.intersection(&b).collect();
+    /// assert_eq!(intersection, [2, 3].iter().collect::<FnvIndexSet<_, usize, 16>>());
     /// ```
     pub fn intersection<'a, S2, U2: Uxx, const N2: usize>(
         &'a self,
@@ -249,16 +249,16 @@ where
     /// ```
     /// use heapless::FnvIndexSet;
     ///
-    /// let mut a: FnvIndexSet<_, 16> = [1, 2, 3].iter().cloned().collect();
-    /// let mut b: FnvIndexSet<_, 16> = [4, 2, 3, 4].iter().cloned().collect();
+    /// let mut a: FnvIndexSet<_, usize, 16> = [1, 2, 3].iter().cloned().collect();
+    /// let mut b: FnvIndexSet<_, usize, 16> = [4, 2, 3, 4].iter().cloned().collect();
     ///
     /// // Print 1, 2, 3, 4 in that order.
     /// for x in a.union(&b) {
     ///     println!("{}", x);
     /// }
     ///
-    /// let union: FnvIndexSet<_, 16> = a.union(&b).collect();
-    /// assert_eq!(union, [1, 2, 3, 4].iter().collect::<FnvIndexSet<_, 16>>());
+    /// let union: FnvIndexSet<_, usize, 16> = a.union(&b).collect();
+    /// assert_eq!(union, [1, 2, 3, 4].iter().collect::<FnvIndexSet<_, usize, 16>>());
     /// ```
     pub fn union<'a, S2, U2: Uxx, const N2: usize>(
         &'a self,
@@ -277,7 +277,7 @@ where
     /// ```
     /// use heapless::FnvIndexSet;
     ///
-    /// let mut v: FnvIndexSet<_, 16> = FnvIndexSet::new();
+    /// let mut v: FnvIndexSet<_, usize, 16> = FnvIndexSet::new();
     /// assert_eq!(v.len(), 0);
     /// v.insert(1).unwrap();
     /// assert_eq!(v.len(), 1);
@@ -293,7 +293,7 @@ where
     /// ```
     /// use heapless::FnvIndexSet;
     ///
-    /// let mut v: FnvIndexSet<_, 16> = FnvIndexSet::new();
+    /// let mut v: FnvIndexSet<_, usize, 16> = FnvIndexSet::new();
     /// assert!(v.is_empty());
     /// v.insert(1).unwrap();
     /// assert!(!v.is_empty());
@@ -309,7 +309,7 @@ where
     /// ```
     /// use heapless::FnvIndexSet;
     ///
-    /// let mut v: FnvIndexSet<_, 16> = FnvIndexSet::new();
+    /// let mut v: FnvIndexSet<_, usize, 16> = FnvIndexSet::new();
     /// v.insert(1).unwrap();
     /// v.clear();
     /// assert!(v.is_empty());
@@ -328,7 +328,7 @@ where
     /// ```
     /// use heapless::FnvIndexSet;
     ///
-    /// let set: FnvIndexSet<_, 16> = [1, 2, 3].iter().cloned().collect();
+    /// let set: FnvIndexSet<_, usize, 16> = [1, 2, 3].iter().cloned().collect();
     /// assert_eq!(set.contains(&1), true);
     /// assert_eq!(set.contains(&4), false);
     /// ```
@@ -348,8 +348,8 @@ where
     /// ```
     /// use heapless::FnvIndexSet;
     ///
-    /// let a: FnvIndexSet<_, 16> = [1, 2, 3].iter().cloned().collect();
-    /// let mut b = FnvIndexSet::<_, 16>::new();
+    /// let a: FnvIndexSet<_, usize, 16> = [1, 2, 3].iter().cloned().collect();
+    /// let mut b = FnvIndexSet::<_, usize, 16>::new();
     ///
     /// assert_eq!(a.is_disjoint(&b), true);
     /// b.insert(4).unwrap();
@@ -372,8 +372,8 @@ where
     /// ```
     /// use heapless::FnvIndexSet;
     ///
-    /// let sup: FnvIndexSet<_, 16> = [1, 2, 3].iter().cloned().collect();
-    /// let mut set = FnvIndexSet::<_, 16>::new();
+    /// let sup: FnvIndexSet<_, usize, 16> = [1, 2, 3].iter().cloned().collect();
+    /// let mut set = FnvIndexSet::<_, usize, 16>::new();
     ///
     /// assert_eq!(set.is_subset(&sup), true);
     /// set.insert(2).unwrap();
@@ -396,8 +396,8 @@ where
     /// ```
     /// use heapless::FnvIndexSet;
     ///
-    /// let sub: FnvIndexSet<_, 16> = [1, 2].iter().cloned().collect();
-    /// let mut set = FnvIndexSet::<_, 16>::new();
+    /// let sub: FnvIndexSet<_, usize, 16> = [1, 2].iter().cloned().collect();
+    /// let mut set = FnvIndexSet::<_, usize, 16>::new();
     ///
     /// assert_eq!(set.is_superset(&sub), false);
     ///
@@ -426,7 +426,7 @@ where
     /// ```
     /// use heapless::FnvIndexSet;
     ///
-    /// let mut set = FnvIndexSet::<_, 16>::new();
+    /// let mut set = FnvIndexSet::<_, usize, 16>::new();
     ///
     /// assert_eq!(set.insert(2).unwrap(), true);
     /// assert_eq!(set.insert(2).unwrap(), false);
@@ -449,7 +449,7 @@ where
     /// ```
     /// use heapless::FnvIndexSet;
     ///
-    /// let mut set = FnvIndexSet::<_, 16>::new();
+    /// let mut set = FnvIndexSet::<_, usize, 16>::new();
     ///
     /// set.insert(2).unwrap();
     /// assert_eq!(set.remove(&2), true);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,12 +12,12 @@
 //! use heapless::Vec; // fixed capacity `std::Vec`
 //!
 //! // on the stack
-//! let mut xs: Vec<u8, usize, 8> = Vec::new(); // can hold up to 8 elements
+//! let mut xs: Vec<u8, 8> = Vec::new(); // can hold up to 8 elements
 //! xs.push(42).unwrap();
 //! assert_eq!(xs.pop(), Some(42));
 //!
 //! // in a `static` variable
-//! static mut XS: Vec<u8, usize, 8> = Vec::new();
+//! static mut XS: Vec<u8, 8> = Vec::new();
 //!
 //! let xs = unsafe { &mut XS };
 //!
@@ -25,7 +25,7 @@
 //! assert_eq!(xs.pop(), Some(42));
 //!
 //! // in the heap (though kind of pointless because no reallocation)
-//! let mut ys: Box<Vec<u8, usize, 8>> = Box::new(Vec::new());
+//! let mut ys: Box<Vec<u8, 8>> = Box::new(Vec::new());
 //! ys.push(42).unwrap();
 //! assert_eq!(ys.pop(), Some(42));
 //! ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,13 +43,13 @@
 //!
 //! List of currently implemented data structures:
 //!
-//! - [`BinaryHeap`](binary_heap/struct.BinaryHeap.html) -- priority queue
-//! - [`IndexMap`](struct.IndexMap.html) -- hash table
-//! - [`IndexSet`](struct.IndexSet.html) -- hash set
-//! - [`LinearMap`](struct.LinearMap.html)
+//! - [`BinaryHeap`](binary_heap/struct.BinaryHeapBase.html) -- priority queue
+//! - [`IndexMap`](struct.IndexMapBase.html) -- hash table
+//! - [`IndexSet`](struct.IndexSetBase.html) -- hash set
+//! - [`LinearMap`](struct.LinearMapBase.html)
 //! - [`Pool`](pool/struct.Pool.html) -- lock-free memory pool
-//! - [`String`](struct.String.html)
-//! - [`Vec`](struct.Vec.html)
+//! - [`String`](struct.StringBase.html)
+//! - [`Vec`](struct.VecBase.html)
 //! - [`mpmc::Q*`](mpmc/index.html) -- multiple producer multiple consumer lock-free queue
 //! - [`spsc::Queue`](spsc/struct.Queue.html) -- single producer single consumer lock-free queue
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,12 +12,12 @@
 //! use heapless::Vec; // fixed capacity `std::Vec`
 //!
 //! // on the stack
-//! let mut xs: Vec<u8, 8> = Vec::new(); // can hold up to 8 elements
+//! let mut xs: Vec<u8, usize, 8> = Vec::new(); // can hold up to 8 elements
 //! xs.push(42).unwrap();
 //! assert_eq!(xs.pop(), Some(42));
 //!
 //! // in a `static` variable
-//! static mut XS: Vec<u8, 8> = Vec::new();
+//! static mut XS: Vec<u8, usize, 8> = Vec::new();
 //!
 //! let xs = unsafe { &mut XS };
 //!
@@ -25,7 +25,7 @@
 //! assert_eq!(xs.pop(), Some(42));
 //!
 //! // in the heap (though kind of pointless because no reallocation)
-//! let mut ys: Box<Vec<u8, 8>> = Box::new(Vec::new());
+//! let mut ys: Box<Vec<u8, usize, 8>> = Box::new(Vec::new());
 //! ys.push(42).unwrap();
 //! assert_eq!(ys.pop(), Some(42));
 //! ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,13 +72,13 @@
 #![deny(rust_2018_idioms)]
 #![deny(warnings)]
 
-pub use binary_heap::BinaryHeap;
+pub use binary_heap::{BinaryHeap, BinaryHeapBase};
 pub use histbuf::HistoryBuffer;
-pub use indexmap::{Bucket, FnvIndexMap, IndexMap, Pos};
-pub use indexset::{FnvIndexSet, IndexSet};
-pub use linear_map::LinearMap;
-pub use string::String;
-pub use vec::Vec;
+pub use indexmap::{Bucket, FnvIndexMap, FnvIndexMapBase, IndexMap, IndexMapBase, Pos};
+pub use indexset::{FnvIndexSet, FnvIndexSetBase, IndexSet, IndexSetBase};
+pub use linear_map::{LinearMap, LinearMapBase};
+pub use string::{String, StringBase};
+pub use vec::{Vec, VecBase};
 
 // NOTE this code was last ported from v0.4.1 of the indexmap crate
 mod histbuf;

--- a/src/linear_map.rs
+++ b/src/linear_map.rs
@@ -38,10 +38,10 @@ impl<K, V, const N: usize> LinearMap<K, V, N> {
     /// use heapless::LinearMap;
     ///
     /// // allocate the map on the stack
-    /// let mut map: LinearMap<&str, isize, _, 8> = LinearMap::new();
+    /// let mut map: LinearMap<&str, isize, 8> = LinearMap::new();
     ///
     /// // allocate the map in a static variable
-    /// static mut MAP: LinearMap<&str, isize, usize, 8> = LinearMap::new();
+    /// static mut MAP: LinearMap<&str, isize, 8> = LinearMap::new();
     /// ```
     pub const fn new() -> Self {
         Self {

--- a/src/linear_map.rs
+++ b/src/linear_map.rs
@@ -9,6 +9,7 @@ pub struct LinearMapBase<K, V, U: Uxx, const N: usize> {
     pub(crate) buffer: VecBase<(K, V), U, N>,
 }
 
+/// A `LinearMapBase` with a length type of `usize`.
 pub type LinearMap<K, V, const N: usize> = LinearMapBase<K, V, usize, N>;
 
 macro_rules! impl_new {

--- a/src/linear_map.rs
+++ b/src/linear_map.rs
@@ -58,7 +58,7 @@ where
     /// ```
     /// use heapless::LinearMap;
     ///
-    /// let map: LinearMap<&str, isize, usize, 8> = LinearMap::new();
+    /// let map: LinearMap<&str, isize, 8> = LinearMap::new();
     /// assert_eq!(map.capacity(), 8);
     /// ```
     pub fn capacity(&self) -> usize {
@@ -74,7 +74,7 @@ where
     /// ```
     /// use heapless::LinearMap;
     ///
-    /// let mut map: LinearMap<_, _, usize, 8> = LinearMap::new();
+    /// let mut map: LinearMap<_, _, 8> = LinearMap::new();
     /// map.insert(1, "a").unwrap();
     /// map.clear();
     /// assert!(map.is_empty());
@@ -92,7 +92,7 @@ where
     /// ```
     /// use heapless::LinearMap;
     ///
-    /// let mut map: LinearMap<_, _, usize, 8> = LinearMap::new();
+    /// let mut map: LinearMap<_, _, 8> = LinearMap::new();
     /// map.insert(1, "a").unwrap();
     /// assert_eq!(map.contains_key(&1), true);
     /// assert_eq!(map.contains_key(&2), false);
@@ -110,7 +110,7 @@ where
     /// ```
     /// use heapless::LinearMap;
     ///
-    /// let mut map: LinearMap<_, _, usize, 8> = LinearMap::new();
+    /// let mut map: LinearMap<_, _, 8> = LinearMap::new();
     /// map.insert(1, "a").unwrap();
     /// assert_eq!(map.get(&1), Some(&"a"));
     /// assert_eq!(map.get(&2), None);
@@ -134,7 +134,7 @@ where
     /// ```
     /// use heapless::LinearMap;
     ///
-    /// let mut map: LinearMap<_, _, usize, 8> = LinearMap::new();
+    /// let mut map: LinearMap<_, _, 8> = LinearMap::new();
     /// map.insert(1, "a").unwrap();
     /// if let Some(x) = map.get_mut(&1) {
     ///     *x = "b";
@@ -160,7 +160,7 @@ where
     /// ```
     /// use heapless::LinearMap;
     ///
-    /// let mut a: LinearMap<_, _, usize, 8> = LinearMap::new();
+    /// let mut a: LinearMap<_, _, 8> = LinearMap::new();
     /// assert_eq!(a.len(), 0);
     /// a.insert(1, "a").unwrap();
     /// assert_eq!(a.len(), 1);
@@ -182,7 +182,7 @@ where
     /// ```
     /// use heapless::LinearMap;
     ///
-    /// let mut map: LinearMap<_, _, usize, 8> = LinearMap::new();
+    /// let mut map: LinearMap<_, _, 8> = LinearMap::new();
     /// assert_eq!(map.insert(37, "a").unwrap(), None);
     /// assert_eq!(map.is_empty(), false);
     ///
@@ -209,7 +209,7 @@ where
     /// ```
     /// use heapless::LinearMap;
     ///
-    /// let mut a: LinearMap<_, _, usize, 8> = LinearMap::new();
+    /// let mut a: LinearMap<_, _, 8> = LinearMap::new();
     /// assert!(a.is_empty());
     /// a.insert(1, "a").unwrap();
     /// assert!(!a.is_empty());
@@ -225,7 +225,7 @@ where
     /// ```
     /// use heapless::LinearMap;
     ///
-    /// let mut map: LinearMap<_, _, usize, 8> = LinearMap::new();
+    /// let mut map: LinearMap<_, _, 8> = LinearMap::new();
     /// map.insert("a", 1).unwrap();
     /// map.insert("b", 2).unwrap();
     /// map.insert("c", 3).unwrap();
@@ -248,7 +248,7 @@ where
     /// ```
     /// use heapless::LinearMap;
     ///
-    /// let mut map: LinearMap<_, _, usize, 8> = LinearMap::new();
+    /// let mut map: LinearMap<_, _, 8> = LinearMap::new();
     /// map.insert("a", 1).unwrap();
     /// map.insert("b", 2).unwrap();
     /// map.insert("c", 3).unwrap();
@@ -275,7 +275,7 @@ where
     /// ```
     /// use heapless::LinearMap;
     ///
-    /// let mut map: LinearMap<_, _, usize, 8> = LinearMap::new();
+    /// let mut map: LinearMap<_, _, 8> = LinearMap::new();
     /// map.insert("a", 1).unwrap();
     /// map.insert("b", 2).unwrap();
     /// map.insert("c", 3).unwrap();
@@ -298,7 +298,7 @@ where
     /// ```
     /// use heapless::LinearMap;
     ///
-    /// let mut map: LinearMap<_, _, usize, 8> = LinearMap::new();
+    /// let mut map: LinearMap<_, _, 8> = LinearMap::new();
     /// map.insert(1, "a").unwrap();
     /// assert_eq!(map.remove(&1), Some("a"));
     /// assert_eq!(map.remove(&1), None);
@@ -324,7 +324,7 @@ where
     /// ```
     /// use heapless::LinearMap;
     ///
-    /// let mut map: LinearMap<_, _, usize, 8> = LinearMap::new();
+    /// let mut map: LinearMap<_, _, 8> = LinearMap::new();
     /// map.insert("a", 1).unwrap();
     /// map.insert("b", 2).unwrap();
     /// map.insert("c", 3).unwrap();
@@ -344,7 +344,7 @@ where
     /// ```
     /// use heapless::LinearMap;
     ///
-    /// let mut map: LinearMap<_, _, usize, 8> = LinearMap::new();
+    /// let mut map: LinearMap<_, _, 8> = LinearMap::new();
     /// map.insert("a", 1).unwrap();
     /// map.insert("b", 2).unwrap();
     /// map.insert("c", 3).unwrap();
@@ -528,16 +528,16 @@ mod test {
 
     #[test]
     fn static_new() {
-        static mut _L: LinearMap<i32, i32, usize, 8> = LinearMap::new();
+        static mut _L: LinearMap<i32, i32, 8> = LinearMap::new();
     }
 
     #[test]
     fn partial_eq() {
         {
-            let mut a = LinearMap::<_, _, usize, 1>::new();
+            let mut a = LinearMap::<_, _, 1>::new();
             a.insert("k1", "v1").unwrap();
 
-            let mut b = LinearMap::<_, _, usize, 2>::new();
+            let mut b = LinearMap::<_, _, 2>::new();
             b.insert("k1", "v1").unwrap();
 
             assert!(a == b);
@@ -548,11 +548,11 @@ mod test {
         }
 
         {
-            let mut a = LinearMap::<_, _, usize, 2>::new();
+            let mut a = LinearMap::<_, _, 2>::new();
             a.insert("k1", "v1").unwrap();
             a.insert("k2", "v2").unwrap();
 
-            let mut b = LinearMap::<_, _, usize, 2>::new();
+            let mut b = LinearMap::<_, _, 2>::new();
             b.insert("k2", "v2").unwrap();
             b.insert("k1", "v1").unwrap();
 

--- a/src/linear_map.rs
+++ b/src/linear_map.rs
@@ -13,9 +13,9 @@ pub struct LinearMapBase<K, V, U: Uxx, const N: usize> {
 pub type LinearMap<K, V, const N: usize> = LinearMapBase<K, V, usize, N>;
 
 macro_rules! impl_new {
-    ($Uxx:ident, $name:ident) => {
+    ($Uxx:ident, $name:ident, $doc:tt) => {
         impl<K, V, const N: usize> LinearMapBase<K, V, $Uxx, N> {
-            /// Creates an empty `LinearMap`
+            #[doc = $doc]
             pub const fn $name() -> Self {
                 Self {
                     buffer: VecBase::$name(),
@@ -25,9 +25,16 @@ macro_rules! impl_new {
     };
 }
 
-impl_new!(u8, u8);
-impl_new!(u16, u16);
-impl_new!(usize, usize);
+impl_new!(
+    u8,
+    u8,
+    "Creates an empty `LinearMap`. **Safety**: Assumes `N <= u8::MAX`."
+);
+impl_new!(
+    u16,
+    u16,
+    "Creates an empty `LinearMap`. **Safety**: Assumes `N <= u16::MAX`."
+);
 
 impl<K, V, const N: usize> LinearMap<K, V, N> {
     /// Creates an empty `LinearMap` with length type of `usize`

--- a/src/linear_map.rs
+++ b/src/linear_map.rs
@@ -1,15 +1,15 @@
-use crate::Vec;
+use crate::{sealed::spsc::Uxx, Vec};
 use core::{borrow::Borrow, fmt, iter::FromIterator, mem, ops, slice};
 
 /// A fixed capacity map / dictionary that performs lookups via linear search
 ///
 /// Note that as this map doesn't use hashing so most operations are **O(N)** instead of O(1)
 
-pub struct LinearMap<K, V, const N: usize> {
-    pub(crate) buffer: Vec<(K, V), N>,
+pub struct LinearMap<K, V, U: Uxx, const N: usize> {
+    pub(crate) buffer: Vec<(K, V), U, N>,
 }
 
-impl<K, V, const N: usize> LinearMap<K, V, N> {
+impl<K, V, U: Uxx, const N: usize> LinearMap<K, V, U, N> {
     /// Creates an empty `LinearMap`
     ///
     /// # Examples
@@ -28,7 +28,7 @@ impl<K, V, const N: usize> LinearMap<K, V, N> {
     }
 }
 
-impl<K, V, const N: usize> LinearMap<K, V, N>
+impl<K, V, U: Uxx, const N: usize> LinearMap<K, V, U, N>
 where
     K: Eq,
 {
@@ -345,7 +345,7 @@ where
     }
 }
 
-impl<'a, K, V, Q, const N: usize> ops::Index<&'a Q> for LinearMap<K, V, N>
+impl<'a, K, V, Q, U: Uxx, const N: usize> ops::Index<&'a Q> for LinearMap<K, V, U, N>
 where
     K: Borrow<Q> + Eq,
     Q: Eq + ?Sized,
@@ -357,7 +357,7 @@ where
     }
 }
 
-impl<'a, K, V, Q, const N: usize> ops::IndexMut<&'a Q> for LinearMap<K, V, N>
+impl<'a, K, V, Q, U: Uxx, const N: usize> ops::IndexMut<&'a Q> for LinearMap<K, V, U, N>
 where
     K: Borrow<Q> + Eq,
     Q: Eq + ?Sized,
@@ -367,7 +367,7 @@ where
     }
 }
 
-impl<K, V, const N: usize> Default for LinearMap<K, V, N>
+impl<K, V, U: Uxx, const N: usize> Default for LinearMap<K, V, U, N>
 where
     K: Eq,
 {
@@ -376,7 +376,7 @@ where
     }
 }
 
-impl<K, V, const N: usize> Clone for LinearMap<K, V, N>
+impl<K, V, U: Uxx, const N: usize> Clone for LinearMap<K, V, U, N>
 where
     K: Eq + Clone,
     V: Clone,
@@ -388,7 +388,7 @@ where
     }
 }
 
-impl<K, V, const N: usize> fmt::Debug for LinearMap<K, V, N>
+impl<K, V, U: Uxx, const N: usize> fmt::Debug for LinearMap<K, V, U, N>
 where
     K: Eq + fmt::Debug,
     V: fmt::Debug,
@@ -398,7 +398,7 @@ where
     }
 }
 
-impl<K, V, const N: usize> FromIterator<(K, V)> for LinearMap<K, V, N>
+impl<K, V, U: Uxx, const N: usize> FromIterator<(K, V)> for LinearMap<K, V, U, N>
 where
     K: Eq,
 {
@@ -412,14 +412,14 @@ where
     }
 }
 
-pub struct IntoIter<K, V, const N: usize>
+pub struct IntoIter<K, V, U: Uxx, const N: usize>
 where
     K: Eq,
 {
-    inner: <Vec<(K, V), N> as IntoIterator>::IntoIter,
+    inner: <Vec<(K, V), U, N> as IntoIterator>::IntoIter,
 }
 
-impl<K, V, const N: usize> Iterator for IntoIter<K, V, N>
+impl<K, V, U: Uxx, const N: usize> Iterator for IntoIter<K, V, U, N>
 where
     K: Eq,
 {
@@ -429,7 +429,7 @@ where
     }
 }
 
-impl<'a, K, V, const N: usize> IntoIterator for &'a LinearMap<K, V, N>
+impl<'a, K, V, U: Uxx, const N: usize> IntoIterator for &'a LinearMap<K, V, U, N>
 where
     K: Eq,
 {
@@ -461,7 +461,7 @@ impl<'a, K, V> Clone for Iter<'a, K, V> {
     }
 }
 
-impl<K, V, const N: usize> Drop for LinearMap<K, V, N> {
+impl<K, V, U: Uxx, const N: usize> Drop for LinearMap<K, V, U, N> {
     fn drop(&mut self) {
         // heapless::Vec implements drop right?
         drop(&self.buffer);
@@ -482,12 +482,13 @@ impl<'a, K, V> Iterator for IterMut<'a, K, V> {
     }
 }
 
-impl<K, V, const N: usize, const N2: usize> PartialEq<LinearMap<K, V, N2>> for LinearMap<K, V, N>
+impl<K, V, U: Uxx, U2: Uxx, const N: usize, const N2: usize> PartialEq<LinearMap<K, V, U2, N2>>
+    for LinearMap<K, V, U, N>
 where
     K: Eq,
     V: PartialEq,
 {
-    fn eq(&self, other: &LinearMap<K, V, N2>) -> bool {
+    fn eq(&self, other: &LinearMap<K, V, U2, N2>) -> bool {
         self.len() == other.len()
             && self
                 .iter()
@@ -495,7 +496,7 @@ where
     }
 }
 
-impl<K, V, const N: usize> Eq for LinearMap<K, V, N>
+impl<K, V, U: Uxx, const N: usize> Eq for LinearMap<K, V, U, N>
 where
     K: Eq,
     V: PartialEq,

--- a/src/linear_map.rs
+++ b/src/linear_map.rs
@@ -9,24 +9,35 @@ pub struct LinearMap<K, V, U: Uxx, const N: usize> {
     pub(crate) buffer: Vec<(K, V), U, N>,
 }
 
-impl<K, V, U: Uxx, const N: usize> LinearMap<K, V, U, N> {
-    /// Creates an empty `LinearMap`
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use heapless::LinearMap;
-    ///
-    /// // allocate the map on the stack
-    /// let mut map: LinearMap<&str, isize, 8> = LinearMap::new();
-    ///
-    /// // allocate the map in a static variable
-    /// static mut MAP: LinearMap<&str, isize, 8> = LinearMap::new();
-    /// ```
-    pub const fn new() -> Self {
-        Self { buffer: Vec::new() }
-    }
+macro_rules! impl_new {
+    ($Uxx:ident, $name:ident) => {
+        impl<K, V, const N: usize> LinearMap<K, V, $Uxx, N> {
+            /// Creates an empty `LinearMap`
+            ///
+            /// # Examples
+            ///
+            /// ```
+            /// use heapless::LinearMap;
+            ///
+            /// // allocate the map on the stack
+            /// let mut map: LinearMap<&str, isize, $Uxx, 8> = LinearMap::$name();
+            ///
+            /// // allocate the map in a static variable
+            /// static mut MAP: LinearMap<&str, isize, $Uxx, 8> = LinearMap::$name();
+            /// ```
+            pub const fn $name() -> Self {
+                Self {
+                    buffer: Vec::$name(),
+                }
+            }
+        }
+    };
 }
+
+impl_new!(u8, u8);
+impl_new!(u16, u16);
+impl_new!(usize, usize);
+impl_new!(usize, new);
 
 impl<K, V, U: Uxx, const N: usize> LinearMap<K, V, U, N>
 where
@@ -372,7 +383,9 @@ where
     K: Eq,
 {
     fn default() -> Self {
-        Self::new()
+        Self {
+            buffer: Vec::default(),
+        }
     }
 }
 
@@ -406,7 +419,7 @@ where
     where
         I: IntoIterator<Item = (K, V)>,
     {
-        let mut out = Self::new();
+        let mut out = Self::default();
         out.buffer.extend(iter);
         out
     }

--- a/src/linear_map.rs
+++ b/src/linear_map.rs
@@ -13,18 +13,6 @@ macro_rules! impl_new {
     ($Uxx:ident, $name:ident) => {
         impl<K, V, const N: usize> LinearMap<K, V, $Uxx, N> {
             /// Creates an empty `LinearMap`
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// use heapless::LinearMap;
-            ///
-            /// // allocate the map on the stack
-            /// let mut map: LinearMap<&str, isize, $Uxx, 8> = LinearMap::$name();
-            ///
-            /// // allocate the map in a static variable
-            /// static mut MAP: LinearMap<&str, isize, $Uxx, 8> = LinearMap::$name();
-            /// ```
             pub const fn $name() -> Self {
                 Self {
                     buffer: Vec::$name(),
@@ -37,7 +25,25 @@ macro_rules! impl_new {
 impl_new!(u8, u8);
 impl_new!(u16, u16);
 impl_new!(usize, usize);
-impl_new!(usize, new);
+
+impl<K, V, const N: usize> LinearMap<K, V, usize, N> {
+    /// Creates an empty `LinearMap` with length type of `usize`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use heapless::LinearMap;
+    ///
+    /// // allocate the map on the stack
+    /// let mut map: LinearMap<&str, isize, _, 8> = LinearMap::new();
+    ///
+    /// // allocate the map in a static variable
+    /// static mut MAP: LinearMap<&str, isize, usize, 8> = LinearMap::new();
+    /// ```
+    pub const fn new() -> Self {
+        Self { buffer: Vec::new() }
+    }
+}
 
 impl<K, V, U: Uxx, const N: usize> LinearMap<K, V, U, N>
 where

--- a/src/linear_map.rs
+++ b/src/linear_map.rs
@@ -52,7 +52,7 @@ where
     /// ```
     /// use heapless::LinearMap;
     ///
-    /// let map: LinearMap<&str, isize, 8> = LinearMap::new();
+    /// let map: LinearMap<&str, isize, usize, 8> = LinearMap::new();
     /// assert_eq!(map.capacity(), 8);
     /// ```
     pub fn capacity(&self) -> usize {
@@ -68,7 +68,7 @@ where
     /// ```
     /// use heapless::LinearMap;
     ///
-    /// let mut map: LinearMap<_, _, 8> = LinearMap::new();
+    /// let mut map: LinearMap<_, _, usize, 8> = LinearMap::new();
     /// map.insert(1, "a").unwrap();
     /// map.clear();
     /// assert!(map.is_empty());
@@ -86,7 +86,7 @@ where
     /// ```
     /// use heapless::LinearMap;
     ///
-    /// let mut map: LinearMap<_, _, 8> = LinearMap::new();
+    /// let mut map: LinearMap<_, _, usize, 8> = LinearMap::new();
     /// map.insert(1, "a").unwrap();
     /// assert_eq!(map.contains_key(&1), true);
     /// assert_eq!(map.contains_key(&2), false);
@@ -104,7 +104,7 @@ where
     /// ```
     /// use heapless::LinearMap;
     ///
-    /// let mut map: LinearMap<_, _, 8> = LinearMap::new();
+    /// let mut map: LinearMap<_, _, usize, 8> = LinearMap::new();
     /// map.insert(1, "a").unwrap();
     /// assert_eq!(map.get(&1), Some(&"a"));
     /// assert_eq!(map.get(&2), None);
@@ -128,7 +128,7 @@ where
     /// ```
     /// use heapless::LinearMap;
     ///
-    /// let mut map: LinearMap<_, _, 8> = LinearMap::new();
+    /// let mut map: LinearMap<_, _, usize, 8> = LinearMap::new();
     /// map.insert(1, "a").unwrap();
     /// if let Some(x) = map.get_mut(&1) {
     ///     *x = "b";
@@ -154,7 +154,7 @@ where
     /// ```
     /// use heapless::LinearMap;
     ///
-    /// let mut a: LinearMap<_, _, 8> = LinearMap::new();
+    /// let mut a: LinearMap<_, _, usize, 8> = LinearMap::new();
     /// assert_eq!(a.len(), 0);
     /// a.insert(1, "a").unwrap();
     /// assert_eq!(a.len(), 1);
@@ -176,7 +176,7 @@ where
     /// ```
     /// use heapless::LinearMap;
     ///
-    /// let mut map: LinearMap<_, _, 8> = LinearMap::new();
+    /// let mut map: LinearMap<_, _, usize, 8> = LinearMap::new();
     /// assert_eq!(map.insert(37, "a").unwrap(), None);
     /// assert_eq!(map.is_empty(), false);
     ///
@@ -203,7 +203,7 @@ where
     /// ```
     /// use heapless::LinearMap;
     ///
-    /// let mut a: LinearMap<_, _, 8> = LinearMap::new();
+    /// let mut a: LinearMap<_, _, usize, 8> = LinearMap::new();
     /// assert!(a.is_empty());
     /// a.insert(1, "a").unwrap();
     /// assert!(!a.is_empty());
@@ -219,7 +219,7 @@ where
     /// ```
     /// use heapless::LinearMap;
     ///
-    /// let mut map: LinearMap<_, _, 8> = LinearMap::new();
+    /// let mut map: LinearMap<_, _, usize, 8> = LinearMap::new();
     /// map.insert("a", 1).unwrap();
     /// map.insert("b", 2).unwrap();
     /// map.insert("c", 3).unwrap();
@@ -242,7 +242,7 @@ where
     /// ```
     /// use heapless::LinearMap;
     ///
-    /// let mut map: LinearMap<_, _, 8> = LinearMap::new();
+    /// let mut map: LinearMap<_, _, usize, 8> = LinearMap::new();
     /// map.insert("a", 1).unwrap();
     /// map.insert("b", 2).unwrap();
     /// map.insert("c", 3).unwrap();
@@ -269,7 +269,7 @@ where
     /// ```
     /// use heapless::LinearMap;
     ///
-    /// let mut map: LinearMap<_, _, 8> = LinearMap::new();
+    /// let mut map: LinearMap<_, _, usize, 8> = LinearMap::new();
     /// map.insert("a", 1).unwrap();
     /// map.insert("b", 2).unwrap();
     /// map.insert("c", 3).unwrap();
@@ -292,7 +292,7 @@ where
     /// ```
     /// use heapless::LinearMap;
     ///
-    /// let mut map: LinearMap<_, _, 8> = LinearMap::new();
+    /// let mut map: LinearMap<_, _, usize, 8> = LinearMap::new();
     /// map.insert(1, "a").unwrap();
     /// assert_eq!(map.remove(&1), Some("a"));
     /// assert_eq!(map.remove(&1), None);
@@ -318,7 +318,7 @@ where
     /// ```
     /// use heapless::LinearMap;
     ///
-    /// let mut map: LinearMap<_, _, 8> = LinearMap::new();
+    /// let mut map: LinearMap<_, _, usize, 8> = LinearMap::new();
     /// map.insert("a", 1).unwrap();
     /// map.insert("b", 2).unwrap();
     /// map.insert("c", 3).unwrap();
@@ -338,7 +338,7 @@ where
     /// ```
     /// use heapless::LinearMap;
     ///
-    /// let mut map: LinearMap<_, _, 8> = LinearMap::new();
+    /// let mut map: LinearMap<_, _, usize, 8> = LinearMap::new();
     /// map.insert("a", 1).unwrap();
     /// map.insert("b", 2).unwrap();
     /// map.insert("c", 3).unwrap();
@@ -522,16 +522,16 @@ mod test {
 
     #[test]
     fn static_new() {
-        static mut _L: LinearMap<i32, i32, 8> = LinearMap::new();
+        static mut _L: LinearMap<i32, i32, usize, 8> = LinearMap::new();
     }
 
     #[test]
     fn partial_eq() {
         {
-            let mut a = LinearMap::<_, _, 1>::new();
+            let mut a = LinearMap::<_, _, usize, 1>::new();
             a.insert("k1", "v1").unwrap();
 
-            let mut b = LinearMap::<_, _, 2>::new();
+            let mut b = LinearMap::<_, _, usize, 2>::new();
             b.insert("k1", "v1").unwrap();
 
             assert!(a == b);
@@ -542,11 +542,11 @@ mod test {
         }
 
         {
-            let mut a = LinearMap::<_, _, 2>::new();
+            let mut a = LinearMap::<_, _, usize, 2>::new();
             a.insert("k1", "v1").unwrap();
             a.insert("k2", "v2").unwrap();
 
-            let mut b = LinearMap::<_, _, 2>::new();
+            let mut b = LinearMap::<_, _, usize, 2>::new();
             b.insert("k2", "v2").unwrap();
             b.insert("k1", "v1").unwrap();
 

--- a/src/sealed.rs
+++ b/src/sealed.rs
@@ -1,9 +1,12 @@
 /// Sealed traits and implementations for `spsc`
 pub mod spsc {
+    use core::ops::{AddAssign, SubAssign};
     #[cfg(has_atomics)]
     use core::sync::atomic::{AtomicU16, AtomicU8, AtomicUsize, Ordering};
 
-    pub unsafe trait Uxx: Into<usize> + Send {
+    pub unsafe trait Uxx:
+        Into<usize> + Send + AddAssign<Self> + SubAssign<Self> + Copy
+    {
         #[doc(hidden)]
         fn saturate(x: usize) -> Self;
 

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -1,13 +1,13 @@
 use crate::{
     sealed::{binary_heap::Kind as BinaryHeapKind, spsc::Uxx},
-    BinaryHeap, IndexMap, IndexSet, LinearMap, String, Vec,
+    BinaryHeapBase, IndexMapBase, IndexSetBase, LinearMapBase, StringBase, VecBase,
 };
 use hash32::{BuildHasher, Hash};
 use serde::ser::{Serialize, SerializeMap, SerializeSeq, Serializer};
 
 // Sequential containers
 
-impl<T, KIND, U: Uxx, const N: usize> Serialize for BinaryHeap<T, KIND, U, N>
+impl<T, KIND, U: Uxx, const N: usize> Serialize for BinaryHeapBase<T, KIND, U, N>
 where
     T: Ord + Serialize,
     KIND: BinaryHeapKind,
@@ -24,7 +24,7 @@ where
     }
 }
 
-impl<T, S, U: Uxx, const N: usize> Serialize for IndexSet<T, S, U, N>
+impl<T, S, U: Uxx, const N: usize> Serialize for IndexSetBase<T, S, U, N>
 where
     T: Eq + Hash + Serialize,
     S: BuildHasher,
@@ -41,7 +41,7 @@ where
     }
 }
 
-impl<T, U: Uxx, const N: usize> Serialize for Vec<T, U, N>
+impl<T, U: Uxx, const N: usize> Serialize for VecBase<T, U, N>
 where
     T: Serialize,
 {
@@ -59,7 +59,7 @@ where
 
 // Dictionaries
 
-impl<K, V, S, U: Uxx, const N: usize> Serialize for IndexMap<K, V, S, U, N>
+impl<K, V, S, U: Uxx, const N: usize> Serialize for IndexMapBase<K, V, S, U, N>
 where
     K: Eq + Hash + Serialize,
     S: BuildHasher,
@@ -77,7 +77,7 @@ where
     }
 }
 
-impl<K, V, U: Uxx, const N: usize> Serialize for LinearMap<K, V, U, N>
+impl<K, V, U: Uxx, const N: usize> Serialize for LinearMapBase<K, V, U, N>
 where
     K: Eq + Serialize,
     V: Serialize,
@@ -96,7 +96,7 @@ where
 
 // String containers
 
-impl<U: Uxx, const N: usize> Serialize for String<U, N> {
+impl<U: Uxx, const N: usize> Serialize for StringBase<U, N> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -1,13 +1,13 @@
 use crate::{
-    sealed::binary_heap::Kind as BinaryHeapKind, BinaryHeap, IndexMap, IndexSet, LinearMap, String,
-    Vec,
+    sealed::{binary_heap::Kind as BinaryHeapKind, spsc::Uxx},
+    BinaryHeap, IndexMap, IndexSet, LinearMap, String, Vec,
 };
 use hash32::{BuildHasher, Hash};
 use serde::ser::{Serialize, SerializeMap, SerializeSeq, Serializer};
 
 // Sequential containers
 
-impl<T, KIND, const N: usize> Serialize for BinaryHeap<T, KIND, N>
+impl<T, KIND, U: Uxx, const N: usize> Serialize for BinaryHeap<T, KIND, U, N>
 where
     T: Ord + Serialize,
     KIND: BinaryHeapKind,
@@ -24,7 +24,7 @@ where
     }
 }
 
-impl<T, S, const N: usize> Serialize for IndexSet<T, S, N>
+impl<T, S, U: Uxx, const N: usize> Serialize for IndexSet<T, S, U, N>
 where
     T: Eq + Hash + Serialize,
     S: BuildHasher,
@@ -41,7 +41,7 @@ where
     }
 }
 
-impl<T, const N: usize> Serialize for Vec<T, N>
+impl<T, U: Uxx, const N: usize> Serialize for Vec<T, U, N>
 where
     T: Serialize,
 {
@@ -59,7 +59,7 @@ where
 
 // Dictionaries
 
-impl<K, V, S, const N: usize> Serialize for IndexMap<K, V, S, N>
+impl<K, V, S, U: Uxx, const N: usize> Serialize for IndexMap<K, V, S, U, N>
 where
     K: Eq + Hash + Serialize,
     S: BuildHasher,
@@ -77,7 +77,7 @@ where
     }
 }
 
-impl<K, V, const N: usize> Serialize for LinearMap<K, V, N>
+impl<K, V, U: Uxx, const N: usize> Serialize for LinearMap<K, V, U, N>
 where
     K: Eq + Serialize,
     V: Serialize,
@@ -96,7 +96,7 @@ where
 
 // String containers
 
-impl<const N: usize> Serialize for String<N> {
+impl<U: Uxx, const N: usize> Serialize for String<U, N> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,

--- a/src/string.rs
+++ b/src/string.rs
@@ -9,6 +9,7 @@ pub struct StringBase<U: Uxx, const N: usize> {
     vec: VecBase<u8, U, N>,
 }
 
+/// A `StringBase` with a length type of `usize`.
 pub type String<const N: usize> = StringBase<usize, N>;
 
 macro_rules! impl_new {

--- a/src/string.rs
+++ b/src/string.rs
@@ -165,7 +165,7 @@ impl<U: Uxx, const N: usize> String<U, N> {
     /// ```
     #[inline]
     pub fn capacity(&self) -> usize {
-        self.vec.capacity()
+        self.vec.capacity_nonconst()
     }
 
     /// Appends the given [`char`] to the end of this `String`.

--- a/src/string.rs
+++ b/src/string.rs
@@ -52,7 +52,7 @@ impl<U: Uxx, const N: usize> String<U, N> {
     /// ```
     /// use heapless::String;
     ///
-    /// let s: String<4> = String::from("ab");
+    /// let s: String<usize, 4> = String::from("ab");
     /// let b = s.into_bytes();
     /// assert!(b.len() == 2);
     ///
@@ -72,7 +72,7 @@ impl<U: Uxx, const N: usize> String<U, N> {
     /// ```
     /// use heapless::String;
     ///
-    /// let mut s: String<4> = String::from("ab");
+    /// let mut s: String<usize, 4> = String::from("ab");
     /// assert!(s.as_str() == "ab");
     ///
     /// let _s = s.as_str();
@@ -92,7 +92,7 @@ impl<U: Uxx, const N: usize> String<U, N> {
     /// ```
     /// use heapless::String;
     ///
-    /// let mut s: String<4> = String::from("ab");
+    /// let mut s: String<usize, 4> = String::from("ab");
     /// let s = s.as_mut_str();
     /// s.make_ascii_uppercase();
     /// ```
@@ -138,7 +138,7 @@ impl<U: Uxx, const N: usize> String<U, N> {
     /// ```
     /// use heapless::String;
     ///
-    /// let mut s: String<8> = String::from("foo");
+    /// let mut s: String<usize, 8> = String::from("foo");
     ///
     /// assert!(s.push_str("bar").is_ok());
     ///
@@ -160,7 +160,7 @@ impl<U: Uxx, const N: usize> String<U, N> {
     /// ```
     /// use heapless::String;
     ///
-    /// let mut s: String<4> = String::new();
+    /// let mut s: String<usize, 4> = String::new();
     /// assert!(s.capacity() == 4);
     /// ```
     #[inline]
@@ -179,7 +179,7 @@ impl<U: Uxx, const N: usize> String<U, N> {
     /// ```
     /// use heapless::String;
     ///
-    /// let mut s: String<8> = String::from("abc");
+    /// let mut s: String<usize, 8> = String::from("abc");
     ///
     /// s.push('1').unwrap();
     /// s.push('2').unwrap();
@@ -220,7 +220,7 @@ impl<U: Uxx, const N: usize> String<U, N> {
     /// ```
     /// use heapless::String;
     ///
-    /// let mut s: String<8> = String::from("hello");
+    /// let mut s: String<usize, 8> = String::from("hello");
     ///
     /// s.truncate(2);
     ///
@@ -247,7 +247,7 @@ impl<U: Uxx, const N: usize> String<U, N> {
     /// ```
     /// use heapless::String;
     ///
-    /// let mut s: String<8> = String::from("foo");
+    /// let mut s: String<usize, 8> = String::from("foo");
     ///
     /// assert_eq!(s.pop(), Some('o'));
     /// assert_eq!(s.pop(), Some('o'));
@@ -280,7 +280,7 @@ impl<U: Uxx, const N: usize> String<U, N> {
     /// ```
     /// use heapless::String;
     ///
-    /// let mut s: String<8> = String::from("foo");
+    /// let mut s: String<usize, 8> = String::from("foo");
     ///
     /// s.clear();
     ///
@@ -514,12 +514,12 @@ mod tests {
 
     #[test]
     fn static_new() {
-        static mut _S: String<8> = String::new();
+        static mut _S: String<usize, 8> = String::new();
     }
 
     #[test]
     fn clone() {
-        let s1: String<20> = String::from("abcd");
+        let s1: String<usize, 20> = String::from("abcd");
         let mut s2 = s1.clone();
         s2.push_str(" efgh").unwrap();
 
@@ -531,7 +531,7 @@ mod tests {
     fn debug() {
         use core::fmt::Write;
 
-        let s: String<8> = String::from("abcd");
+        let s: String<usize, 8> = String::from("abcd");
         let mut std_s = std::string::String::new();
         write!(std_s, "{:?}", s).unwrap();
         assert_eq!("\"abcd\"", std_s);
@@ -541,7 +541,7 @@ mod tests {
     fn display() {
         use core::fmt::Write;
 
-        let s: String<8> = String::from("abcd");
+        let s: String<usize, 8> = String::from("abcd");
         let mut std_s = std::string::String::new();
         write!(std_s, "{}", s).unwrap();
         assert_eq!("abcd", std_s);
@@ -549,7 +549,7 @@ mod tests {
 
     #[test]
     fn empty() {
-        let s: String<4> = String::new();
+        let s: String<usize, 4> = String::new();
         assert!(s.capacity() == 4);
         assert_eq!(s, "");
         assert_eq!(s.len(), 0);
@@ -558,7 +558,7 @@ mod tests {
 
     #[test]
     fn from() {
-        let s: String<4> = String::from("123");
+        let s: String<usize, 4> = String::from("123");
         assert!(s.len() == 3);
         assert_eq!(s, "123");
     }
@@ -567,37 +567,37 @@ mod tests {
     fn from_str() {
         use core::str::FromStr;
 
-        let s: String<4> = String::<4>::from_str("123").unwrap();
+        let s: String<usize, 4> = String::<usize, 4>::from_str("123").unwrap();
         assert!(s.len() == 3);
         assert_eq!(s, "123");
 
-        let e: () = String::<2>::from_str("123").unwrap_err();
+        let e: () = String::<usize, 2>::from_str("123").unwrap_err();
         assert_eq!(e, ());
     }
 
     #[test]
     #[should_panic]
     fn from_panic() {
-        let _: String<4> = String::from("12345");
+        let _: String<usize, 4> = String::from("12345");
     }
 
     #[test]
     fn from_num() {
-        let v: String<20> = String::from(18446744073709551615 as u64);
+        let v: String<usize, 20> = String::from(18446744073709551615 as u64);
         assert_eq!(v, "18446744073709551615");
     }
 
     #[test]
     fn into_bytes() {
-        let s: String<4> = String::from("ab");
-        let b: Vec<u8, 4> = s.into_bytes();
+        let s: String<usize, 4> = String::from("ab");
+        let b: Vec<u8, usize, 4> = s.into_bytes();
         assert_eq!(b.len(), 2);
         assert_eq!(&['a' as u8, 'b' as u8], &b[..]);
     }
 
     #[test]
     fn as_str() {
-        let s: String<4> = String::from("ab");
+        let s: String<usize, 4> = String::from("ab");
 
         assert_eq!(s.as_str(), "ab");
         // should be moved to fail test
@@ -607,7 +607,7 @@ mod tests {
 
     #[test]
     fn as_mut_str() {
-        let mut s: String<4> = String::from("ab");
+        let mut s: String<usize, 4> = String::from("ab");
         let s = s.as_mut_str();
         s.make_ascii_uppercase();
         assert_eq!(s, "AB");
@@ -615,7 +615,7 @@ mod tests {
 
     #[test]
     fn push_str() {
-        let mut s: String<8> = String::from("foo");
+        let mut s: String<usize, 8> = String::from("foo");
         assert!(s.push_str("bar").is_ok());
         assert_eq!("foobar", s);
         assert_eq!(s, "foobar");
@@ -626,7 +626,7 @@ mod tests {
 
     #[test]
     fn push() {
-        let mut s: String<6> = String::from("abc");
+        let mut s: String<usize, 6> = String::from("abc");
         assert!(s.push('1').is_ok());
         assert!(s.push('2').is_ok());
         assert!(s.push('3').is_ok());
@@ -636,13 +636,13 @@ mod tests {
 
     #[test]
     fn as_bytes() {
-        let s: String<8> = String::from("hello");
+        let s: String<usize, 8> = String::from("hello");
         assert_eq!(&[104, 101, 108, 108, 111], s.as_bytes());
     }
 
     #[test]
     fn truncate() {
-        let mut s: String<8> = String::from("hello");
+        let mut s: String<usize, 8> = String::from("hello");
         s.truncate(6);
         assert_eq!(s.len(), 5);
         s.truncate(2);
@@ -653,7 +653,7 @@ mod tests {
 
     #[test]
     fn pop() {
-        let mut s: String<8> = String::from("foo");
+        let mut s: String<usize, 8> = String::from("foo");
         assert_eq!(s.pop(), Some('o'));
         assert_eq!(s.pop(), Some('o'));
         assert_eq!(s.pop(), Some('f'));
@@ -662,7 +662,7 @@ mod tests {
 
     #[test]
     fn pop_uenc() {
-        let mut s: String<8> = String::from("é");
+        let mut s: String<usize, 8> = String::from("é");
         assert_eq!(s.len(), 3);
         match s.pop() {
             Some(c) => {
@@ -676,7 +676,7 @@ mod tests {
 
     #[test]
     fn is_empty() {
-        let mut v: String<8> = String::new();
+        let mut v: String<usize, 8> = String::new();
         assert!(v.is_empty());
         let _ = v.push('a');
         assert!(!v.is_empty());
@@ -684,7 +684,7 @@ mod tests {
 
     #[test]
     fn clear() {
-        let mut s: String<8> = String::from("foo");
+        let mut s: String<usize, 8> = String::from("foo");
         s.clear();
         assert!(s.is_empty());
         assert_eq!(0, s.len());

--- a/src/string.rs
+++ b/src/string.rs
@@ -41,10 +41,10 @@ impl<const N: usize> String<N> {
     /// use heapless::String;
     ///
     /// // allocate the string on the stack
-    /// let mut s: String<_, 4> = String::new();
+    /// let mut s: String<4> = String::new();
     ///
     /// // allocate the string in a static variable
-    /// static mut S: String<usize, 4> = String::new();
+    /// static mut S: String<4> = String::new();
     /// ```
     #[inline]
     pub const fn new() -> Self {

--- a/src/string.rs
+++ b/src/string.rs
@@ -13,20 +13,6 @@ macro_rules! impl_new {
     ($Uxx:ident, $name:ident) => {
         impl<const N: usize> String<$Uxx, N> {
             /// Constructs a new, empty `String` with a fixed capacity of `N`
-            ///
-            /// # Examples
-            ///
-            /// Basic usage:
-            ///
-            /// ```
-            /// use heapless::String;
-            ///
-            /// // allocate the string on the stack
-            /// let mut s: String<$Uxx, 4> = String::$name();
-            ///
-            /// // allocate the string in a static variable
-            /// static mut S: String<$Uxx, 4> = String::$name();
-            /// ```
             #[inline]
             pub const fn $name() -> Self {
                 Self { vec: Vec::$name() }
@@ -38,7 +24,28 @@ macro_rules! impl_new {
 impl_new!(u8, u8);
 impl_new!(u16, u16);
 impl_new!(usize, usize);
-impl_new!(usize, new);
+
+impl<const N: usize> String<usize, N> {
+    /// Constructs a new, empty `String` with a fixed capacity of `N` and length type of `usize`
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use heapless::String;
+    ///
+    /// // allocate the string on the stack
+    /// let mut s: String<_, 4> = String::new();
+    ///
+    /// // allocate the string in a static variable
+    /// static mut S: String<usize, 4> = String::new();
+    /// ```
+    #[inline]
+    pub const fn new() -> Self {
+        Self { vec: Vec::new() }
+    }
+}
 
 impl<U: Uxx, const N: usize> String<U, N> {
     /// Converts a `String` into a byte vector.

--- a/src/string.rs
+++ b/src/string.rs
@@ -13,10 +13,10 @@ pub struct StringBase<U: Uxx, const N: usize> {
 pub type String<const N: usize> = StringBase<usize, N>;
 
 macro_rules! impl_new {
-    ($Uxx:ident, $name:ident) => {
+    ($Uxx:ident, $name:ident, $doc:tt) => {
         impl<const N: usize> StringBase<$Uxx, N> {
-            /// Constructs a new, empty `String` with a fixed capacity of `N`
             #[inline]
+            #[doc = $doc]
             pub const fn $name() -> Self {
                 Self {
                     vec: VecBase::$name(),
@@ -26,9 +26,8 @@ macro_rules! impl_new {
     };
 }
 
-impl_new!(u8, u8);
-impl_new!(u16, u16);
-impl_new!(usize, usize);
+impl_new!(u8, u8, "Constructs a new, empty `String` with a fixed capacity of `N`. **Safety**: Assumes `N <= u8::MAX`.");
+impl_new!(u16, u16, "Constructs a new, empty `String` with a fixed capacity of `N`. **Safety**: Assumes `N <= u16::MAX`.");
 
 impl<const N: usize> String<N> {
     /// Constructs a new, empty `String` with a fixed capacity of `N` and length type of `usize`

--- a/src/string.rs
+++ b/src/string.rs
@@ -59,7 +59,7 @@ impl<U: Uxx, const N: usize> String<U, N> {
     /// ```
     /// use heapless::String;
     ///
-    /// let s: String<usize, 4> = String::from("ab");
+    /// let s: String<4> = String::from("ab");
     /// let b = s.into_bytes();
     /// assert!(b.len() == 2);
     ///
@@ -79,7 +79,7 @@ impl<U: Uxx, const N: usize> String<U, N> {
     /// ```
     /// use heapless::String;
     ///
-    /// let mut s: String<usize, 4> = String::from("ab");
+    /// let mut s: String<4> = String::from("ab");
     /// assert!(s.as_str() == "ab");
     ///
     /// let _s = s.as_str();
@@ -99,7 +99,7 @@ impl<U: Uxx, const N: usize> String<U, N> {
     /// ```
     /// use heapless::String;
     ///
-    /// let mut s: String<usize, 4> = String::from("ab");
+    /// let mut s: String<4> = String::from("ab");
     /// let s = s.as_mut_str();
     /// s.make_ascii_uppercase();
     /// ```
@@ -145,7 +145,7 @@ impl<U: Uxx, const N: usize> String<U, N> {
     /// ```
     /// use heapless::String;
     ///
-    /// let mut s: String<usize, 8> = String::from("foo");
+    /// let mut s: String<8> = String::from("foo");
     ///
     /// assert!(s.push_str("bar").is_ok());
     ///
@@ -167,7 +167,7 @@ impl<U: Uxx, const N: usize> String<U, N> {
     /// ```
     /// use heapless::String;
     ///
-    /// let mut s: String<usize, 4> = String::new();
+    /// let mut s: String<4> = String::new();
     /// assert!(s.capacity() == 4);
     /// ```
     #[inline]
@@ -186,7 +186,7 @@ impl<U: Uxx, const N: usize> String<U, N> {
     /// ```
     /// use heapless::String;
     ///
-    /// let mut s: String<usize, 8> = String::from("abc");
+    /// let mut s: String<8> = String::from("abc");
     ///
     /// s.push('1').unwrap();
     /// s.push('2').unwrap();
@@ -227,7 +227,7 @@ impl<U: Uxx, const N: usize> String<U, N> {
     /// ```
     /// use heapless::String;
     ///
-    /// let mut s: String<usize, 8> = String::from("hello");
+    /// let mut s: String<8> = String::from("hello");
     ///
     /// s.truncate(2);
     ///
@@ -254,7 +254,7 @@ impl<U: Uxx, const N: usize> String<U, N> {
     /// ```
     /// use heapless::String;
     ///
-    /// let mut s: String<usize, 8> = String::from("foo");
+    /// let mut s: String<8> = String::from("foo");
     ///
     /// assert_eq!(s.pop(), Some('o'));
     /// assert_eq!(s.pop(), Some('o'));
@@ -287,7 +287,7 @@ impl<U: Uxx, const N: usize> String<U, N> {
     /// ```
     /// use heapless::String;
     ///
-    /// let mut s: String<usize, 8> = String::from("foo");
+    /// let mut s: String<8> = String::from("foo");
     ///
     /// s.clear();
     ///
@@ -521,12 +521,12 @@ mod tests {
 
     #[test]
     fn static_new() {
-        static mut _S: String<usize, 8> = String::new();
+        static mut _S: String<8> = String::new();
     }
 
     #[test]
     fn clone() {
-        let s1: String<usize, 20> = String::from("abcd");
+        let s1: String<20> = String::from("abcd");
         let mut s2 = s1.clone();
         s2.push_str(" efgh").unwrap();
 
@@ -538,7 +538,7 @@ mod tests {
     fn debug() {
         use core::fmt::Write;
 
-        let s: String<usize, 8> = String::from("abcd");
+        let s: String<8> = String::from("abcd");
         let mut std_s = std::string::String::new();
         write!(std_s, "{:?}", s).unwrap();
         assert_eq!("\"abcd\"", std_s);
@@ -548,7 +548,7 @@ mod tests {
     fn display() {
         use core::fmt::Write;
 
-        let s: String<usize, 8> = String::from("abcd");
+        let s: String<8> = String::from("abcd");
         let mut std_s = std::string::String::new();
         write!(std_s, "{}", s).unwrap();
         assert_eq!("abcd", std_s);
@@ -556,7 +556,7 @@ mod tests {
 
     #[test]
     fn empty() {
-        let s: String<usize, 4> = String::new();
+        let s: String<4> = String::new();
         assert!(s.capacity() == 4);
         assert_eq!(s, "");
         assert_eq!(s.len(), 0);
@@ -565,7 +565,7 @@ mod tests {
 
     #[test]
     fn from() {
-        let s: String<usize, 4> = String::from("123");
+        let s: String<4> = String::from("123");
         assert!(s.len() == 3);
         assert_eq!(s, "123");
     }
@@ -574,37 +574,37 @@ mod tests {
     fn from_str() {
         use core::str::FromStr;
 
-        let s: String<usize, 4> = String::<usize, 4>::from_str("123").unwrap();
+        let s: String<4> = String::<4>::from_str("123").unwrap();
         assert!(s.len() == 3);
         assert_eq!(s, "123");
 
-        let e: () = String::<usize, 2>::from_str("123").unwrap_err();
+        let e: () = String::<2>::from_str("123").unwrap_err();
         assert_eq!(e, ());
     }
 
     #[test]
     #[should_panic]
     fn from_panic() {
-        let _: String<usize, 4> = String::from("12345");
+        let _: String<4> = String::from("12345");
     }
 
     #[test]
     fn from_num() {
-        let v: String<usize, 20> = String::from(18446744073709551615 as u64);
+        let v: String<20> = String::from(18446744073709551615 as u64);
         assert_eq!(v, "18446744073709551615");
     }
 
     #[test]
     fn into_bytes() {
-        let s: String<usize, 4> = String::from("ab");
-        let b: Vec<u8, usize, 4> = s.into_bytes();
+        let s: String<4> = String::from("ab");
+        let b: Vec<u8, 4> = s.into_bytes();
         assert_eq!(b.len(), 2);
         assert_eq!(&['a' as u8, 'b' as u8], &b[..]);
     }
 
     #[test]
     fn as_str() {
-        let s: String<usize, 4> = String::from("ab");
+        let s: String<4> = String::from("ab");
 
         assert_eq!(s.as_str(), "ab");
         // should be moved to fail test
@@ -614,7 +614,7 @@ mod tests {
 
     #[test]
     fn as_mut_str() {
-        let mut s: String<usize, 4> = String::from("ab");
+        let mut s: String<4> = String::from("ab");
         let s = s.as_mut_str();
         s.make_ascii_uppercase();
         assert_eq!(s, "AB");
@@ -622,7 +622,7 @@ mod tests {
 
     #[test]
     fn push_str() {
-        let mut s: String<usize, 8> = String::from("foo");
+        let mut s: String<8> = String::from("foo");
         assert!(s.push_str("bar").is_ok());
         assert_eq!("foobar", s);
         assert_eq!(s, "foobar");
@@ -633,7 +633,7 @@ mod tests {
 
     #[test]
     fn push() {
-        let mut s: String<usize, 6> = String::from("abc");
+        let mut s: String<6> = String::from("abc");
         assert!(s.push('1').is_ok());
         assert!(s.push('2').is_ok());
         assert!(s.push('3').is_ok());
@@ -643,13 +643,13 @@ mod tests {
 
     #[test]
     fn as_bytes() {
-        let s: String<usize, 8> = String::from("hello");
+        let s: String<8> = String::from("hello");
         assert_eq!(&[104, 101, 108, 108, 111], s.as_bytes());
     }
 
     #[test]
     fn truncate() {
-        let mut s: String<usize, 8> = String::from("hello");
+        let mut s: String<8> = String::from("hello");
         s.truncate(6);
         assert_eq!(s.len(), 5);
         s.truncate(2);
@@ -660,7 +660,7 @@ mod tests {
 
     #[test]
     fn pop() {
-        let mut s: String<usize, 8> = String::from("foo");
+        let mut s: String<8> = String::from("foo");
         assert_eq!(s.pop(), Some('o'));
         assert_eq!(s.pop(), Some('o'));
         assert_eq!(s.pop(), Some('f'));
@@ -669,7 +669,7 @@ mod tests {
 
     #[test]
     fn pop_uenc() {
-        let mut s: String<usize, 8> = String::from("é");
+        let mut s: String<8> = String::from("é");
         assert_eq!(s.len(), 3);
         match s.pop() {
             Some(c) => {
@@ -683,7 +683,7 @@ mod tests {
 
     #[test]
     fn is_empty() {
-        let mut v: String<usize, 8> = String::new();
+        let mut v: String<8> = String::new();
         assert!(v.is_empty());
         let _ = v.push('a');
         assert!(!v.is_empty());
@@ -691,7 +691,7 @@ mod tests {
 
     #[test]
     fn clear() {
-        let mut s: String<usize, 8> = String::from("foo");
+        let mut s: String<8> = String::from("foo");
         s.clear();
         assert!(s.is_empty());
         assert_eq!(0, s.len());

--- a/src/string.rs
+++ b/src/string.rs
@@ -9,27 +9,38 @@ pub struct String<U: Uxx, const N: usize> {
     vec: Vec<u8, U, N>,
 }
 
-impl<U: Uxx, const N: usize> String<U, N> {
-    /// Constructs a new, empty `String` with a fixed capacity of `N`
-    ///
-    /// # Examples
-    ///
-    /// Basic usage:
-    ///
-    /// ```
-    /// use heapless::String;
-    ///
-    /// // allocate the string on the stack
-    /// let mut s: String<4> = String::new();
-    ///
-    /// // allocate the string in a static variable
-    /// static mut S: String<4> = String::new();
-    /// ```
-    #[inline]
-    pub const fn new() -> Self {
-        Self { vec: Vec::new() }
-    }
+macro_rules! impl_new {
+    ($Uxx:ident, $name:ident) => {
+        impl<const N: usize> String<$Uxx, N> {
+            /// Constructs a new, empty `String` with a fixed capacity of `N`
+            ///
+            /// # Examples
+            ///
+            /// Basic usage:
+            ///
+            /// ```
+            /// use heapless::String;
+            ///
+            /// // allocate the string on the stack
+            /// let mut s: String<$Uxx, 4> = String::$name();
+            ///
+            /// // allocate the string in a static variable
+            /// static mut S: String<$Uxx, 4> = String::$name();
+            /// ```
+            #[inline]
+            pub const fn $name() -> Self {
+                Self { vec: Vec::$name() }
+            }
+        }
+    };
+}
 
+impl_new!(u8, u8);
+impl_new!(u16, u16);
+impl_new!(usize, usize);
+impl_new!(usize, new);
+
+impl<U: Uxx, const N: usize> String<U, N> {
     /// Converts a `String` into a byte vector.
     ///
     /// This consumes the `String`, so we do not need to copy its contents.
@@ -285,13 +296,15 @@ impl<U: Uxx, const N: usize> String<U, N> {
 
 impl<U: Uxx, const N: usize> Default for String<U, N> {
     fn default() -> Self {
-        Self::new()
+        Self {
+            vec: Vec::default(),
+        }
     }
 }
 
 impl<'a, U: Uxx, const N: usize> From<&'a str> for String<U, N> {
     fn from(s: &'a str) -> Self {
-        let mut new = String::new();
+        let mut new = String::default();
         new.push_str(s).unwrap();
         new
     }
@@ -301,7 +314,7 @@ impl<U: Uxx, const N: usize> str::FromStr for String<U, N> {
     type Err = ();
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let mut new = String::new();
+        let mut new = String::default();
         new.push_str(s)?;
         Ok(new)
     }
@@ -477,7 +490,7 @@ macro_rules! impl_from_num {
     ($num:ty, $size:expr) => {
         impl<U: Uxx, const N: usize> From<$num> for String<U, N> {
             fn from(s: $num) -> Self {
-                let mut new = String::new();
+                let mut new = String::default();
                 write!(&mut new, "{}", s).unwrap();
                 new
             }

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -12,7 +12,7 @@ use crate::sealed::spsc::Uxx;
 ///
 ///
 /// // A vector with a fixed capacity of 8 elements allocated on the stack
-/// let mut vec = Vec::<_, usize, 8>::new();
+/// let mut vec = Vec::<_, 8>::new();
 /// vec.push(1);
 /// vec.push(2);
 ///
@@ -105,7 +105,7 @@ impl<T, U: Uxx, const N: usize> Vec<T, U, N> {
     /// ```
     /// use heapless::Vec;
     ///
-    /// let mut v: Vec<u8, usize, 16> = Vec::new();
+    /// let mut v: Vec<u8, 16> = Vec::new();
     /// v.extend_from_slice(&[1, 2, 3]).unwrap();
     /// ```
     #[inline]
@@ -136,7 +136,7 @@ impl<T, U: Uxx, const N: usize> Vec<T, U, N> {
     ///
     /// ```
     /// use heapless::Vec;
-    /// let buffer: Vec<u8, usize, 5> = Vec::from_slice(&[1, 2, 3, 5, 8]).unwrap();
+    /// let buffer: Vec<u8, 5> = Vec::from_slice(&[1, 2, 3, 5, 8]).unwrap();
     /// assert_eq!(buffer.as_slice(), &[1, 2, 3, 5, 8]);
     /// ```
     pub fn as_slice(&self) -> &[T] {
@@ -153,7 +153,7 @@ impl<T, U: Uxx, const N: usize> Vec<T, U, N> {
     ///
     /// ```
     /// use heapless::Vec;
-    /// let mut buffer: Vec<u8, usize, 5> = Vec::from_slice(&[1, 2, 3, 5, 8]).unwrap();
+    /// let mut buffer: Vec<u8, 5> = Vec::from_slice(&[1, 2, 3, 5, 8]).unwrap();
     /// buffer[0] = 9;
     /// assert_eq!(buffer.as_slice(), &[9, 2, 3, 5, 8]);
     /// ```
@@ -193,7 +193,7 @@ impl<T, U: Uxx, const N: usize> Vec<T, U, N> {
     /// ```
     /// use heapless::Vec;
     ///
-    /// let mut vec = Vec::<u8, usize, 8>::new();
+    /// let mut vec = Vec::<u8, 8>::new();
     /// vec.push(1).unwrap();
     /// vec.extend_from_slice(&[2, 3, 4]).unwrap();
     /// assert_eq!(*vec, [1, 2, 3, 4]);
@@ -361,7 +361,7 @@ impl<T, U: Uxx, const N: usize> Vec<T, U, N> {
     /// #     ) -> i32;
     /// # }
     /// # impl StreamWrapper {
-    /// pub fn get_dictionary(&self) -> Option<Vec<u8, usize, 32768>> {
+    /// pub fn get_dictionary(&self) -> Option<Vec<u8, 32768>> {
     ///     // Per the FFI method's docs, "32768 bytes is always enough".
     ///     let mut dict = Vec::new();
     ///     let mut dict_length = 0;
@@ -391,7 +391,7 @@ impl<T, U: Uxx, const N: usize> Vec<T, U, N> {
     /// use core::iter::FromIterator;
     /// use heapless::Vec;
     ///
-    /// let mut vec = Vec::<Vec<u8, u8, 3>, u8, 3>::from_iter(
+    /// let mut vec = Vec::<Vec<u8, 3>, 3>::from_iter(
     ///     [
     ///         Vec::from_iter([1, 0, 0].iter().cloned()),
     ///         Vec::from_iter([0, 1, 0].iter().cloned()),
@@ -432,7 +432,7 @@ impl<T, U: Uxx, const N: usize> Vec<T, U, N> {
     /// use heapless::Vec;
     ///// use heapless::consts::*;
     ///
-    /// let mut v: Vec<_, usize, 8> = Vec::new();
+    /// let mut v: Vec<_, 8> = Vec::new();
     /// v.push("foo").unwrap();
     /// v.push("bar").unwrap();
     /// v.push("baz").unwrap();
@@ -464,7 +464,7 @@ impl<T, U: Uxx, const N: usize> Vec<T, U, N> {
     /// ```
     /// use heapless::Vec;
     ///
-    /// let mut v: Vec<_, usize, 8> = Vec::new();
+    /// let mut v: Vec<_, 8> = Vec::new();
     /// v.push("foo").unwrap();
     /// v.push("bar").unwrap();
     /// v.push("baz").unwrap();
@@ -501,7 +501,7 @@ impl<T, U: Uxx, const N: usize> Vec<T, U, N> {
     /// ```
     /// use heapless::Vec;
     ///
-    /// let v: Vec<_, usize, 8> = Vec::from_slice(b"abc").unwrap();
+    /// let v: Vec<_, 8> = Vec::from_slice(b"abc").unwrap();
     /// assert_eq!(v.starts_with(b""), true);
     /// assert_eq!(v.starts_with(b"ab"), true);
     /// assert_eq!(v.starts_with(b"bc"), false);
@@ -524,7 +524,7 @@ impl<T, U: Uxx, const N: usize> Vec<T, U, N> {
     /// ```
     /// use heapless::Vec;
     ///
-    /// let v: Vec<_, usize, 8> = Vec::from_slice(b"abc").unwrap();
+    /// let v: Vec<_, 8> = Vec::from_slice(b"abc").unwrap();
     /// assert_eq!(v.ends_with(b""), true);
     /// assert_eq!(v.ends_with(b"ab"), false);
     /// assert_eq!(v.ends_with(b"bc"), true);
@@ -837,12 +837,12 @@ mod tests {
 
     #[test]
     fn static_new() {
-        static mut _V: Vec<i32, usize, 4> = Vec::new();
+        static mut _V: Vec<i32, 4> = Vec::new();
     }
 
     #[test]
     fn stack_new() {
-        static mut _V: Vec<i32, usize, 4> = Vec::new();
+        static mut _V: Vec<i32, 4> = Vec::new();
     }
 
     macro_rules! droppable {
@@ -873,7 +873,7 @@ mod tests {
         droppable!();
 
         {
-            let mut v: Vec<Droppable, usize, 2> = Vec::new();
+            let mut v: Vec<Droppable, 2> = Vec::new();
             v.push(Droppable::new()).ok().unwrap();
             v.push(Droppable::new()).ok().unwrap();
             v.pop().unwrap();
@@ -882,7 +882,7 @@ mod tests {
         assert_eq!(unsafe { COUNT }, 0);
 
         {
-            let mut v: Vec<Droppable, usize, 2> = Vec::new();
+            let mut v: Vec<Droppable, 2> = Vec::new();
             v.push(Droppable::new()).ok().unwrap();
             v.push(Droppable::new()).ok().unwrap();
         }
@@ -892,8 +892,8 @@ mod tests {
 
     #[test]
     fn eq() {
-        let mut xs: Vec<i32, usize, 4> = Vec::new();
-        let mut ys: Vec<i32, usize, 8> = Vec::new();
+        let mut xs: Vec<i32, 4> = Vec::new();
+        let mut ys: Vec<i32, 8> = Vec::new();
 
         assert_eq!(xs, ys);
 
@@ -905,7 +905,7 @@ mod tests {
 
     #[test]
     fn full() {
-        let mut v: Vec<i32, usize, 4> = Vec::new();
+        let mut v: Vec<i32, 4> = Vec::new();
 
         v.push(0).unwrap();
         v.push(1).unwrap();
@@ -917,7 +917,7 @@ mod tests {
 
     #[test]
     fn iter() {
-        let mut v: Vec<i32, usize, 4> = Vec::new();
+        let mut v: Vec<i32, 4> = Vec::new();
 
         v.push(0).unwrap();
         v.push(1).unwrap();
@@ -935,7 +935,7 @@ mod tests {
 
     #[test]
     fn iter_mut() {
-        let mut v: Vec<i32, usize, 4> = Vec::new();
+        let mut v: Vec<i32, 4> = Vec::new();
 
         v.push(0).unwrap();
         v.push(1).unwrap();
@@ -954,7 +954,7 @@ mod tests {
     #[test]
     fn collect_from_iter() {
         let slice = &[1, 2, 3];
-        let vec: Vec<i32, usize, 4> = slice.iter().cloned().collect();
+        let vec: Vec<i32, 4> = slice.iter().cloned().collect();
         // PER: Auto deref did not work
         assert_eq!(vec.as_slice(), slice);
     }
@@ -963,12 +963,12 @@ mod tests {
     #[should_panic]
     fn collect_from_iter_overfull() {
         let slice = &[1, 2, 3];
-        let _vec = slice.iter().cloned().collect::<Vec<_, usize, 2>>();
+        let _vec = slice.iter().cloned().collect::<Vec<_, 2>>();
     }
 
     #[test]
     fn iter_move() {
-        let mut v: Vec<i32, usize, 4> = Vec::new();
+        let mut v: Vec<i32, 4> = Vec::new();
         v.push(0).unwrap();
         v.push(1).unwrap();
         v.push(2).unwrap();
@@ -988,7 +988,7 @@ mod tests {
         droppable!();
 
         {
-            let mut vec: Vec<Droppable, usize, 2> = Vec::new();
+            let mut vec: Vec<Droppable, 2> = Vec::new();
             vec.push(Droppable::new()).ok().unwrap();
             vec.push(Droppable::new()).ok().unwrap();
             let mut items = vec.into_iter();
@@ -1000,7 +1000,7 @@ mod tests {
         assert_eq!(unsafe { COUNT }, 0);
 
         {
-            let mut vec: Vec<Droppable, usize, 2> = Vec::new();
+            let mut vec: Vec<Droppable, 2> = Vec::new();
             vec.push(Droppable::new()).ok().unwrap();
             vec.push(Droppable::new()).ok().unwrap();
             let _items = vec.into_iter();
@@ -1010,7 +1010,7 @@ mod tests {
         assert_eq!(unsafe { COUNT }, 0);
 
         {
-            let mut vec: Vec<Droppable, usize, 2> = Vec::new();
+            let mut vec: Vec<Droppable, 2> = Vec::new();
             vec.push(Droppable::new()).ok().unwrap();
             vec.push(Droppable::new()).ok().unwrap();
             let mut items = vec.into_iter();
@@ -1022,7 +1022,7 @@ mod tests {
 
     #[test]
     fn push_and_pop() {
-        let mut v: Vec<i32, usize, 4> = Vec::new();
+        let mut v: Vec<i32, 4> = Vec::new();
         assert_eq!(v.len(), 0);
 
         assert_eq!(v.pop(), None);
@@ -1040,7 +1040,7 @@ mod tests {
 
     #[test]
     fn resize_size_limit() {
-        let mut v: Vec<u8, usize, 4> = Vec::new();
+        let mut v: Vec<u8, 4> = Vec::new();
 
         v.resize(0, 0).unwrap();
         v.resize(4, 0).unwrap();
@@ -1049,7 +1049,7 @@ mod tests {
 
     #[test]
     fn resize_length_cases() {
-        let mut v: Vec<u8, usize, 4> = Vec::new();
+        let mut v: Vec<u8, 4> = Vec::new();
 
         assert_eq!(v.len(), 0);
 
@@ -1076,7 +1076,7 @@ mod tests {
 
     #[test]
     fn resize_contents() {
-        let mut v: Vec<u8, usize, 4> = Vec::new();
+        let mut v: Vec<u8, 4> = Vec::new();
 
         // New entries take supplied value when growing
         v.resize(1, 17).unwrap();
@@ -1099,7 +1099,7 @@ mod tests {
 
     #[test]
     fn resize_default() {
-        let mut v: Vec<u8, usize, 4> = Vec::new();
+        let mut v: Vec<u8, 4> = Vec::new();
 
         // resize_default is implemented using resize, so just check the
         // correct value is being written.
@@ -1109,14 +1109,14 @@ mod tests {
 
     #[test]
     fn write() {
-        let mut v: Vec<u8, usize, 4> = Vec::new();
+        let mut v: Vec<u8, 4> = Vec::new();
         write!(v, "{:x}", 1234).unwrap();
         assert_eq!(&v[..], b"4d2");
     }
 
     #[test]
     fn extend_from_slice() {
-        let mut v: Vec<u8, usize, 4> = Vec::new();
+        let mut v: Vec<u8, 4> = Vec::new();
         assert_eq!(v.len(), 0);
         v.extend_from_slice(&[1, 2]).unwrap();
         assert_eq!(v.len(), 2);
@@ -1132,17 +1132,17 @@ mod tests {
     #[test]
     fn from_slice() {
         // Successful construction
-        let v: Vec<u8, usize, 4> = Vec::from_slice(&[1, 2, 3]).unwrap();
+        let v: Vec<u8, 4> = Vec::from_slice(&[1, 2, 3]).unwrap();
         assert_eq!(v.len(), 3);
         assert_eq!(v.as_slice(), &[1, 2, 3]);
 
         // Slice too large
-        assert!(Vec::<u8, usize, 2>::from_slice(&[1, 2, 3]).is_err());
+        assert!(Vec::<u8, 2>::from_slice(&[1, 2, 3]).is_err());
     }
 
     #[test]
     fn starts_with() {
-        let v: Vec<_, usize, 8> = Vec::from_slice(b"ab").unwrap();
+        let v: Vec<_, 8> = Vec::from_slice(b"ab").unwrap();
         assert!(v.starts_with(&[]));
         assert!(v.starts_with(b""));
         assert!(v.starts_with(b"a"));
@@ -1154,7 +1154,7 @@ mod tests {
 
     #[test]
     fn ends_with() {
-        let v: Vec<_, usize, 8> = Vec::from_slice(b"ab").unwrap();
+        let v: Vec<_, 8> = Vec::from_slice(b"ab").unwrap();
         assert!(v.ends_with(&[]));
         assert!(v.ends_with(b""));
         assert!(v.ends_with(b"b"));

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -32,6 +32,17 @@ use crate::sealed::spsc::Uxx;
 /// }
 /// assert_eq!(*vec, [7, 1, 2, 3]);
 /// ```
+///
+/// The length type of `Vec` and `Vec`-based containers is generic and can use `u8`, `u16`, or
+/// `usize`. Using smaller length types can reduce memory footprint for containers with low
+/// alignment requirements.  The easiest way to construct a `Vec` with a smaller index type is to
+/// use the [`u8`] and [`u16`] constructors.
+///
+/// [`u8`]: struct.Vec.html#method.u8
+/// [`u16`]: struct.Vec.html#method.u16
+///
+/// *IMPORTANT*: `Vec<_, u8, N>` has a maximum capacity of 255 elements; `Vec<_,
+/// u16, N>` has a maximum capacity of 65535 elements.
 pub struct Vec<T, U: Uxx, const N: usize> {
     buffer: MaybeUninit<[T; N]>,
     len: U,

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -12,7 +12,7 @@ use crate::sealed::spsc::Uxx;
 ///
 ///
 /// // A vector with a fixed capacity of 8 elements allocated on the stack
-/// let mut vec = Vec::<_, 8>::new();
+/// let mut vec = Vec::<_, usize, 8>::new();
 /// vec.push(1);
 /// vec.push(2);
 ///
@@ -93,7 +93,7 @@ impl<T, U: Uxx, const N: usize> Vec<T, U, N> {
     /// ```
     /// use heapless::Vec;
     ///
-    /// let mut v: Vec<u8, 16> = Vec::new();
+    /// let mut v: Vec<u8, usize, 16> = Vec::new();
     /// v.extend_from_slice(&[1, 2, 3]).unwrap();
     /// ```
     #[inline]
@@ -124,7 +124,7 @@ impl<T, U: Uxx, const N: usize> Vec<T, U, N> {
     ///
     /// ```
     /// use heapless::Vec;
-    /// let buffer: Vec<u8, 5> = Vec::from_slice(&[1, 2, 3, 5, 8]).unwrap();
+    /// let buffer: Vec<u8, usize, 5> = Vec::from_slice(&[1, 2, 3, 5, 8]).unwrap();
     /// assert_eq!(buffer.as_slice(), &[1, 2, 3, 5, 8]);
     /// ```
     pub fn as_slice(&self) -> &[T] {
@@ -141,7 +141,7 @@ impl<T, U: Uxx, const N: usize> Vec<T, U, N> {
     ///
     /// ```
     /// use heapless::Vec;
-    /// let mut buffer: Vec<u8, 5> = Vec::from_slice(&[1, 2, 3, 5, 8]).unwrap();
+    /// let mut buffer: Vec<u8, usize, 5> = Vec::from_slice(&[1, 2, 3, 5, 8]).unwrap();
     /// buffer[0] = 9;
     /// assert_eq!(buffer.as_slice(), &[9, 2, 3, 5, 8]);
     /// ```
@@ -181,7 +181,7 @@ impl<T, U: Uxx, const N: usize> Vec<T, U, N> {
     /// ```
     /// use heapless::Vec;
     ///
-    /// let mut vec = Vec::<u8, 8>::new();
+    /// let mut vec = Vec::<u8, usize, 8>::new();
     /// vec.push(1).unwrap();
     /// vec.extend_from_slice(&[2, 3, 4]).unwrap();
     /// assert_eq!(*vec, [1, 2, 3, 4]);
@@ -349,7 +349,7 @@ impl<T, U: Uxx, const N: usize> Vec<T, U, N> {
     /// #     ) -> i32;
     /// # }
     /// # impl StreamWrapper {
-    /// pub fn get_dictionary(&self) -> Option<Vec<u8, 32768>> {
+    /// pub fn get_dictionary(&self) -> Option<Vec<u8, usize, 32768>> {
     ///     // Per the FFI method's docs, "32768 bytes is always enough".
     ///     let mut dict = Vec::new();
     ///     let mut dict_length = 0;
@@ -379,7 +379,7 @@ impl<T, U: Uxx, const N: usize> Vec<T, U, N> {
     /// use core::iter::FromIterator;
     /// use heapless::Vec;
     ///
-    /// let mut vec = Vec::<Vec<u8, 3>, 3>::from_iter(
+    /// let mut vec = Vec::<Vec<u8, usize, 3>, 3>::from_iter(
     ///     [
     ///         Vec::from_iter([1, 0, 0].iter().cloned()),
     ///         Vec::from_iter([0, 1, 0].iter().cloned()),
@@ -420,7 +420,7 @@ impl<T, U: Uxx, const N: usize> Vec<T, U, N> {
     /// use heapless::Vec;
     ///// use heapless::consts::*;
     ///
-    /// let mut v: Vec<_, 8> = Vec::new();
+    /// let mut v: Vec<_, usize, 8> = Vec::new();
     /// v.push("foo").unwrap();
     /// v.push("bar").unwrap();
     /// v.push("baz").unwrap();
@@ -452,7 +452,7 @@ impl<T, U: Uxx, const N: usize> Vec<T, U, N> {
     /// ```
     /// use heapless::Vec;
     ///
-    /// let mut v: Vec<_, 8> = Vec::new();
+    /// let mut v: Vec<_, usize, 8> = Vec::new();
     /// v.push("foo").unwrap();
     /// v.push("bar").unwrap();
     /// v.push("baz").unwrap();
@@ -489,7 +489,7 @@ impl<T, U: Uxx, const N: usize> Vec<T, U, N> {
     /// ```
     /// use heapless::Vec;
     ///
-    /// let v: Vec<_, 8> = Vec::from_slice(b"abc").unwrap();
+    /// let v: Vec<_, usize, 8> = Vec::from_slice(b"abc").unwrap();
     /// assert_eq!(v.starts_with(b""), true);
     /// assert_eq!(v.starts_with(b"ab"), true);
     /// assert_eq!(v.starts_with(b"bc"), false);
@@ -512,7 +512,7 @@ impl<T, U: Uxx, const N: usize> Vec<T, U, N> {
     /// ```
     /// use heapless::Vec;
     ///
-    /// let v: Vec<_, 8> = Vec::from_slice(b"abc").unwrap();
+    /// let v: Vec<_, usize, 8> = Vec::from_slice(b"abc").unwrap();
     /// assert_eq!(v.ends_with(b""), true);
     /// assert_eq!(v.ends_with(b"ab"), false);
     /// assert_eq!(v.ends_with(b"bc"), true);
@@ -825,12 +825,12 @@ mod tests {
 
     #[test]
     fn static_new() {
-        static mut _V: Vec<i32, 4> = Vec::new();
+        static mut _V: Vec<i32, usize, 4> = Vec::new();
     }
 
     #[test]
     fn stack_new() {
-        static mut _V: Vec<i32, 4> = Vec::new();
+        static mut _V: Vec<i32, usize, 4> = Vec::new();
     }
 
     macro_rules! droppable {
@@ -861,7 +861,7 @@ mod tests {
         droppable!();
 
         {
-            let mut v: Vec<Droppable, 2> = Vec::new();
+            let mut v: Vec<Droppable, usize, 2> = Vec::new();
             v.push(Droppable::new()).ok().unwrap();
             v.push(Droppable::new()).ok().unwrap();
             v.pop().unwrap();
@@ -870,7 +870,7 @@ mod tests {
         assert_eq!(unsafe { COUNT }, 0);
 
         {
-            let mut v: Vec<Droppable, 2> = Vec::new();
+            let mut v: Vec<Droppable, usize, 2> = Vec::new();
             v.push(Droppable::new()).ok().unwrap();
             v.push(Droppable::new()).ok().unwrap();
         }
@@ -880,8 +880,8 @@ mod tests {
 
     #[test]
     fn eq() {
-        let mut xs: Vec<i32, 4> = Vec::new();
-        let mut ys: Vec<i32, 8> = Vec::new();
+        let mut xs: Vec<i32, usize, 4> = Vec::new();
+        let mut ys: Vec<i32, usize, 8> = Vec::new();
 
         assert_eq!(xs, ys);
 
@@ -893,7 +893,7 @@ mod tests {
 
     #[test]
     fn full() {
-        let mut v: Vec<i32, 4> = Vec::new();
+        let mut v: Vec<i32, usize, 4> = Vec::new();
 
         v.push(0).unwrap();
         v.push(1).unwrap();
@@ -905,7 +905,7 @@ mod tests {
 
     #[test]
     fn iter() {
-        let mut v: Vec<i32, 4> = Vec::new();
+        let mut v: Vec<i32, usize, 4> = Vec::new();
 
         v.push(0).unwrap();
         v.push(1).unwrap();
@@ -923,7 +923,7 @@ mod tests {
 
     #[test]
     fn iter_mut() {
-        let mut v: Vec<i32, 4> = Vec::new();
+        let mut v: Vec<i32, usize, 4> = Vec::new();
 
         v.push(0).unwrap();
         v.push(1).unwrap();
@@ -942,7 +942,7 @@ mod tests {
     #[test]
     fn collect_from_iter() {
         let slice = &[1, 2, 3];
-        let vec: Vec<i32, 4> = slice.iter().cloned().collect();
+        let vec: Vec<i32, usize, 4> = slice.iter().cloned().collect();
         // PER: Auto deref did not work
         assert_eq!(vec.as_slice(), slice);
     }
@@ -951,12 +951,12 @@ mod tests {
     #[should_panic]
     fn collect_from_iter_overfull() {
         let slice = &[1, 2, 3];
-        let _vec = slice.iter().cloned().collect::<Vec<_, 2>>();
+        let _vec = slice.iter().cloned().collect::<Vec<_, usize, 2>>();
     }
 
     #[test]
     fn iter_move() {
-        let mut v: Vec<i32, 4> = Vec::new();
+        let mut v: Vec<i32, usize, 4> = Vec::new();
         v.push(0).unwrap();
         v.push(1).unwrap();
         v.push(2).unwrap();
@@ -976,7 +976,7 @@ mod tests {
         droppable!();
 
         {
-            let mut vec: Vec<Droppable, 2> = Vec::new();
+            let mut vec: Vec<Droppable, usize, 2> = Vec::new();
             vec.push(Droppable::new()).ok().unwrap();
             vec.push(Droppable::new()).ok().unwrap();
             let mut items = vec.into_iter();
@@ -988,7 +988,7 @@ mod tests {
         assert_eq!(unsafe { COUNT }, 0);
 
         {
-            let mut vec: Vec<Droppable, 2> = Vec::new();
+            let mut vec: Vec<Droppable, usize, 2> = Vec::new();
             vec.push(Droppable::new()).ok().unwrap();
             vec.push(Droppable::new()).ok().unwrap();
             let _items = vec.into_iter();
@@ -998,7 +998,7 @@ mod tests {
         assert_eq!(unsafe { COUNT }, 0);
 
         {
-            let mut vec: Vec<Droppable, 2> = Vec::new();
+            let mut vec: Vec<Droppable, usize, 2> = Vec::new();
             vec.push(Droppable::new()).ok().unwrap();
             vec.push(Droppable::new()).ok().unwrap();
             let mut items = vec.into_iter();
@@ -1010,7 +1010,7 @@ mod tests {
 
     #[test]
     fn push_and_pop() {
-        let mut v: Vec<i32, 4> = Vec::new();
+        let mut v: Vec<i32, usize, 4> = Vec::new();
         assert_eq!(v.len(), 0);
 
         assert_eq!(v.pop(), None);
@@ -1028,7 +1028,7 @@ mod tests {
 
     #[test]
     fn resize_size_limit() {
-        let mut v: Vec<u8, 4> = Vec::new();
+        let mut v: Vec<u8, usize, 4> = Vec::new();
 
         v.resize(0, 0).unwrap();
         v.resize(4, 0).unwrap();
@@ -1037,7 +1037,7 @@ mod tests {
 
     #[test]
     fn resize_length_cases() {
-        let mut v: Vec<u8, 4> = Vec::new();
+        let mut v: Vec<u8, usize, 4> = Vec::new();
 
         assert_eq!(v.len(), 0);
 
@@ -1064,7 +1064,7 @@ mod tests {
 
     #[test]
     fn resize_contents() {
-        let mut v: Vec<u8, 4> = Vec::new();
+        let mut v: Vec<u8, usize, 4> = Vec::new();
 
         // New entries take supplied value when growing
         v.resize(1, 17).unwrap();
@@ -1087,7 +1087,7 @@ mod tests {
 
     #[test]
     fn resize_default() {
-        let mut v: Vec<u8, 4> = Vec::new();
+        let mut v: Vec<u8, usize, 4> = Vec::new();
 
         // resize_default is implemented using resize, so just check the
         // correct value is being written.
@@ -1097,14 +1097,14 @@ mod tests {
 
     #[test]
     fn write() {
-        let mut v: Vec<u8, 4> = Vec::new();
+        let mut v: Vec<u8, usize, 4> = Vec::new();
         write!(v, "{:x}", 1234).unwrap();
         assert_eq!(&v[..], b"4d2");
     }
 
     #[test]
     fn extend_from_slice() {
-        let mut v: Vec<u8, 4> = Vec::new();
+        let mut v: Vec<u8, usize, 4> = Vec::new();
         assert_eq!(v.len(), 0);
         v.extend_from_slice(&[1, 2]).unwrap();
         assert_eq!(v.len(), 2);
@@ -1120,17 +1120,17 @@ mod tests {
     #[test]
     fn from_slice() {
         // Successful construction
-        let v: Vec<u8, 4> = Vec::from_slice(&[1, 2, 3]).unwrap();
+        let v: Vec<u8, usize, 4> = Vec::from_slice(&[1, 2, 3]).unwrap();
         assert_eq!(v.len(), 3);
         assert_eq!(v.as_slice(), &[1, 2, 3]);
 
         // Slice too large
-        assert!(Vec::<u8, 2>::from_slice(&[1, 2, 3]).is_err());
+        assert!(Vec::<u8, usize, 2>::from_slice(&[1, 2, 3]).is_err());
     }
 
     #[test]
     fn starts_with() {
-        let v: Vec<_, 8> = Vec::from_slice(b"ab").unwrap();
+        let v: Vec<_, usize, 8> = Vec::from_slice(b"ab").unwrap();
         assert!(v.starts_with(&[]));
         assert!(v.starts_with(b""));
         assert!(v.starts_with(b"a"));
@@ -1142,7 +1142,7 @@ mod tests {
 
     #[test]
     fn ends_with() {
-        let v: Vec<_, 8> = Vec::from_slice(b"ab").unwrap();
+        let v: Vec<_, usize, 8> = Vec::from_slice(b"ab").unwrap();
         assert!(v.ends_with(&[]));
         assert!(v.ends_with(b""));
         assert!(v.ends_with(b"b"));

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -85,10 +85,10 @@ impl<T, const N: usize> Vec<T, N> {
     /// use heapless::Vec;
     ///
     /// // allocate the vector on the stack
-    /// let mut x: Vec<u8, _, 16> = Vec::new();
+    /// let mut x: Vec<u8, 16> = Vec::new();
     ///
     /// // allocate the vector in a static variable
-    /// static mut X: Vec<u8, usize, 16> = Vec::new();
+    /// static mut X: Vec<u8, 16> = Vec::new();
     /// ```
     pub const fn new() -> Self {
         Self::usize()

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -41,18 +41,6 @@ macro_rules! impl_new {
     ($Uxx:ident, $name:ident) => {
         impl<T, const N: usize> Vec<T, $Uxx, N> {
             /// Constructs a new, empty vector with a fixed capacity of `N`
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// use heapless::Vec;
-            ///
-            /// // allocate the vector on the stack
-            /// let mut x: Vec<u8, $Uxx, 16> = Vec::$name();
-            ///
-            /// // allocate the vector in a static variable
-            /// static mut X: Vec<u8, $Uxx, 16> = Vec::$name();
-            /// ```
             /// `Vec` `const` constructor; wrap the returned value in [`Vec`](../struct.Vec.html)
             pub const fn $name() -> Self {
                 Self {
@@ -74,7 +62,20 @@ impl_new!(u16, u16);
 impl_new!(usize, usize);
 
 impl<T, const N: usize> Vec<T, usize, N> {
-    /// Alias for `usize()`
+    /// Constructs a new, empty vector with a fixed capacity of `N` and length type of `usize`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use heapless::Vec;
+    ///
+    /// // allocate the vector on the stack
+    /// let mut x: Vec<u8, _, 16> = Vec::new();
+    ///
+    /// // allocate the vector in a static variable
+    /// static mut X: Vec<u8, usize, 16> = Vec::new();
+    /// ```
+    /// `Vec` `const` constructor; wrap the returned value in [`Vec`](../struct.Vec.html)
     pub const fn new() -> Self {
         Self::usize()
     }
@@ -379,7 +380,7 @@ impl<T, U: Uxx, const N: usize> Vec<T, U, N> {
     /// use core::iter::FromIterator;
     /// use heapless::Vec;
     ///
-    /// let mut vec = Vec::<Vec<u8, usize, 3>, 3>::from_iter(
+    /// let mut vec = Vec::<Vec<u8, u8, 3>, u8, 3>::from_iter(
     ///     [
     ///         Vec::from_iter([1, 0, 0].iter().cloned()),
     ///         Vec::from_iter([0, 1, 0].iter().cloned()),
@@ -398,10 +399,10 @@ impl<T, U: Uxx, const N: usize> Vec<T, U, N> {
     ///
     /// Normally, here, one would use [`clear`] instead to correctly drop
     /// the contents and thus not leak memory.
-    pub unsafe fn set_len(&mut self, new_len: U) {
-        debug_assert!(new_len.into() <= self.capacity_nonconst());
+    pub unsafe fn set_len(&mut self, new_len: usize) {
+        debug_assert!(new_len <= self.capacity_nonconst());
 
-        self.len = new_len
+        self.len = U::truncate(new_len)
     }
 
     /// Removes an element from the vector and returns it.

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -56,7 +56,7 @@ macro_rules! impl_new {
     ($Uxx:ident, $name:ident) => {
         impl<T, const N: usize> VecBase<T, $Uxx, N> {
             /// Constructs a new, empty vector with a fixed capacity of `N`
-            /// `Vec` `const` constructor; wrap the returned value in [`Vec`](../struct.Vec.html)
+            /// `Vec` `const` constructor; wrap the returned value in [`VecBase`](../struct.VecBase.html)
             pub const fn $name() -> Self {
                 Self {
                     buffer: MaybeUninit::uninit(),
@@ -90,7 +90,6 @@ impl<T, const N: usize> Vec<T, N> {
     /// // allocate the vector in a static variable
     /// static mut X: Vec<u8, usize, 16> = Vec::new();
     /// ```
-    /// `Vec` `const` constructor; wrap the returned value in [`Vec`](../struct.Vec.html)
     pub const fn new() -> Self {
         Self::usize()
     }
@@ -291,7 +290,7 @@ impl<T, U: Uxx, const N: usize> VecBase<T, U, N> {
     /// difference, with each additional slot filled with value. If
     /// new_len is less than len, the Vec is simply truncated.
     ///
-    /// See also [`resize_default`](struct.Vec.html#method.resize_default).
+    /// See also [`resize_default`](struct.VecBase.html#method.resize_default).
     pub fn resize(&mut self, new_len: usize, value: T) -> Result<(), ()>
     where
         T: Clone,
@@ -317,7 +316,7 @@ impl<T, U: Uxx, const N: usize> VecBase<T, U, N> {
     /// difference, with each additional slot filled with `U::truncate(0)`.
     /// If `new_len` is less than `len`, the `Vec` is simply truncated.
     ///
-    /// See also [`resize`](struct.Vec.html#method.resize).
+    /// See also [`resize`](struct.VecBase.html#method.resize).
     pub fn resize_default(&mut self, new_len: usize) -> Result<(), ()>
     where
         T: Clone + Default,
@@ -652,9 +651,9 @@ impl<T, U: Uxx, const N: usize> FromIterator<T> for VecBase<T, U, N> {
     }
 }
 
-/// An iterator that moves out of an [`Vec`][`Vec`].
+/// An iterator that moves out of an [`VecBase`][`VecBase`].
 ///
-/// This struct is created by calling the `into_iter` method on [`Vec`][`Vec`].
+/// This struct is created by calling the `into_iter` method on [`VecBase`][`VecBase`].
 ///
 /// [`Vec`]: (https://doc.rust-lang.org/std/vec/struct.Vec.html)
 ///

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -5,6 +5,23 @@ use crate::sealed::spsc::Uxx;
 
 /// A fixed capacity [`Vec`](https://doc.rust-lang.org/std/vec/struct.Vec.html)
 ///
+/// The length type of `VecBase` and `VecBase`-based containers is generic and can use `u8`, `u16`,
+/// or `usize`. Using smaller length types can reduce memory footprint for containers with low
+/// alignment requirements.  The easiest way to construct a `VecBase` with a smaller index type is
+/// to use the [`u8`] and [`u16`] constructors.
+///
+/// [`u8`]: struct.VecBase.html#method.u8
+/// [`u16`]: struct.VecBase.html#method.u16
+///
+/// *IMPORTANT*: `VecBase<_, u8, N>` has a maximum capacity of 255 elements; `VecBase<_, u16, N>`
+/// has a maximum capacity of 65535 elements.
+pub struct VecBase<T, U: Uxx, const N: usize> {
+    buffer: MaybeUninit<[T; N]>,
+    len: U,
+}
+
+/// A `VecBase` that has a length type of `usize`.
+///
 /// # Examples
 ///
 /// ```
@@ -33,21 +50,6 @@ use crate::sealed::spsc::Uxx;
 /// assert_eq!(*vec, [7, 1, 2, 3]);
 /// ```
 ///
-/// The length type of `Vec` and `Vec`-based containers is generic and can use `u8`, `u16`, or
-/// `usize`. Using smaller length types can reduce memory footprint for containers with low
-/// alignment requirements.  The easiest way to construct a `Vec` with a smaller index type is to
-/// use the [`u8`] and [`u16`] constructors.
-///
-/// [`u8`]: struct.Vec.html#method.u8
-/// [`u16`]: struct.Vec.html#method.u16
-///
-/// *IMPORTANT*: `Vec<_, u8, N>` has a maximum capacity of 255 elements; `Vec<_,
-/// u16, N>` has a maximum capacity of 65535 elements.
-pub struct VecBase<T, U: Uxx, const N: usize> {
-    buffer: MaybeUninit<[T; N]>,
-    len: U,
-}
-
 pub type Vec<T, const N: usize> = VecBase<T, usize, N>;
 
 macro_rules! impl_new {

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -53,10 +53,9 @@ pub struct VecBase<T, U: Uxx, const N: usize> {
 pub type Vec<T, const N: usize> = VecBase<T, usize, N>;
 
 macro_rules! impl_new {
-    ($Uxx:ident, $name:ident) => {
+    ($Uxx:ident, $name:ident, $doc:tt) => {
         impl<T, const N: usize> VecBase<T, $Uxx, N> {
-            /// Constructs a new, empty vector with a fixed capacity of `N`
-            /// `Vec` `const` constructor; wrap the returned value in [`VecBase`](../struct.VecBase.html)
+            #[doc = $doc]
             pub const fn $name() -> Self {
                 Self {
                     buffer: MaybeUninit::uninit(),
@@ -72,9 +71,8 @@ macro_rules! impl_new {
     };
 }
 
-impl_new!(u8, u8);
-impl_new!(u16, u16);
-impl_new!(usize, usize);
+impl_new!(u8, u8, "Constructs a new, empty vector with a fixed capacity of `N`. **Safety**: Assumes `N <= u8::MAX`.");
+impl_new!(u16, u16, "Constructs a new, empty vector with a fixed capacity of `N`. **Safety**: Assumes `N <= u16::MAX`.");
 
 impl<T, const N: usize> Vec<T, N> {
     /// Constructs a new, empty vector with a fixed capacity of `N` and length type of `usize`
@@ -91,7 +89,15 @@ impl<T, const N: usize> Vec<T, N> {
     /// static mut X: Vec<u8, 16> = Vec::new();
     /// ```
     pub const fn new() -> Self {
-        Self::usize()
+        Self {
+            buffer: MaybeUninit::uninit(),
+            len: 0,
+        }
+    }
+
+    /// Returns the maximum number of elements the vector can hold.
+    pub const fn capacity(&self) -> usize {
+        N
     }
 }
 

--- a/tests/cpass.rs
+++ b/tests/cpass.rs
@@ -20,6 +20,6 @@ fn send() {
     is_send::<Consumer<IsSend, usize, 4>>();
     is_send::<Producer<IsSend, usize, 4>>();
     is_send::<Queue<IsSend, usize, 4>>();
-    is_send::<Vec<IsSend, 4>>();
+    is_send::<Vec<IsSend, usize, 4>>();
     is_send::<HistoryBuffer<IsSend, 4>>();
 }

--- a/tests/cpass.rs
+++ b/tests/cpass.rs
@@ -21,5 +21,7 @@ fn send() {
     is_send::<Producer<IsSend, usize, 4>>();
     is_send::<Queue<IsSend, usize, 4>>();
     is_send::<Vec<IsSend, usize, 4>>();
+    is_send::<Vec<IsSend, u8, 4>>();
+    is_send::<Vec<IsSend, u16, 4>>();
     is_send::<HistoryBuffer<IsSend, 4>>();
 }

--- a/tests/cpass.rs
+++ b/tests/cpass.rs
@@ -2,7 +2,7 @@
 
 use heapless::{
     spsc::{Consumer, Producer, Queue},
-    HistoryBuffer, Vec,
+    HistoryBuffer, VecBase,
 };
 
 #[test]
@@ -20,8 +20,8 @@ fn send() {
     is_send::<Consumer<IsSend, usize, 4>>();
     is_send::<Producer<IsSend, usize, 4>>();
     is_send::<Queue<IsSend, usize, 4>>();
-    is_send::<Vec<IsSend, usize, 4>>();
-    is_send::<Vec<IsSend, u8, 4>>();
-    is_send::<Vec<IsSend, u16, 4>>();
+    is_send::<VecBase<IsSend, usize, 4>>();
+    is_send::<VecBase<IsSend, u8, 4>>();
+    is_send::<VecBase<IsSend, u16, 4>>();
     is_send::<HistoryBuffer<IsSend, 4>>();
 }


### PR DESCRIPTION
Basically the same as #204 except this one's on top of the const_generics branch. The compile-time capacity checking is gone because setting trait bounds with const generics is not supported (this is arguably a good thing because it makes the trait bounds much simpler). Also there's no default length type since default types and const generics don't mix. Still addresses #139.