### PR TITLE
CAS Pool x86_64: lazily initialized ANCHOR

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,9 @@ atomic-polyfill = { version = "0.1.2", optional = true }
 [dependencies]
 hash32 = "0.2.1"
 
+[target.'cfg(target_arch = "x86_64")'.dependencies]
+spin = "0.9.2"
+
 [dependencies.serde]
 version = "1"
 optional = true


### PR DESCRIPTION
this reduces the chances of hitting the 32-bit address space issue on x86_64

instead of (always) using a static ANCHOR variable located in .bss we lazily initialize the ANCHOR
variable using the value passed to the first `Ptr::new` invocation. In practice, this means the very
first `Pool::grow` (on x86_64) call is guaranteed to work (use the given memory). Follow up `grow`
invocations are *more likely* to work (but not guaranteed) *if* all given memory comes from the
heap.

We still need an ANCHOR in .bss as a fallback because it's possible to allocate ZST on a pool
without calling `Pool::grow` (= the lazily init ANCHOR is never initialized *but* it can be read)