### PR TITLE
update TSAN supressions file

### DIFF
--- a/suppressions.txt
+++ b/suppressions.txt
@@ -4,4 +4,7 @@ race:*drop_slow*
 race:__call_tls_dtors
 
 # false positives in scoped_threadpool (?)
-race:*drop*
+race:call_once*scoped_threadpool
+race:drop*scoped_threadpool
+race:scoped_threadpool*cgu
+race:scoped_threadpool::


### PR DESCRIPTION
to catch false positives in newer version of scoped_threadpool

this change is required to prevent this snippet triggering a TSAN error (data race)
``` rust
// scoped_threadpool = "0.1.9"

use scoped_threadpool::Pool;

fn main() {
    Pool::new(2).scoped(move |scope| {
        scope.execute(move || {});
        scope.execute(move || {});
    });
}
```