### PR TITLE
Add clarification in String

### DIFF
--- a/src/string.rs
+++ b/src/string.rs
@@ -10,7 +10,7 @@ pub struct String<const N: usize> {
 }
 
 impl<const N: usize> String<N> {
-    /// Constructs a new, empty `String` with a fixed capacity of `N`
+    /// Constructs a new, empty `String` with a fixed capacity of `N` bytes
     ///
     /// # Examples
     ///


### PR DESCRIPTION
Needed to look into implementation to be sure String was allocating bytes not chars.