### PR TITLE
Add support for Arduino Uno and 2560

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Added support for AVR architecture
+
 ### Changed
 
 ## [v0.7.10] - 2022-01-21

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,10 +36,7 @@ atomic-polyfill = { version = "0.1.4" }
 [target.riscv32imc-unknown-none-elf.dependencies]
 atomic-polyfill = { version = "0.1.4" }
 
-[target.avr-atmega328p.dependencies]
-atomic-polyfill = { version = "0.1.8", optional = true }
-
-[target.avr-atmega2560.dependencies]
+[target.'cfg(target_arch = "avr")'.dependencies]
 atomic-polyfill = { version = "0.1.8", optional = true }
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,13 +31,17 @@ defmt-impl = ["defmt"]
 scoped_threadpool = "0.1.8"
 
 [target.thumbv6m-none-eabi.dependencies]
-atomic-polyfill = { version = "0.1.2", optional = true }
+atomic-polyfill = { git="https://github.com/mutantbob/atomic-polyfill.git", branch="main", optional = true }
 
 [target.riscv32i-unknown-none-elf.dependencies]
-atomic-polyfill = { version = "0.1.4", optional = true }
+atomic-polyfill = { git="https://github.com/mutantbob/atomic-polyfill.git", branch="main", optional = true }
 
 [target.riscv32imc-unknown-none-elf.dependencies]
-atomic-polyfill = { version = "0.1.4", optional = true }
+atomic-polyfill = { git="https://github.com/mutantbob/atomic-polyfill.git", branch="main", optional = true }
+
+[target.avr-atmega328p.dependencies]
+atomic-polyfill = { git="https://github.com/mutantbob/atomic-polyfill.git", branch="main", optional = true }
+
 
 [dependencies]
 hash32 = "0.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,10 +40,10 @@ atomic-polyfill = { version = "0.1.4", optional = true }
 atomic-polyfill = { version = "0.1.4", optional = true }
 
 [target.avr-atmega328p.dependencies]
-atomic-polyfill = { version = "0.1.7", optional = true }
+atomic-polyfill = { version = "0.1.8", optional = true }
 
 [target.avr-atmega2560.dependencies]
-atomic-polyfill = { version = "0.1.7", optional = true }
+atomic-polyfill = { version = "0.1.8", optional = true }
 
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,19 +31,19 @@ defmt-impl = ["defmt"]
 scoped_threadpool = "0.1.8"
 
 [target.thumbv6m-none-eabi.dependencies]
-atomic-polyfill = { git="https://github.com/mutantbob/atomic-polyfill.git", branch="main", optional = true }
+atomic-polyfill = { version = "0.1.2", optional = true }
 
 [target.riscv32i-unknown-none-elf.dependencies]
-atomic-polyfill = { git="https://github.com/mutantbob/atomic-polyfill.git", branch="main", optional = true }
+atomic-polyfill = { version = "0.1.4", optional = true }
 
 [target.riscv32imc-unknown-none-elf.dependencies]
-atomic-polyfill = { git="https://github.com/mutantbob/atomic-polyfill.git", branch="main", optional = true }
+atomic-polyfill = { version = "0.1.4", optional = true }
 
 [target.avr-atmega328p.dependencies]
-atomic-polyfill = { git="https://github.com/mutantbob/atomic-polyfill.git", branch="main", optional = true }
+atomic-polyfill = { version = "0.1.7", optional = true }
 
 [target.avr-atmega2560.dependencies]
-atomic-polyfill = { git="https://github.com/mutantbob/atomic-polyfill.git", branch="main", optional = true }
+atomic-polyfill = { version = "0.1.7", optional = true }
 
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,9 @@ atomic-polyfill = { git="https://github.com/mutantbob/atomic-polyfill.git", bran
 [target.avr-atmega328p.dependencies]
 atomic-polyfill = { git="https://github.com/mutantbob/atomic-polyfill.git", branch="main", optional = true }
 
+[target.avr-atmega2560.dependencies]
+atomic-polyfill = { git="https://github.com/mutantbob/atomic-polyfill.git", branch="main", optional = true }
+
 
 [dependencies]
 hash32 = "0.2.1"

--- a/build.rs
+++ b/build.rs
@@ -23,10 +23,15 @@ fn main() -> Result<(), Box<dyn Error>> {
         println!("cargo:rustc-cfg=armv7a");
     }
 
+    let is_avr = env::var("CARGO_CFG_TARGET_ARCH") == Ok("avr".to_string());
+
     // built-in targets with no atomic / CAS support as of nightly-2022-01-13
     // AND not supported by the atomic-polyfill crate
     // see the `no-atomics.sh` / `no-cas.sh` script sitting next to this file
-    match &target[..] {
+    if is_avr {
+        // lacks cas
+    } else {
+        match &target[..] {
         "avr-unknown-gnu-atmega328"
         | "bpfeb-unknown-none"
         | "bpfel-unknown-none"
@@ -40,11 +45,14 @@ fn main() -> Result<(), Box<dyn Error>> {
         _ => {
             println!("cargo:rustc-cfg=has_cas");
         }
+    }
     };
 
-    match &target[..] {
-        "avr-unknown-gnu-atmega328"
-        | "msp430-none-elf"
+    if is_avr {
+        // lacks atomics
+    } else {
+        match &target[..] {
+        "msp430-none-elf"
         // | "riscv32i-unknown-none-elf"    // supported by atomic-polyfill
         // | "riscv32imc-unknown-none-elf"  // supported by atomic-polyfill
         => {}
@@ -52,23 +60,26 @@ fn main() -> Result<(), Box<dyn Error>> {
         _ => {
             println!("cargo:rustc-cfg=has_atomics");
         }
+    }
     };
 
     // Let the code know if it should use atomic-polyfill or not, and what aspects
     // of polyfill it requires
-    match &target[..] {
-        "riscv32i-unknown-none-elf"
-        | "riscv32imc-unknown-none-elf"
-        | "avr-atmega328p"
-        | "avr-atmega2560" => {
-            println!("cargo:rustc-cfg=full_atomic_polyfill");
-            println!("cargo:rustc-cfg=cas_atomic_polyfill");
-        }
+    if is_avr {
+        println!("cargo:rustc-cfg=full_atomic_polyfill");
+        println!("cargo:rustc-cfg=cas_atomic_polyfill");
+    } else {
+        match &target[..] {
+            "riscv32i-unknown-none-elf" | "riscv32imc-unknown-none-elf" => {
+                println!("cargo:rustc-cfg=full_atomic_polyfill");
+                println!("cargo:rustc-cfg=cas_atomic_polyfill");
+            }
 
-        "thumbv6m-none-eabi" => {
-            println!("cargo:rustc-cfg=cas_atomic_polyfill");
+            "thumbv6m-none-eabi" => {
+                println!("cargo:rustc-cfg=cas_atomic_polyfill");
+            }
+            _ => {}
         }
-        _ => {}
     }
 
     if !matches!(

--- a/build.rs
+++ b/build.rs
@@ -43,6 +43,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     match &target[..] {
         "avr-unknown-gnu-atmega328"
         | "msp430-none-elf"
+        | "avr-atmega328p"
         // | "riscv32i-unknown-none-elf"    // supported by atomic-polyfill
         // | "riscv32imc-unknown-none-elf"  // supported by atomic-polyfill
         => {}
@@ -55,7 +56,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     // Let the code know if it should use atomic-polyfill or not, and what aspects
     // of polyfill it requires
     match &target[..] {
-        "riscv32i-unknown-none-elf" | "riscv32imc-unknown-none-elf" => {
+        "riscv32i-unknown-none-elf" | "riscv32imc-unknown-none-elf" | "avr-atmega328p" => {
             println!("cargo:rustc-cfg=full_atomic_polyfill");
             println!("cargo:rustc-cfg=cas_atomic_polyfill");
         }

--- a/build.rs
+++ b/build.rs
@@ -44,6 +44,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         "avr-unknown-gnu-atmega328"
         | "msp430-none-elf"
         | "avr-atmega328p"
+        | "avr-atmega2560"
         // | "riscv32i-unknown-none-elf"    // supported by atomic-polyfill
         // | "riscv32imc-unknown-none-elf"  // supported by atomic-polyfill
         => {}
@@ -56,7 +57,10 @@ fn main() -> Result<(), Box<dyn Error>> {
     // Let the code know if it should use atomic-polyfill or not, and what aspects
     // of polyfill it requires
     match &target[..] {
-        "riscv32i-unknown-none-elf" | "riscv32imc-unknown-none-elf" | "avr-atmega328p" => {
+        "riscv32i-unknown-none-elf"
+        | "riscv32imc-unknown-none-elf"
+        | "avr-atmega328p"
+        | "avr-atmega2560" => {
             println!("cargo:rustc-cfg=full_atomic_polyfill");
             println!("cargo:rustc-cfg=cas_atomic_polyfill");
         }

--- a/build.rs
+++ b/build.rs
@@ -45,8 +45,6 @@ fn main() -> Result<(), Box<dyn Error>> {
     match &target[..] {
         "avr-unknown-gnu-atmega328"
         | "msp430-none-elf"
-        | "avr-atmega328p"
-        | "avr-atmega2560"
         // | "riscv32i-unknown-none-elf"    // supported by atomic-polyfill
         // | "riscv32imc-unknown-none-elf"  // supported by atomic-polyfill
         => {}

--- a/src/sorted_linked_list.rs
+++ b/src/sorted_linked_list.rs
@@ -180,6 +180,9 @@ macro_rules! impl_index_and_const_new {
 
 impl_index_and_const_new!(LinkedIndexU8, u8, new_u8, 254); // val is 2^8 - 2 (one less than max)
 impl_index_and_const_new!(LinkedIndexU16, u16, new_u16, 65_534); // val is 2^16 - 2
+#[cfg(target_pointer_width = "16")]
+impl_index_and_const_new!(LinkedIndexUsize, usize, new_usize, 65_534); // val is 2^16 - 2
+#[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
 impl_index_and_const_new!(LinkedIndexUsize, usize, new_usize, 4_294_967_294); // val is 2^32 - 2
 
 impl<T, Idx, K, const N: usize> SortedLinkedList<T, Idx, K, N>

--- a/src/sorted_linked_list.rs
+++ b/src/sorted_linked_list.rs
@@ -180,9 +180,7 @@ macro_rules! impl_index_and_const_new {
 
 impl_index_and_const_new!(LinkedIndexU8, u8, new_u8, { u8::MAX as usize - 1 });
 impl_index_and_const_new!(LinkedIndexU16, u16, new_u16, { u16::MAX as usize - 1 });
-impl_index_and_const_new!(LinkedIndexUsize, usize, new_usize, {
-    usize::MAX as usize - 1
-});
+impl_index_and_const_new!(LinkedIndexUsize, usize, new_usize, { usize::MAX - 1 });
 
 impl<T, Idx, K, const N: usize> SortedLinkedList<T, Idx, K, N>
 where

--- a/src/sorted_linked_list.rs
+++ b/src/sorted_linked_list.rs
@@ -95,7 +95,7 @@ where
 
 // Internal macro for generating indexes for the linkedlist and const new for the linked list
 macro_rules! impl_index_and_const_new {
-    ($name:ident, $ty:ty, $new_name:ident, $max_val:literal) => {
+    ($name:ident, $ty:ty, $new_name:ident, $max_val:expr) => {
         /// Index for the [`SortedLinkedList`] with specific backing storage.
         #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
         pub struct $name($ty);
@@ -178,12 +178,11 @@ macro_rules! impl_index_and_const_new {
     };
 }
 
-impl_index_and_const_new!(LinkedIndexU8, u8, new_u8, 254); // val is 2^8 - 2 (one less than max)
-impl_index_and_const_new!(LinkedIndexU16, u16, new_u16, 65_534); // val is 2^16 - 2
-#[cfg(target_pointer_width = "16")]
-impl_index_and_const_new!(LinkedIndexUsize, usize, new_usize, 65_534); // val is 2^16 - 2
-#[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
-impl_index_and_const_new!(LinkedIndexUsize, usize, new_usize, 4_294_967_294); // val is 2^32 - 2
+impl_index_and_const_new!(LinkedIndexU8, u8, new_u8, { u8::MAX as usize - 1 });
+impl_index_and_const_new!(LinkedIndexU16, u16, new_u16, { u16::MAX as usize - 1 });
+impl_index_and_const_new!(LinkedIndexUsize, usize, new_usize, {
+    usize::MAX as usize - 1
+});
 
 impl<T, Idx, K, const N: usize> SortedLinkedList<T, Idx, K, N>
 where


### PR DESCRIPTION
This patch includes changes I needed to build my Arduino Uno sketches.  I incorporated the work from https://github.com/japaric/heapless/pull/264 to reduce the chance of conflicts.

Now that atomic-polyfill 0.1.8 supports AVR, things are a bit easier.
