### PR TITLE
Relax Vec bounds to allow for zero-length Vecs

### DIFF
--- a/src/sealed.rs
+++ b/src/sealed.rs
@@ -54,6 +54,12 @@ pub(crate) const fn smaller_than<const N: usize, const MAX: usize>() {
 
 #[allow(dead_code)]
 #[allow(path_statements)]
+pub(crate) const fn greater_than_eq_0<const N: usize>() {
+    Assert::<N, 0>::GREATER_EQ;
+}
+
+#[allow(dead_code)]
+#[allow(path_statements)]
 pub(crate) const fn greater_than_0<const N: usize>() {
     Assert::<N, 0>::GREATER;
 }

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -56,8 +56,8 @@ impl<T, const N: usize> Vec<T, N> {
     /// ```
     /// `Vec` `const` constructor; wrap the returned value in [`Vec`](../struct.Vec.html)
     pub const fn new() -> Self {
-        // Const assert N > 0
-        crate::sealed::greater_than_0::<N>();
+        // Const assert N >= 0
+        crate::sealed::greater_than_eq_0::<N>();
 
         Self {
             buffer: [Self::INIT; N],
@@ -1232,5 +1232,24 @@ mod tests {
         assert!(!v.ends_with(b"abc"));
         assert!(!v.ends_with(b"ba"));
         assert!(!v.ends_with(b"a"));
+    }
+
+    #[test]
+    fn zero_capacity() {
+        let mut v: Vec<u8, 0> = Vec::new();
+        // Validate capacity
+        assert_eq!(v.capacity(), 0);
+
+        // Make sure there is no capacity
+        assert!(v.push(1).is_err());
+
+        // Validate length
+        assert_eq!(v.len(), 0);
+
+        // Validate pop
+        assert_eq!(v.pop(), None);
+
+        // Validate slice
+        assert_eq!(v.as_slice(), &[]);
     }
 }

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -1251,5 +1251,11 @@ mod tests {
 
         // Validate slice
         assert_eq!(v.as_slice(), &[]);
+
+        // Validate empty
+        assert!(v.is_empty());
+
+        // Validate full
+        assert!(v.is_full());
     }
 }


### PR DESCRIPTION
Use when building generated code where it's possible to have a zero
length array/vector (e.g. wire-format). See #252

- Added vec::tests::zero_capacity test
- Added sealed::greater_than_eq_0