### PR TITLE
Generic MPMC

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,17 +4,11 @@ authors = [
   "Per Lindgren <per.lindgren@ltu.se>",
   "Emil Fresk <emil.fresk@gmail.com>",
 ]
-categories = [
-    "data-structures",
-    "no-std",
-]
+categories = ["data-structures", "no-std"]
 description = "`static` friendly data structures that don't require dynamic memory allocation"
 documentation = "https://docs.rs/heapless"
 edition = "2018"
-keywords = [
-    "static",
-    "no-heap",
-]
+keywords = ["static", "no-heap"]
 license = "MIT OR Apache-2.0"
 name = "heapless"
 repository = "https://github.com/japaric/heapless"
@@ -28,6 +22,8 @@ ufmt-impl = ["ufmt-write"]
 x86-sync-pool = []
 # only for tests
 __trybuild = []
+# Enable larger MPMC sizes.
+mpmc_large = []
 
 [target.x86_64-unknown-linux-gnu.dev-dependencies]
 scoped_threadpool = "0.1.8"


### PR DESCRIPTION
Current MPMC has a very limited size set. This PR makes it generic over different sizes.

The PR also preserves the current behavior with U8 as max size. This should be completely backward compatible. 
There is also an alternative with Usized size which doesn't have the limitation on the number of elements. This can be enabled by the `mpmc_large` feature flag.