### PR TITLE
implement memory pool using LL/SC operations

### DIFF
--- a/src/pool/llsc-arm.rs
+++ b/src/pool/llsc-arm.rs
@@ -1,0 +1,85 @@
+//! Stack based on LL/SC atomics
+
+pub use core::ptr::NonNull as Ptr;
+use core::{cell::UnsafeCell, ptr};
+
+/// Unfortunate implementation detail required to use the
+/// [`Pool.grow_exact`](struct.Pool.html#method.grow_exact) method
+pub struct Node<T> {
+    next: Option<Ptr<Node<T>>>,
+    pub(crate) data: UnsafeCell<T>,
+}
+
+pub struct Stack<T> {
+    top: Option<Ptr<Node<T>>>,
+}
+
+impl<T> Stack<T> {
+    pub const fn new() -> Self {
+        Self { top: None }
+    }
+
+    pub fn push(&self, mut node: Ptr<Node<T>>) {
+        unsafe {
+            let top_addr = ptr::addr_of!(self.top) as *mut usize;
+            loop {
+                let top = arch::load_link(top_addr);
+                node.as_mut().next = Ptr::new(top as *mut _);
+                if arch::store_conditional(node.as_ptr() as usize, top_addr).is_ok() {
+                    break;
+                }
+            }
+        }
+    }
+
+    pub fn try_pop(&self) -> Option<Ptr<Node<T>>> {
+        unsafe {
+            let top_addr = ptr::addr_of!(self.top) as *mut usize;
+            loop {
+                let top = arch::load_link(top_addr);
+                if let Some(top) = Ptr::<Node<T>>::new(top as *mut _) {
+                    let next = top.as_ref().next;
+                    if arch::store_conditional(
+                        next.map(|nn| nn.as_ptr() as usize).unwrap_or_default(),
+                        top_addr,
+                    )
+                    .is_ok()
+                    {
+                        break Some(top);
+                    }
+                } else {
+                    arch::clear_load_link();
+                    break None;
+                }
+            }
+        }
+    }
+}
+
+#[cfg(target_arch = "arm")]
+mod arch {
+    use core::arch::asm;
+
+    #[inline(always)]
+    pub unsafe fn clear_load_link() {
+        asm!("clrex", options(nomem, nostack));
+    }
+
+    #[inline(always)]
+    pub unsafe fn load_link(addr: *const usize) -> usize {
+        let value;
+        asm!("ldrex {}, [{}]", out(reg) value, in(reg) addr, options(nostack));
+        value
+    }
+
+    #[inline(always)]
+    pub unsafe fn store_conditional(value: usize, addr: *mut usize) -> Result<(), ()> {
+        let outcome: usize;
+        asm!("strex {}, {}, [{}]", out(reg) outcome, in(reg) value, in(reg) addr, options(nostack));
+        if outcome == 0 {
+            Ok(())
+        } else {
+            Err(())
+        }
+    }
+}

--- a/src/pool/mod.rs
+++ b/src/pool/mod.rs
@@ -254,9 +254,17 @@ use stack::{Ptr, Stack};
 pub mod singleton;
 #[cfg_attr(any(target_arch = "x86_64", target_arch = "x86"), path = "cas.rs")]
 #[cfg_attr(
-    not(any(target_arch = "x86_64", target_arch = "x86")),
+    not(any(
+        target_arch = "x86_64",
+        target_arch = "x86",
+        armv7a,
+        armv7r,
+        armv7m,
+        armv8m_main
+    )),
     path = "llsc.rs"
 )]
+#[cfg_attr(any(armv7a, armv7r, armv7m, armv8m_main), path = "llsc-arm.rs")]
 mod stack;
 
 /// A lock-free memory pool


### PR DESCRIPTION
this changes the implementation of the underlying Treiber Stack to use LDREX and STREX on
Cortex-v7A/R/M. other architectures are left unchanged in this PR. in principle, RISC-V could be
implemented in a similar fashion but haven't tested that yet

this does bump the MSRV so it's technically a breaking change ...

to make this easier to maintain I'd like to drop the llsc.rs and make pool only available on targets
where it implements Sync *and* it's sound but that's a API breaking change. there are other API
breaking changes I'd like to make (e.g. remove the Uninit type state) so I'll write a RFC first

fixes #180