### PR TITLE
remove unsafe from Droppable test helper

### DIFF
--- a/src/binary_heap.rs
+++ b/src/binary_heap.rs
@@ -582,7 +582,7 @@ mod tests {
             v.pop().unwrap();
         }
 
-        assert_eq!(unsafe { COUNT }, 0);
+        assert_eq!(Droppable::count(), 0);
 
         {
             let mut v: BinaryHeap<Droppable, Max, 2> = BinaryHeap::new();
@@ -590,7 +590,7 @@ mod tests {
             v.push(Droppable::new()).ok().unwrap();
         }
 
-        assert_eq!(unsafe { COUNT }, 0);
+        assert_eq!(Droppable::count(), 0);
 
         {
             let mut v: BinaryHeap<Droppable, Min, 2> = BinaryHeap::new();
@@ -599,7 +599,7 @@ mod tests {
             v.pop().unwrap();
         }
 
-        assert_eq!(unsafe { COUNT }, 0);
+        assert_eq!(Droppable::count(), 0);
 
         {
             let mut v: BinaryHeap<Droppable, Min, 2> = BinaryHeap::new();
@@ -607,7 +607,7 @@ mod tests {
             v.push(Droppable::new()).ok().unwrap();
         }
 
-        assert_eq!(unsafe { COUNT }, 0);
+        assert_eq!(Droppable::count(), 0);
     }
 
     #[test]

--- a/src/deque.rs
+++ b/src/deque.rs
@@ -565,29 +565,6 @@ mod tests {
         let mut _v: Deque<i32, 4> = Deque::new();
     }
 
-    macro_rules! droppable {
-        () => {
-            struct Droppable;
-            impl Droppable {
-                fn new() -> Self {
-                    unsafe {
-                        COUNT += 1;
-                    }
-                    Droppable
-                }
-            }
-            impl Drop for Droppable {
-                fn drop(&mut self) {
-                    unsafe {
-                        COUNT -= 1;
-                    }
-                }
-            }
-
-            static mut COUNT: i32 = 0;
-        };
-    }
-
     #[test]
     fn drop() {
         droppable!();
@@ -599,7 +576,7 @@ mod tests {
             v.pop_front().unwrap();
         }
 
-        assert_eq!(unsafe { COUNT }, 0);
+        assert_eq!(Droppable::count(), 0);
 
         {
             let mut v: Deque<Droppable, 2> = Deque::new();
@@ -607,14 +584,14 @@ mod tests {
             v.push_back(Droppable::new()).ok().unwrap();
         }
 
-        assert_eq!(unsafe { COUNT }, 0);
+        assert_eq!(Droppable::count(), 0);
         {
             let mut v: Deque<Droppable, 2> = Deque::new();
             v.push_front(Droppable::new()).ok().unwrap();
             v.push_front(Droppable::new()).ok().unwrap();
         }
 
-        assert_eq!(unsafe { COUNT }, 0);
+        assert_eq!(Droppable::count(), 0);
     }
 
     #[test]
@@ -754,7 +731,7 @@ mod tests {
             let _ = items.next();
         }
 
-        assert_eq!(unsafe { COUNT }, 0);
+        assert_eq!(Droppable::count(), 0);
 
         {
             let mut deque: Deque<Droppable, 2> = Deque::new();
@@ -764,7 +741,7 @@ mod tests {
             // Move none
         }
 
-        assert_eq!(unsafe { COUNT }, 0);
+        assert_eq!(Droppable::count(), 0);
 
         {
             let mut deque: Deque<Droppable, 2> = Deque::new();
@@ -774,7 +751,7 @@ mod tests {
             let _ = items.next(); // Move partly
         }
 
-        assert_eq!(unsafe { COUNT }, 0);
+        assert_eq!(Droppable::count(), 0);
     }
 
     #[test]

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -1,23 +1,23 @@
 macro_rules! droppable {
     () => {
+        static COUNT: core::sync::atomic::AtomicI32 = core::sync::atomic::AtomicI32::new(0);
+
         #[derive(Eq, Ord, PartialEq, PartialOrd)]
         struct Droppable(i32);
         impl Droppable {
             fn new() -> Self {
-                unsafe {
-                    COUNT += 1;
-                    Droppable(COUNT)
-                }
+                COUNT.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+                Droppable(Self::count())
+            }
+
+            fn count() -> i32 {
+                COUNT.load(core::sync::atomic::Ordering::Relaxed)
             }
         }
         impl Drop for Droppable {
             fn drop(&mut self) {
-                unsafe {
-                    COUNT -= 1;
-                }
+                COUNT.fetch_sub(1, core::sync::atomic::Ordering::Relaxed);
             }
         }
-
-        static mut COUNT: i32 = 0;
     };
 }

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -912,7 +912,7 @@ mod tests {
             v.pop().unwrap();
         }
 
-        assert_eq!(unsafe { COUNT }, 0);
+        assert_eq!(Droppable::count(), 0);
 
         {
             let mut v: Vec<Droppable, 2> = Vec::new();
@@ -920,7 +920,7 @@ mod tests {
             v.push(Droppable::new()).ok().unwrap();
         }
 
-        assert_eq!(unsafe { COUNT }, 0);
+        assert_eq!(Droppable::count(), 0);
     }
 
     #[test]
@@ -1055,7 +1055,7 @@ mod tests {
             let _ = items.next();
         }
 
-        assert_eq!(unsafe { COUNT }, 0);
+        assert_eq!(Droppable::count(), 0);
 
         {
             let mut vec: Vec<Droppable, 2> = Vec::new();
@@ -1065,7 +1065,7 @@ mod tests {
             // Move none
         }
 
-        assert_eq!(unsafe { COUNT }, 0);
+        assert_eq!(Droppable::count(), 0);
 
         {
             let mut vec: Vec<Droppable, 2> = Vec::new();
@@ -1075,7 +1075,7 @@ mod tests {
             let _ = items.next(); // Move partly
         }
 
-        assert_eq!(unsafe { COUNT }, 0);
+        assert_eq!(Droppable::count(), 0);
     }
 
     #[test]


### PR DESCRIPTION
it's safe to assume that test platforms have CAS operations available