### PR TITLE
Feature/historybuf ordered iterator

### DIFF
--- a/src/histbuf.rs
+++ b/src/histbuf.rs
@@ -272,6 +272,7 @@ impl<T, const N: usize> Default for HistoryBuffer<T, N> {
     }
 }
 
+/// An iterator on the underlying buffer ordered from oldest data to newest
 #[derive(Clone)]
 pub struct OrderedIter<'a, T, const N: usize> {
     buf: &'a HistoryBuffer<T, N>,

--- a/src/histbuf.rs
+++ b/src/histbuf.rs
@@ -272,6 +272,7 @@ impl<T, const N: usize> Default for HistoryBuffer<T, N> {
     }
 }
 
+#[derive(Clone)]
 pub struct OrderedIter<'a, T, const N: usize> {
     buf: &'a HistoryBuffer<T, N>,
     cur: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,7 @@
 
 pub use binary_heap::BinaryHeap;
 pub use deque::Deque;
-pub use histbuf::HistoryBuffer;
+pub use histbuf::{HistoryBuffer, OrderedIter};
 pub use indexmap::{Bucket, FnvIndexMap, IndexMap, Pos};
 pub use indexset::{FnvIndexSet, IndexSet};
 pub use linear_map::LinearMap;


### PR DESCRIPTION
This adds a method called .ordered() to the HistoryBuffer which returns an iterator over the underlying buffer that starts from the oldest data and stops at the last data entered (regardless if the buffer is full).  This implementation will be in lieu of #247, which will be rejected.

It would be easy to modify this to be simple an implentation of the IntoIterator trait, which would allow it to be used in certain functions  and methods that expect a generic that implements such a trait.  However, given the slightly specialized nature of what it does I thought it more suitable to use a more descriptive name.