### PR TITLE
assume native compilation if target_os is not "none" to allow non-x86 hosts to run tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `cargo test` can now run on non-`x86` hosts
+
 ## [v0.7.9] - 2021-12-16
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ mpmc_large = []
 # This flag has no version guarantee, the `defmt` dependency can be updated in a patch release
 defmt-impl = ["defmt"]
 
-[target.'cfg(any(target_arch = "x86_64", target_arch = "x86"))'.dev-dependencies]
+[target.'cfg(not(target_os = "none"))'.dev-dependencies]
 scoped_threadpool = "0.1.8"
 
 [target.thumbv6m-none-eabi.dependencies]


### PR DESCRIPTION
I have an M1 Mac so the x86 specific test prevented me from running `cargo test`. I'm not sure why `scoped_threadpool` isn't just a plain old [`dev-dependency]` though... should I just make it an unqualified `[dev-dependency]` instead?