### PR TITLE
Miri fixes

### DIFF
--- a/src/deque.rs
+++ b/src/deque.rs
@@ -350,7 +350,7 @@ impl<T, const N: usize> Deque<T, N> {
         let done = self.is_empty();
         IterMut {
             _phantom: PhantomData,
-            buffer: &mut self.buffer[0] as *mut MaybeUninit<T>,
+            buffer: &mut self.buffer as *mut _ as *mut MaybeUninit<T>,
             front: self.front,
             back: self.back,
             done,

--- a/src/deque.rs
+++ b/src/deque.rs
@@ -168,22 +168,21 @@ impl<T, const N: usize> Deque<T, N> {
 
     /// Returns a pair of mutable slices which contain, in order, the contents of the `Deque`.
     pub fn as_mut_slices(&mut self) -> (&mut [T], &mut [T]) {
+        let ptr = self.buffer.as_mut_ptr();
+
         // NOTE(unsafe) avoid bound checks in the slicing operation
         unsafe {
             if self.is_empty() {
                 (&mut [], &mut [])
             } else if self.back <= self.front {
                 (
-                    slice::from_raw_parts_mut(
-                        self.buffer.as_mut_ptr().add(self.front) as *mut T,
-                        N - self.front,
-                    ),
-                    slice::from_raw_parts_mut(self.buffer.as_mut_ptr() as *mut T, self.back),
+                    slice::from_raw_parts_mut(ptr.add(self.front) as *mut T, N - self.front),
+                    slice::from_raw_parts_mut(ptr as *mut T, self.back),
                 )
             } else {
                 (
                     slice::from_raw_parts_mut(
-                        self.buffer.as_mut_ptr().add(self.front) as *mut T,
+                        ptr.add(self.front) as *mut T,
                         self.back - self.front,
                     ),
                     &mut [],

--- a/src/spsc.rs
+++ b/src/spsc.rs
@@ -621,6 +621,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // too slow
     fn len() {
         let mut rb: Queue<i32, 3> = Queue::new();
 
@@ -641,6 +642,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // too slow
     fn try_overflow() {
         const N: usize = 23;
         let mut rb: Queue<i32, N> = Queue::new();

--- a/tests/tsan.rs
+++ b/tests/tsan.rs
@@ -74,6 +74,7 @@ fn scoped() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)] // too slow
 fn contention() {
     const N: usize = 1024;
 
@@ -118,6 +119,7 @@ fn contention() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)] // too slow
 fn mpmc_contention() {
     const N: u32 = 64;
 
@@ -163,6 +165,7 @@ fn mpmc_contention() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)] // too slow
 fn unchecked() {
     const N: usize = 1024;
 


### PR DESCRIPTION
- Fix 2 miri errors in `Deque`
- Ignore a few tests that take way too long in miri (gave up after waiting 5+ min)