### PR TITLE
Feature/historybuf `OldestOrdered` iterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Added `OldestOrdered` iterator for `HistoryBuffer`
+
 ## [v0.7.7] - 2021-09-22
 
 ### Fixed

--- a/src/histbuf.rs
+++ b/src/histbuf.rs
@@ -272,6 +272,7 @@ impl<T, const N: usize> Default for HistoryBuffer<T, N> {
     }
 }
 
+/// An iterator on the underlying buffer ordered from oldest data to newest
 #[derive(Clone)]
 pub struct OrderedIter<'a, T, const N: usize> {
     buf: &'a HistoryBuffer<T, N>,

--- a/src/histbuf.rs
+++ b/src/histbuf.rs
@@ -272,6 +272,7 @@ impl<T, const N: usize> Default for HistoryBuffer<T, N> {
     }
 }
 
+#[derive(Clone)]
 pub struct OrderedIter<'a, T, const N: usize> {
     buf: &'a HistoryBuffer<T, N>,
     cur: usize,

--- a/src/histbuf.rs
+++ b/src/histbuf.rs
@@ -384,26 +384,19 @@ mod tests {
         assert_eq!(iter.next(), None);
         assert_eq!(iter.next(), None);
 
-        let mut buffer: HistoryBuffer<u8, 6> = HistoryBuffer::new();
-        buffer.write(1);
-        let mut iter = buffer.oldest_ordered();
-        assert_eq!(iter.next(), Some(&1));
-        assert_eq!(iter.next(), None);
-
-        // test on a filled buffer
-        let mut buffer: HistoryBuffer<u8, 6> = HistoryBuffer::new();
-        buffer.extend([0, 0, 0, 1, 2, 3, 4, 5, 6]);
-        assert_eq!(buffer.len(), 6);
-
-        assert_eq_iter(buffer.oldest_ordered(), &[1, 2, 3, 4, 5, 6]);
-
         // test on a un-filled buffer
         let mut buffer: HistoryBuffer<u8, 6> = HistoryBuffer::new();
         buffer.extend([1, 2, 3]);
         assert_eq!(buffer.len(), 3);
         assert_eq_iter(buffer.oldest_ordered(), &[1, 2, 3]);
 
-        // comprehensive test
+        // test on a filled buffer
+        let mut buffer: HistoryBuffer<u8, 6> = HistoryBuffer::new();
+        buffer.extend([0, 0, 0, 1, 2, 3, 4, 5, 6]);
+        assert_eq!(buffer.len(), 6);
+        assert_eq_iter(buffer.oldest_ordered(), &[1, 2, 3, 4, 5, 6]);
+
+        // comprehensive test all cases
         for n in 0..50 {
             const N: usize = 7;
             let mut buffer: HistoryBuffer<u8, N> = HistoryBuffer::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,7 @@
 
 pub use binary_heap::BinaryHeap;
 pub use deque::Deque;
-pub use histbuf::HistoryBuffer;
+pub use histbuf::{HistoryBuffer, OrderedIter};
 pub use indexmap::{Bucket, FnvIndexMap, IndexMap, Pos};
 pub use indexset::{FnvIndexSet, IndexSet};
 pub use linear_map::LinearMap;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,7 @@
 
 pub use binary_heap::BinaryHeap;
 pub use deque::Deque;
-pub use histbuf::{HistoryBuffer, OrderedIter};
+pub use histbuf::{HistoryBuffer, OldestOrdered};
 pub use indexmap::{Bucket, FnvIndexMap, IndexMap, Pos};
 pub use indexset::{FnvIndexSet, IndexSet};
 pub use linear_map::LinearMap;


### PR DESCRIPTION
My use case requires an oldest..newest iterator. I tried https://github.com/japaric/heapless/pull/253 but ran into a crash when the buffer was empty (len = 0).

This PR:
- fixes the crash when len is 0
- adds more test cases
- addresses https://github.com/japaric/heapless/pull/253#issuecomment-1012914870