### PR TITLE
fix return value of `Pool::grow` on x86_64

### DIFF
--- a/src/pool/mod.rs
+++ b/src/pool/mod.rs
@@ -359,15 +359,16 @@ impl<T> Pool<T> {
                 () => {
                     if let Some(p) = Ptr::new(p as *mut _) {
                         self.stack.push(p);
+                        n += 1;
                     }
                 }
 
                 #[cfg(not(target_arch = "x86_64"))]
                 () => {
                     self.stack.push(unsafe { Ptr::new_unchecked(p as *mut _) });
+                    n += 1;
                 }
             }
-            n += 1;
 
             p = unsafe { p.add(sz) };
             len -= sz;


### PR DESCRIPTION
the logic was increasing the "capacity" counter even in the case the given memory address was out of
range (ANCHOR +- 2GB) -- `None` branch in code -- resulting in a wrong / misleading value being
reported