### PR TITLE
Add feature gate for atomic load/store, gate `spsc` behind `loadstore` (Alternative fix for #271)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,10 @@ repository = "https://github.com/japaric/heapless"
 version = "0.7.10"
 
 [features]
-default = ["cas"]
+default = ["atomics"]
+atomics = ["loadstore", "cas"]
 cas = ["atomic-polyfill"]
+loadstore = ["atomic-polyfill"]
 ufmt-impl = ["ufmt-write"]
 # read the docs before enabling: makes `Pool` Sync on x86_64
 x86-sync-pool = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,7 +106,7 @@ pub mod mpmc;
 #[cfg(all(has_cas, feature = "cas"))]
 pub mod pool;
 pub mod sorted_linked_list;
-#[cfg(has_atomics)]
+#[cfg(all(has_atomics, feature = "loadstore"))]
 pub mod spsc;
 
 #[cfg(feature = "ufmt-impl")]


### PR DESCRIPTION
The `spsc` module should only be build when `atomic_polyfill` is available. It's a big dependency (pulls in 12 extra dependencies) so for projects that don't need the atomics it's better to hide it behind a (default) feature gate.

I added two new features:
* `loadstore` that pulls in `atomic_polyfill` for architectures that need it and gates `spsc`
* `atomics` that enables `loadstone` and `cas` (replaces `cas` as the default feature)

Doing it this way should allow for more granular configuration of architectures, i.e. only pull-in `atomic_polyfill` if an architecture uses `loadstore` and doesn't have native support. This pull request does not contain that granularity as I'm not familiar with other architectures.