### PR TITLE
add BinaryHeap::into_vec

### DIFF
--- a/src/binary_heap.rs
+++ b/src/binary_heap.rs
@@ -100,7 +100,7 @@ impl private::Sealed for Min {}
 
 pub struct BinaryHeap<T, K, const N: usize> {
     pub(crate) _kind: PhantomData<K>,
-    pub(crate) data: ManuallyDrop<Vec<T, N>>,
+    pub(crate) data: Vec<T, N>,
 }
 
 impl<T, K, const N: usize> BinaryHeap<T, K, N> {
@@ -120,7 +120,7 @@ impl<T, K, const N: usize> BinaryHeap<T, K, N> {
     pub const fn new() -> Self {
         Self {
             _kind: PhantomData,
-            data: ManuallyDrop::new(Vec::new()),
+            data: Vec::new(),
         }
     }
 }
@@ -338,10 +338,7 @@ where
 
     /// Returns the underlying ```Vec<T,N>```. Order is arbitrary and time is O(1).
     pub fn into_vec(self) -> Vec<T, N> {
-        // prevents dropping self.data at the end of this fn
-        let mut dropless_heap = ManuallyDrop::new(self);
-        // https://users.rust-lang.org/t/moving-out-of-a-type-implementing-drop/38225/5
-        unsafe { ManuallyDrop::take(&mut dropless_heap.data) }
+        self.data
     }
 
     /* Private API */


### PR DESCRIPTION
std::collections::BinaryHeap provides an into_vec method https://doc.rust-lang.org/std/collections/struct.BinaryHeap.html#method.into_vec

My use case is I want a sorted iterator  similar to BinaryHeap.into_sorted_iter. I found my self creating a new heapless:Vec from heapless::BinaryHeap::into_iter and then sorting it. It seemed better to return the underlying vec and sort that.

But the functionality seemed generally useful and helps the API jive a little better with std::collections::BinaryHeap.

Do you see any issues with this implementation? Also, apologies for anything weird... This is my first PR :) 

