### PR TITLE
[breaking-change] use hash32 v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- [breaking-change] `IndexMap` and `IndexSet` now require that keys implement the `core::hash::Hash`
+  trait instead of the `hash32::Hash` (v0.2.0) trait
+
 ### Fixed
 
 ## [v0.7.16] - 2022-08-09

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ atomic-polyfill = { version = "0.1.4" }
 atomic-polyfill = { version = "0.1.8", optional = true }
 
 [dependencies]
-hash32 = "0.2.1"
+hash32 = "0.3.0"
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 spin = "0.9.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["static", "no-heap"]
 license = "MIT OR Apache-2.0"
 name = "heapless"
 repository = "https://github.com/japaric/heapless"
-version = "0.7.16"
+version = "0.8.0"
 
 [features]
 default = ["cas"]

--- a/src/de.rs
+++ b/src/de.rs
@@ -1,8 +1,12 @@
 use crate::{
     binary_heap::Kind as BinaryHeapKind, BinaryHeap, IndexMap, IndexSet, LinearMap, String, Vec,
 };
-use core::{fmt, marker::PhantomData};
-use hash32::{BuildHasherDefault, Hash, Hasher};
+use core::{
+    fmt,
+    hash::{Hash, Hasher},
+    marker::PhantomData,
+};
+use hash32::BuildHasherDefault;
 use serde::de::{self, Deserialize, Deserializer, Error, MapAccess, SeqAccess};
 
 // Sequential containers

--- a/src/indexmap.rs
+++ b/src/indexmap.rs
@@ -1,6 +1,14 @@
-use core::{borrow::Borrow, fmt, iter::FromIterator, mem, num::NonZeroU32, ops, slice};
+use core::{
+    borrow::Borrow,
+    fmt,
+    hash::{BuildHasher, Hash, Hasher as _},
+    iter::FromIterator,
+    mem,
+    num::NonZeroU32,
+    ops, slice,
+};
 
-use hash32::{BuildHasher, BuildHasherDefault, FnvHasher, Hash, Hasher};
+use hash32::{BuildHasherDefault, FnvHasher};
 
 use crate::Vec;
 

--- a/src/indexset.rs
+++ b/src/indexset.rs
@@ -1,6 +1,11 @@
 use crate::indexmap::{self, IndexMap};
-use core::{borrow::Borrow, fmt, iter::FromIterator};
-use hash32::{BuildHasher, BuildHasherDefault, FnvHasher, Hash};
+use core::{
+    borrow::Borrow,
+    fmt,
+    hash::{BuildHasher, Hash},
+    iter::FromIterator,
+};
+use hash32::{BuildHasherDefault, FnvHasher};
 
 /// A [`heapless::IndexSet`](./struct.IndexSet.html) using the
 /// default FNV hasher.

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -1,7 +1,8 @@
+use core::hash::{BuildHasher, Hash};
+
 use crate::{
     binary_heap::Kind as BinaryHeapKind, BinaryHeap, IndexMap, IndexSet, LinearMap, String, Vec,
 };
-use hash32::{BuildHasher, Hash};
 use serde::ser::{Serialize, SerializeMap, SerializeSeq, Serializer};
 
 // Sequential containers

--- a/src/spsc.rs
+++ b/src/spsc.rs
@@ -451,18 +451,6 @@ where
     }
 }
 
-impl<T, const N: usize> hash32::Hash for Queue<T, N>
-where
-    T: hash32::Hash,
-{
-    fn hash<H: hash32::Hasher>(&self, state: &mut H) {
-        // iterate over self in order
-        for t in self.iter() {
-            hash32::Hash::hash(t, state);
-        }
-    }
-}
-
 impl<'a, T, const N: usize> IntoIterator for &'a Queue<T, N> {
     type Item = &'a T;
     type IntoIter = Iter<'a, T, N>;
@@ -590,8 +578,9 @@ impl<'a, T, const N: usize> Producer<'a, T, N> {
 
 #[cfg(test)]
 mod tests {
+    use std::hash::{Hash, Hasher};
+
     use crate::spsc::Queue;
-    use hash32::Hasher;
 
     #[test]
     fn full() {
@@ -892,13 +881,13 @@ mod tests {
         };
         let hash1 = {
             let mut hasher1 = hash32::FnvHasher::default();
-            hash32::Hash::hash(&rb1, &mut hasher1);
+            rb1.hash(&mut hasher1);
             let hash1 = hasher1.finish();
             hash1
         };
         let hash2 = {
             let mut hasher2 = hash32::FnvHasher::default();
-            hash32::Hash::hash(&rb2, &mut hasher2);
+            rb2.hash(&mut hasher2);
             let hash2 = hasher2.finish();
             hash2
         };

--- a/src/string.rs
+++ b/src/string.rs
@@ -1,7 +1,5 @@
 use core::{cmp::Ordering, fmt, fmt::Write, hash, iter, ops, str};
 
-use hash32;
-
 use crate::Vec;
 
 /// A fixed capacity [`String`](https://doc.rust-lang.org/std/string/struct.String.html)
@@ -361,13 +359,6 @@ impl<const N: usize> hash::Hash for String<N> {
     #[inline]
     fn hash<H: hash::Hasher>(&self, hasher: &mut H) {
         <str as hash::Hash>::hash(self, hasher)
-    }
-}
-
-impl<const N: usize> hash32::Hash for String<N> {
-    #[inline]
-    fn hash<H: hash32::Hasher>(&self, hasher: &mut H) {
-        <str as hash32::Hash>::hash(self, hasher)
     }
 }
 

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -2,7 +2,6 @@ use core::{
     cmp::Ordering, convert::TryFrom, fmt, hash, iter::FromIterator, mem::MaybeUninit, ops, ptr,
     slice,
 };
-use hash32;
 
 /// A fixed capacity [`Vec`](https://doc.rust-lang.org/std/vec/struct.Vec.html)
 ///
@@ -895,15 +894,6 @@ where
 {
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
         <[T] as hash::Hash>::hash(self, state)
-    }
-}
-
-impl<T, const N: usize> hash32::Hash for Vec<T, N>
-where
-    T: hash32::Hash,
-{
-    fn hash<H: hash32::Hasher>(&self, state: &mut H) {
-        <[T] as hash32::Hash>::hash(self, state)
     }
 }
 


### PR DESCRIPTION
this release of `hash32` has the advantage that 32-bit hashers can be used to hash types that
implement the `core::hash::Hash` trait removing the need for the `hash32::Hash` implementations in
this crate and the uses of the `#[derive(Hash32)]` macro (which did not support enums) in dependent
crates

with this change the following code works
``` rust
// NOTE no derive(Hash32)
#[derive(Hash)]
struct Int(i32);

let mut x = FnvIndexSet::<_, 4>::default();
let _ = x.insert(Int(0));
```

this change is technically a breaking change because the following code is no longer accepted

``` rust
// assume this type comes from a dependency
// NOTE no derive(Hash)
#[derive(Hash32)]
struct Int(i32);

let mut x = FnvIndexSet::<_, 4>::default();
let _ = x.insert(Int(0)); // error: does not implement Hash
```