### PR TITLE
Sync Pool support for (32-bit) x86

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,8 +41,8 @@ jobs:
       matrix:
         target:
           - x86_64-unknown-linux-gnu
+          - i686-unknown-linux-musl
           - riscv32imc-unknown-none-elf
-          - x86_64-unknown-linux-gnu
           - armv7r-none-eabi
           - thumbv6m-none-eabi
           - thumbv7m-none-eabi
@@ -102,6 +102,7 @@ jobs:
       matrix:
         target:
           - x86_64-unknown-linux-gnu
+          - i686-unknown-linux-musl
         toolchain:
           - stable
           - nightly
@@ -157,6 +158,7 @@ jobs:
       matrix:
         target:
           - x86_64-unknown-linux-gnu
+          - i686-unknown-linux-musl
         toolchain:
           - nightly
         features:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -158,7 +158,6 @@ jobs:
       matrix:
         target:
           - x86_64-unknown-linux-gnu
-          - i686-unknown-linux-musl
         toolchain:
           - nightly
         features:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ __trybuild = []
 mpmc_large = []
 defmt-impl = ["defmt"]
 
-[target.x86_64-unknown-linux-gnu.dev-dependencies]
+[target.'cfg(any(target_arch = "x86_64", target_arch = "x86"))'.dev-dependencies]
 scoped_threadpool = "0.1.8"
 
 [target.thumbv6m-none-eabi.dependencies]
@@ -58,4 +58,3 @@ optional = true
 [dev-dependencies.defmt]
 version = "0.2.1"
 features = ["unstable-test"]
-

--- a/src/pool/mod.rs
+++ b/src/pool/mod.rs
@@ -267,7 +267,10 @@ pub struct Pool<T> {
     armv7r,
     armv7m,
     armv8m_main,
-    all(target_arch = "x86_64", feature = "x86-sync-pool"),
+    all(
+        any(target_arch = "x86_64", target_arch = "x86"),
+        feature = "x86-sync-pool"
+    ),
     test
 ))]
 unsafe impl<T> Sync for Pool<T> {}

--- a/src/pool/singleton.rs
+++ b/src/pool/singleton.rs
@@ -19,7 +19,10 @@ use super::{Init, Node, Uninit};
     armv7r,
     armv7m,
     armv8m_main,
-    all(target_arch = "x86_64", feature = "x86-sync-pool"),
+    all(
+        any(target_arch = "x86_64", target_arch = "x86"),
+        feature = "x86-sync-pool"
+    ),
     test
 ))]
 #[macro_export]


### PR DESCRIPTION
the implementation uses a 64-bit atomic on `x86` to avoid the `ANCHOR` variable and the address
space limitation seen with the x86_64 compilation target

this PR also adds the i686-linux-musl target to the test matrix to exercise the new implementation

closes #231