### PR TITLE
Add an "order()" method for re-arranging the backing buffer of HistoryBuffer from oldest data to newest

### DIFF
--- a/src/histbuf.rs
+++ b/src/histbuf.rs
@@ -182,7 +182,7 @@ impl<T, const N: usize> HistoryBuffer<T, N> {
         unsafe { slice::from_raw_parts(self.data.as_ptr() as *const _, self.len()) }
     }
 
-    /// Re-arranges the backing buffer to that it is ordered from oldest to newest
+    /// Re-arranges the backing buffer so that it is ordered from oldest to newest
     ///
     /// # Example
     /// ```
@@ -203,10 +203,7 @@ impl<T, const N: usize> HistoryBuffer<T, N> {
     /// assert_eq!(x.as_slice(), [0, 1, 2, 3, 4, 5]);
     /// ```
     pub fn order(&mut self) {
-        let offset = self.write_at;
-        for i in 0..self.len()-offset {
-            self.data.swap(i, offset+i);
-        }
+        self.data.rotate_left(self.write_at);
         self.write_at = 0;
     }
 }
@@ -346,15 +343,14 @@ mod tests {
     #[test]
     fn order() {
         let mut x:HistoryBuffer<u8, 6> = HistoryBuffer::new();
-        x.write(0);
-        x.write(0);
-        x.write(0);
-        x.write(1);
-        x.write(2);
-        x.write(3);
-        x.write(4);
-        x.write(5);
+        x.extend([0, 0, 0, 1, 2, 3, 4, 5]);
         x.order();
         assert_eq!(x.as_slice(), [0, 1, 2, 3, 4, 5]);
+
+        let mut x:HistoryBuffer<u8, 4> = HistoryBuffer::new();
+
+        x.extend([0, 1, 2, 3, 4, 5, 6]);
+        x.order();
+        assert_eq!(x.as_slice(), [3,4,5,6]);
     }
 }

--- a/src/histbuf.rs
+++ b/src/histbuf.rs
@@ -352,5 +352,11 @@ mod tests {
         x.extend([0, 1, 2, 3, 4, 5, 6]);
         x.order();
         assert_eq!(x.as_slice(), [3, 4, 5, 6]);
+
+        // test to make sure we do not break the length
+        let mut x: HistoryBuffer<u8, 6> = HistoryBuffer::new();
+        x.extend([1, 2, 3]);
+        x.order();
+        assert_eq!(x.len(), 3);
     }
 }

--- a/src/histbuf.rs
+++ b/src/histbuf.rs
@@ -184,7 +184,7 @@ impl<T, const N: usize> HistoryBuffer<T, N> {
 
     // Re-arranges the data so that the underlying array slice is ordered oldest to newest
     pub fn order(&mut self) {
-        let offset = self.write_at
+        let offset = self.write_at;
         for i in 0..offset {
             self.data.swap(i, offset+i);
         }

--- a/src/histbuf.rs
+++ b/src/histbuf.rs
@@ -184,7 +184,8 @@ impl<T, const N: usize> HistoryBuffer<T, N> {
 
     // Re-arranges the data so that the underlying array slice is ordered oldest to newest
     pub fn order(&mut self) {
-        for i in 0..self.write_at {
+        let offset = self.write_at
+        for i in 0..offset {
             self.data.swap(i, offset+i);
         }
         self.write_at = 0;

--- a/src/histbuf.rs
+++ b/src/histbuf.rs
@@ -182,7 +182,24 @@ impl<T, const N: usize> HistoryBuffer<T, N> {
         unsafe { slice::from_raw_parts(self.data.as_ptr() as *const _, self.len()) }
     }
 
-    // Re-arranges the data so that the underlying array slice is ordered oldest to newest
+    /// Re-arranges the backing buffer to that it is ordered from oldest to newest
+    ///
+    /// # Example
+    /// ```
+    /// use heapless::HistoryBuffer;
+    ///
+    /// let mut x: HistoryBuffer<u8, 6> = HistoryBuffer::new();
+    /// x.write(0);
+    /// x.write(0);
+    /// x.write(0);
+    /// x.write(1);
+    /// x.write(2);
+    /// x.write(3);
+    /// x.write(4);
+    /// x.write(5);
+    ///
+    /// assert_eq!(x.as_slice(), [0, 1, 2, 3, 4, 5]);
+    /// ```
     pub fn order(&mut self) {
         let offset = self.write_at;
         for i in 0..self.len()-offset {
@@ -322,5 +339,20 @@ mod tests {
         x.extend([1, 2, 3, 4, 5].iter());
 
         assert_eq!(x.as_slice(), [5, 2, 3, 4]);
+    }
+
+    #[test]
+    fn order() {
+        let mut x:HistoryBuffer<u8, 6> = HistoryBuffer::new();
+        x.write(0);
+        x.write(0);
+        x.write(0);
+        x.write(1);
+        x.write(2);
+        x.write(3);
+        x.write(4);
+        x.write(5);
+        x.order();
+        assert_eq!(x.as_slice(), [0, 1, 2, 3, 4, 5]);
     }
 }

--- a/src/histbuf.rs
+++ b/src/histbuf.rs
@@ -342,15 +342,15 @@ mod tests {
 
     #[test]
     fn order() {
-        let mut x:HistoryBuffer<u8, 6> = HistoryBuffer::new();
+        let mut x: HistoryBuffer<u8, 6> = HistoryBuffer::new();
         x.extend([0, 0, 0, 1, 2, 3, 4, 5]);
         x.order();
         assert_eq!(x.as_slice(), [0, 1, 2, 3, 4, 5]);
 
-        let mut x:HistoryBuffer<u8, 4> = HistoryBuffer::new();
+        let mut x: HistoryBuffer<u8, 4> = HistoryBuffer::new();
 
         x.extend([0, 1, 2, 3, 4, 5, 6]);
         x.order();
-        assert_eq!(x.as_slice(), [3,4,5,6]);
+        assert_eq!(x.as_slice(), [3, 4, 5, 6]);
     }
 }

--- a/src/histbuf.rs
+++ b/src/histbuf.rs
@@ -181,6 +181,14 @@ impl<T, const N: usize> HistoryBuffer<T, N> {
     pub fn as_slice(&self) -> &[T] {
         unsafe { slice::from_raw_parts(self.data.as_ptr() as *const _, self.len()) }
     }
+
+    // Re-arranges the data so that the underlying array slice is ordered oldest to newest
+    pub fn order(&mut self) {
+        for i in 0..self.write_at {
+            self.data.swap(i, offset+i);
+        }
+        self.write_at = 0;
+    }
 }
 
 impl<T, const N: usize> Extend<T> for HistoryBuffer<T, N> {

--- a/src/histbuf.rs
+++ b/src/histbuf.rs
@@ -203,8 +203,10 @@ impl<T, const N: usize> HistoryBuffer<T, N> {
     /// assert_eq!(x.as_slice(), [0, 1, 2, 3, 4, 5]);
     /// ```
     pub fn order(&mut self) {
-        self.data.rotate_left(self.write_at);
-        self.write_at = 0;
+        if self.filled {
+            self.data.rotate_left(self.write_at);
+            self.write_at = 0;
+        }
     }
 }
 

--- a/src/histbuf.rs
+++ b/src/histbuf.rs
@@ -198,6 +198,8 @@ impl<T, const N: usize> HistoryBuffer<T, N> {
     /// x.write(4);
     /// x.write(5);
     ///
+    /// x.order();
+    ///
     /// assert_eq!(x.as_slice(), [0, 1, 2, 3, 4, 5]);
     /// ```
     pub fn order(&mut self) {

--- a/src/histbuf.rs
+++ b/src/histbuf.rs
@@ -185,7 +185,7 @@ impl<T, const N: usize> HistoryBuffer<T, N> {
     // Re-arranges the data so that the underlying array slice is ordered oldest to newest
     pub fn order(&mut self) {
         let offset = self.write_at;
-        for i in 0..offset {
+        for i in 0..self.len()-offset {
             self.data.swap(i, offset+i);
         }
         self.write_at = 0;


### PR DESCRIPTION
This is a simple no-copy method for re-arranging the underlying buffer from oldest data to newest.  Very useful when used in from of as_slice(), which makes no such guarantees.