### PR TITLE
use std::thread::scope instead of scoped_threadpool

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,9 +27,6 @@ mpmc_large = []
 # This flag has no version guarantee, the `defmt` dependency can be updated in a patch release
 defmt-impl = ["defmt"]
 
-[target.'cfg(not(target_os = "none"))'.dev-dependencies]
-scoped_threadpool = "0.1.8"
-
 [target.thumbv6m-none-eabi.dependencies]
 atomic-polyfill = { version = "0.1.2", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,5 +62,8 @@ version = "0.1"
 version = ">=0.2.0,<0.4"
 optional = true
 
+[build-dependencies]
+rustc_version = "0.4.0"
+
 [package.metadata.docs.rs]
 all-features = true

--- a/build.rs
+++ b/build.rs
@@ -2,6 +2,8 @@
 
 use std::{env, error::Error};
 
+use rustc_version::Channel;
+
 fn main() -> Result<(), Box<dyn Error>> {
     let target = env::var("TARGET")?;
 
@@ -64,6 +66,13 @@ fn main() -> Result<(), Box<dyn Error>> {
             println!("cargo:rustc-cfg=cas_atomic_polyfill");
         }
         _ => {}
+    }
+
+    if !matches!(
+        rustc_version::version_meta().unwrap().channel,
+        Channel::Stable | Channel::Beta
+    ) {
+        println!("cargo:rustc-cfg=unstable_channel");
     }
 
     Ok(())

--- a/suppressions.txt
+++ b/suppressions.txt
@@ -1,2 +1,7 @@
 race:std::panic::catch_unwind
 race:std::thread::scope
+
+# std::thread::spawn false positive; seen on Ubuntu 20.04 but not on Arch Linux (2022-04-29)
+race:drop_in_place*JoinHandle
+race:alloc::sync::Arc<*>::drop_slow
+race:__call_tls_dtors

--- a/suppressions.txt
+++ b/suppressions.txt
@@ -1,7 +1,2 @@
-# false positives in thread::spawn (?)
-race:*dealloc
-race:*drop_slow*
-race:__call_tls_dtors
-
-# false positives in scoped_threadpool (?)
-race:*drop*
+race:std::panic::catch_unwind
+race:std::thread::scope

--- a/tests/tsan.rs
+++ b/tests/tsan.rs
@@ -1,11 +1,11 @@
-#![feature(scoped_threads)]
+#![cfg_attr(unstable_channel, feature(scoped_threads))]
 #![deny(rust_2018_compatibility)]
 #![deny(rust_2018_idioms)]
 #![deny(warnings)]
 
-use std::{sync::mpsc, thread};
+use std::thread;
 
-use heapless::{mpmc::Q64, spsc};
+use heapless::spsc;
 
 #[test]
 fn once() {
@@ -51,6 +51,7 @@ fn twice() {
 }
 
 #[test]
+#[cfg(unstable_channel)]
 fn scoped() {
     let mut rb: spsc::Queue<i32, 5> = spsc::Queue::new();
 
@@ -75,6 +76,7 @@ fn scoped() {
 
 #[test]
 #[cfg_attr(miri, ignore)] // too slow
+#[cfg(unstable_channel)]
 fn contention() {
     const N: usize = 1024;
 
@@ -120,7 +122,12 @@ fn contention() {
 
 #[test]
 #[cfg_attr(miri, ignore)] // too slow
+#[cfg(unstable_channel)]
 fn mpmc_contention() {
+    use std::sync::mpsc;
+
+    use heapless::mpmc::Q64;
+
     const N: u32 = 64;
 
     static Q: Q64<u32> = Q64::new();
@@ -166,6 +173,7 @@ fn mpmc_contention() {
 
 #[test]
 #[cfg_attr(miri, ignore)] // too slow
+#[cfg(unstable_channel)]
 fn unchecked() {
     const N: usize = 1024;
 

--- a/tests/tsan.rs
+++ b/tests/tsan.rs
@@ -254,7 +254,7 @@ fn pool() {
 
     A::grow(unsafe { &mut M });
 
-    thread::pool(move |scope| {
+    thread::scope(move |scope| {
         scope.spawn(move || {
             for _ in 0..N / 4 {
                 let a = A::alloc().unwrap();


### PR DESCRIPTION
as it's easier to deal with TSAN false positives in the former API

as it surfaced in PR #280 the current supression rules don't handle newer versions of the
`scoped_threadpool` crate

trying to update the supression rules related to `scoped_threadpool` in PR #282 revealed that the
supression rules are masking (hiding) real data races:
https://github.com/japaric/heapless/pull/282#issuecomment-1113173358

`std::thread::scope` requires less supression rules and does not mask real data races -- for instance,
the data race in the linked issue comment is not masked when using `std::thread::scope`

tradeoffs:
- pro: one less dev dependency but added a small build dependency
- pro: supressions file is simpler
- cons: `std::thread::scope` is only available on recent nightlies but the API is only used in tests so it doesn't affect the MSRV