### PR TITLE
Make the docs build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fixed some broken links in the documentation.
+
 ## [v0.7.15] - 2022-07-05
 
 ### Added

--- a/src/mpmc.rs
+++ b/src/mpmc.rs
@@ -1,7 +1,8 @@
 //! A fixed capacity Multiple-Producer Multiple-Consumer (MPMC) lock-free queue
 //!
 //! NOTE: This module is not available on targets that do *not* support CAS operations and are not
-//! emulated by the [`atomic_polyfill`] crate (e.g., MSP430).
+//! emulated by the [`atomic_polyfill`](https://crates.io/crates/atomic-polyfill) crate (e.g.,
+//! MSP430).
 //!
 //! # Example
 //!
@@ -75,9 +76,11 @@
 //! # Portability
 //!
 //! This module requires CAS atomic instructions which are not available on all architectures
-//! (e.g.  ARMv6-M (`thumbv6m-none-eabi`) and MSP430 (`msp430-none-elf`)). These atomics can be emulated
-//! however with [`atomic_polyfill`], which is enabled with the `cas` feature and is enabled by default
-//! for `thumbv6m-none-eabi` and `riscv32` targets. MSP430 is currently not supported by [`atomic_polyfill`].
+//! (e.g.  ARMv6-M (`thumbv6m-none-eabi`) and MSP430 (`msp430-none-elf`)). These atomics can be
+//! emulated however with [`atomic_polyfill`](https://crates.io/crates/atomic-polyfill), which is
+//! enabled with the `cas` feature and is enabled by default for `thumbv6m-none-eabi` and `riscv32`
+//! targets. MSP430 is currently not supported by
+//! [`atomic_polyfill`](https://crates.io/crates/atomic-polyfill).
 //!
 //! # References
 //!

--- a/src/pool/mod.rs
+++ b/src/pool/mod.rs
@@ -1,7 +1,8 @@
 //! A heap-less, interrupt-safe, lock-free memory pool (\*)
 //!
 //! NOTE: This module is not available on targets that do *not* support CAS operations and are not
-//! emulated by the [`atomic_polyfill`] crate (e.g., MSP430).
+//! emulated by the [`atomic_polyfill`](https://crates.io/crates/atomic-polyfill) crate (e.g.,
+//! MSP430).
 //!
 //! (\*) Currently, the implementation is only lock-free *and* `Sync` on ARMv6, ARMv7-{A,R,M} & ARMv8-M
 //! devices
@@ -64,10 +65,12 @@
 //! on the target architecture (see section on ['Soundness'](#soundness) for more information). For
 //! this reason, `Pool` only implements `Sync` when compiling for some ARM cores.
 //!
-//! This module requires CAS atomic instructions which are not available on all architectures
-//! (e.g.  ARMv6-M (`thumbv6m-none-eabi`) and MSP430 (`msp430-none-elf`)). These atomics can be emulated
-//! however with [`atomic_polyfill`], which is enabled with the `cas` feature and is enabled by default
-//! for `thumbv6m-none-eabi` and `riscv32` targets. MSP430 is currently not supported by [`atomic_polyfill`].
+//! This module requires CAS atomic instructions which are not available on all architectures (e.g.
+//! ARMv6-M (`thumbv6m-none-eabi`) and MSP430 (`msp430-none-elf`)). These atomics can be emulated
+//! however with [`atomic_polyfill`](https://crates.io/crates/atomic-polyfill), which is enabled
+//! with the `cas` feature and is enabled by default for `thumbv6m-none-eabi` and `riscv32` targets.
+//! MSP430 is currently not supported by
+//! [`atomic_polyfill`](https://crates.io/crates/atomic-polyfill).
 //!
 //! # Soundness
 //!

--- a/src/spsc.rs
+++ b/src/spsc.rs
@@ -3,7 +3,7 @@
 //! Implementation based on <https://www.codeproject.com/Articles/43510/Lock-Free-Single-Producer-Single-Consumer-Circular>
 //!
 //! NOTE: This module is not available on targets that do *not* support atomic loads and are not
-//! supported by [`atomic_polyfill`]. (e.g., MSP430).
+//! supported by [`atomic_polyfill`](https://crates.io/crates/atomic-polyfill). (e.g., MSP430).
 //!
 //! # Examples
 //!

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -624,13 +624,13 @@ impl<T, const N: usize> Vec<T, N> {
     /// shifting all elements after it to the left.
     ///
     /// Note: Because this shifts over the remaining elements, it has a
-    /// worst-case performance of *O*(*n*). If you don't need the order of elements
-    /// to be preserved, use [`swap_remove`] instead. If you'd like to remove
-    /// elements from the beginning of the `Vec`, consider using
-    /// [`VecDeque::pop_front`] instead.
+    /// worst-case performance of *O*(*n*). If you don't need the order of
+    /// elements to be preserved, use [`swap_remove`] instead. If you'd like to
+    /// remove elements from the beginning of the `Vec`, consider using
+    /// [`Deque::pop_front`] instead.
     ///
     /// [`swap_remove`]: Vec::swap_remove
-    /// [`VecDeque::pop_front`]: crate::VecDeque::pop_front
+    /// [`Deque::pop_front`]: crate::Deque::pop_front
     ///
     /// # Panics
     ///


### PR DESCRIPTION
Turns out there were some broken links and `#![deny(warnings)]` in the crate root.