### PR TITLE
Add PartialOrd and Ord to Vec and String

### DIFF
--- a/src/string.rs
+++ b/src/string.rs
@@ -1,4 +1,4 @@
-use core::{fmt, fmt::Write, hash, ops, str};
+use core::{cmp::Ordering, fmt, fmt::Write, hash, ops, str};
 
 use hash32;
 
@@ -438,6 +438,20 @@ impl<const N: usize> PartialEq<String<N>> for &str {
 }
 
 impl<const N: usize> Eq for String<N> {}
+
+impl<const N: usize> PartialOrd for String<N> {
+    #[inline]
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        PartialOrd::partial_cmp(&**self, &**other)
+    }
+}
+
+impl<const N: usize> Ord for String<N> {
+    #[inline]
+    fn cmp(&self, other: &Self) -> Ordering {
+        Ord::cmp(&**self, &**other)
+    }
+}
 
 macro_rules! impl_from_num {
     ($num:ty, $size:expr) => {

--- a/src/string.rs
+++ b/src/string.rs
@@ -439,9 +439,9 @@ impl<const N: usize> PartialEq<String<N>> for &str {
 
 impl<const N: usize> Eq for String<N> {}
 
-impl<const N: usize> PartialOrd for String<N> {
+impl<const N1: usize, const N2: usize> PartialOrd<String<N2>> for String<N1> {
     #[inline]
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+    fn partial_cmp(&self, other: &String<N2>) -> Option<Ordering> {
         PartialOrd::partial_cmp(&**self, &**other)
     }
 }

--- a/src/string.rs
+++ b/src/string.rs
@@ -495,6 +495,22 @@ mod tests {
     }
 
     #[test]
+    fn cmp() {
+        let s1: String<4> = String::from("abcd");
+        let s2: String<4> = String::from("zzzz");
+
+        assert!(s1 < s2);
+    }
+
+    #[test]
+    fn cmp_heterogenous_size() {
+        let s1: String<4> = String::from("abcd");
+        let s2: String<8> = String::from("zzzz");
+
+        assert!(s1 < s2);
+    }
+
+    #[test]
     fn debug() {
         use core::fmt::Write;
 

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -908,6 +908,32 @@ mod tests {
     }
 
     #[test]
+    fn cmp() {
+        let mut xs: Vec<i32, 4> = Vec::new();
+        let mut ys: Vec<i32, 4> = Vec::new();
+
+        assert_eq!(xs, ys);
+
+        xs.push(1).unwrap();
+        ys.push(2).unwrap();
+
+        assert!(xs < ys);
+    }
+
+    #[test]
+    fn cmp_heterogenous_size() {
+        let mut xs: Vec<i32, 4> = Vec::new();
+        let mut ys: Vec<i32, 8> = Vec::new();
+
+        assert_eq!(xs, ys);
+
+        xs.push(1).unwrap();
+        ys.push(2).unwrap();
+
+        assert!(xs < ys);
+    }
+
+    #[test]
     fn full() {
         let mut v: Vec<i32, 4> = Vec::new();
 

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -764,12 +764,11 @@ where
 // Implements Eq if underlying data is Eq
 impl<T, const N: usize> Eq for Vec<T, N> where T: Eq {}
 
-impl<T, const N: usize> PartialOrd for Vec<T, N>
+impl<T, const N1: usize, const N2: usize> PartialOrd<Vec<T, N2>> for Vec<T, N1>
 where
     T: PartialOrd,
 {
-    #[inline]
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+    fn partial_cmp(&self, other: &Vec<T, N2>) -> Option<Ordering> {
         PartialOrd::partial_cmp(&**self, &**other)
     }
 }

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -1,4 +1,4 @@
-use core::{fmt, hash, iter::FromIterator, mem::MaybeUninit, ops, ptr, slice};
+use core::{cmp::Ordering, fmt, hash, iter::FromIterator, mem::MaybeUninit, ops, ptr, slice};
 use hash32;
 
 /// A fixed capacity [`Vec`](https://doc.rust-lang.org/std/vec/struct.Vec.html)
@@ -763,6 +763,26 @@ where
 
 // Implements Eq if underlying data is Eq
 impl<T, const N: usize> Eq for Vec<T, N> where T: Eq {}
+
+impl<T, const N: usize> PartialOrd for Vec<T, N>
+where
+    T: PartialOrd,
+{
+    #[inline]
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        PartialOrd::partial_cmp(&**self, &**other)
+    }
+}
+
+impl<T, const N: usize> Ord for Vec<T, N>
+where
+    T: Ord,
+{
+    #[inline]
+    fn cmp(&self, other: &Self) -> Ordering {
+        Ord::cmp(&**self, &**other)
+    }
+}
 
 impl<T, const N: usize> ops::Deref for Vec<T, N> {
     type Target = [T];


### PR DESCRIPTION
As described in the subject. These were missing and are otherwise implemented by the standard library.