### PR TITLE
Adding assume_init function for Box

### DIFF
--- a/src/pool/mod.rs
+++ b/src/pool/mod.rs
@@ -425,6 +425,17 @@ impl<T> Box<T, Uninit> {
             _state: PhantomData,
         }
     }
+
+    /// Assumes the memory block is already initialized.
+    ///
+    /// # Safety
+    /// The underlying memory must be already initialized to an acceptable, defined state.
+    pub unsafe fn assume_init(self) -> Box<T, Init> {
+        Box {
+            node: self.node,
+            _state: PhantomData,
+        }
+    }
 }
 
 /// Uninitialized type state


### PR DESCRIPTION
This PR fixes #222 by adding an `assume_init()` for pool::Box structures. This allows the underlying box'd data to not require memory copies for initialization (e.g. for the case when an array is Box'd and the contents are not yet written).