### PR TITLE
unconditionally depend on atomic-polyfill for riscv32i target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,7 @@ jobs:
           - nightly
         features:
           - ""
+          - "cas"
           - "serde"
     steps:
       - name: Checkout
@@ -92,7 +93,7 @@ jobs:
         with:
           use-cross: false
           command: check
-          args: --target=${{ matrix.target }} --features=${{ matrix.features }}
+          args: --target=${{ matrix.target }} --no-default-features --features=${{ matrix.features }}
 
   # Run cpass tests
   testcpass:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 * Optimize the codegen of `Vec::clone`
+* `riscv32i` targets unconditionally (`no-default-features`) depends on `atomic-polyfill`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 * Optimize the codegen of `Vec::clone`
-* `riscv32i` targets unconditionally (`no-default-features`) depends on `atomic-polyfill`
+* `riscv32i` and `riscv32imc` targets unconditionally (e.g. `build --no-default-features`) depends on `atomic-polyfill`
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ defmt-impl = ["defmt"]
 atomic-polyfill = { version = "0.1.2", optional = true }
 
 [target.riscv32i-unknown-none-elf.dependencies]
-atomic-polyfill = { version = "0.1.4", optional = true }
+atomic-polyfill = { version = "0.1.4" }
 
 [target.riscv32imc-unknown-none-elf.dependencies]
 atomic-polyfill = { version = "0.1.4", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ atomic-polyfill = { version = "0.1.2", optional = true }
 atomic-polyfill = { version = "0.1.4" }
 
 [target.riscv32imc-unknown-none-elf.dependencies]
-atomic-polyfill = { version = "0.1.4", optional = true }
+atomic-polyfill = { version = "0.1.4" }
 
 [dependencies]
 hash32 = "0.2.1"


### PR DESCRIPTION
due to a limitation in the llvm backend [1] the `riscv32i-unknown-none-elf` target lacks the `core::sync::atomic` API even though the actual hardware is capable of atomic loads and stores (`fence` instruction). thus, at this point in time, this target needs `atomic-polyfill` for a working SPSC implementation

[1]: https://github.com/knurling-rs/defmt/issues/597#issuecomment-934467023

fixes #271 
closes #272 
closes #273 