### PR TITLE
compile-time check power of two invariant in Index{Set,Map}'s default method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- `IndexSet` and `IndexMap`'s `default` method now compile time checks that their capacity is a power of two.
+
 ## [v0.7.13] - 2022-05-16
 
 ### Added

--- a/src/indexmap.rs
+++ b/src/indexmap.rs
@@ -952,6 +952,10 @@ where
     S: BuildHasher + Default,
 {
     fn default() -> Self {
+        // Const assert
+        crate::sealed::greater_than_1::<N>();
+        crate::sealed::power_of_two::<N>();
+
         IndexMap {
             build_hasher: <_>::default(),
             core: CoreMap::new(),


### PR DESCRIPTION
closes #295

I tested this manually with both `FnvIndexSet` and `FnvIndexMap`. I tried to add a compile fail test but discovered (the hard way) that all the const assert trickery in `sealed` is checked when the code is built with `cargo build` but *not* when the code is built with `cargo check`. As `trybuild` uses `cargo check` under the hood it's not possible to compile fail test any of those const asserts.

r? @korken89 