### PR TITLE
switch to atomic-polyfill-1.0.0 on AVR to get around old code in critical-section

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,20 +1,58 @@
 name: Build
 on:
   pull_request:
+    branches: [main]
   push:
-    branches:
-      - master
-      - staging
-      - trying
+    branches: [staging, trying]
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  # Run MIRI tests on nightly
+  # NOTE first because it takes the longest to complete
+  testmiri:
+    name: testmiri
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Cache cargo dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            - ~/.cargo/bin/
+            - ~/.cargo/registry/index/
+            - ~/.cargo/registry/cache/
+            - ~/.cargo/git/db/
+          key: ${{ runner.OS }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.OS }}-cargo-
+
+      - name: Cache build output dependencies
+        uses: actions/cache@v2
+        with:
+          path: target
+          key: ${{ runner.OS }}-build-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.OS }}-build-
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          target: x86_64-unknown-linux-gnu
+          components: miri
+          override: true
+
+      - name: Run miri
+        run: MIRIFLAGS=-Zmiri-ignore-leaks cargo miri test
+
   # Run cargo fmt --check
   style:
     name: style
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v1
@@ -36,7 +74,7 @@ jobs:
   # Compilation check
   check:
     name: check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         target:
@@ -95,10 +133,62 @@ jobs:
           command: check
           args: --target=${{ matrix.target }} --no-default-features --features=${{ matrix.features }}
 
+  doc:
+    name: doc
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+          - x86_64-unknown-linux-gnu
+          - thumbv7m-none-eabi
+        features:
+          - ""
+          - "cas"
+          - "serde"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Cache cargo dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            - ~/.cargo/bin/
+            - ~/.cargo/registry/index/
+            - ~/.cargo/registry/cache/
+            - ~/.cargo/git/db/
+          key: ${{ runner.OS }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.OS }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+            ${{ runner.OS }}-cargo-
+
+      - name: Cache build output dependencies
+        uses: actions/cache@v2
+        with:
+          path: target
+          key: ${{ runner.OS }}-build-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.OS }}-build-${{ hashFiles('**/Cargo.lock') }}
+            ${{ runner.OS }}-build-
+
+      - name: Install stable Rust with target (${{ matrix.target }})
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: ${{ matrix.target }}
+          override: true
+
+      - name: cargo doc
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: false
+          command: doc
+          args: --target=${{ matrix.target }} --no-default-features --features=${{ matrix.features }}
+
   # Run cpass tests
   testcpass:
     name: testcpass
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         target:
@@ -107,7 +197,6 @@ jobs:
         toolchain:
           - stable
           - nightly
-          - 1.51.0
         features:
           - serde
         buildtype:
@@ -154,7 +243,7 @@ jobs:
   # Run test suite for UI
   testtsan:
     name: testtsan
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         target:
@@ -212,7 +301,7 @@ jobs:
   # Run cfail tests on MSRV
   testcfail:
     name: testcfail
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: cfail
@@ -244,7 +333,7 @@ jobs:
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.51.0
+          toolchain: stable
           target: x86_64-unknown-linux-gnu
           override: true
 
@@ -252,44 +341,6 @@ jobs:
         run: cargo run
 
 
-  # Run MIRI tests on nightly
-  testmiri:
-    name: testmiri
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Cache cargo dependencies
-        uses: actions/cache@v2
-        with:
-          path: |
-            - ~/.cargo/bin/
-            - ~/.cargo/registry/index/
-            - ~/.cargo/registry/cache/
-            - ~/.cargo/git/db/
-          key: ${{ runner.OS }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.OS }}-cargo-
-
-      - name: Cache build output dependencies
-        uses: actions/cache@v2
-        with:
-          path: target
-          key: ${{ runner.OS }}-build-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.OS }}-build-
-
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          target: x86_64-unknown-linux-gnu
-          components: miri
-          override: true
-
-      - name: Run miri
-        run: MIRIFLAGS=-Zmiri-ignore-leaks cargo miri test
 
   # Refs: https://github.com/rust-lang/crater/blob/9ab6f9697c901c4a44025cf0a39b73ad5b37d198/.github/workflows/bors.yml#L125-L149
   #
@@ -301,10 +352,12 @@ jobs:
     needs:
       - style
       - check
+      - doc
       - testcpass
       - testtsan
       - testcfail
-    runs-on: ubuntu-20.04
+      - testmiri
+    runs-on: ubuntu-latest
     steps:
       - name: Mark the job as a success
         run: exit 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [v0.7.16] - 2022-08-09
+
+### Added
+
 - add more `PartialEq` implementations to `Vec` where `Vec` is the RHS
 
 ### Changed
 
 ### Fixed
 
+- clarify in the docs that the capacity `heapless::String` is in bytes, not characters
 - Fixed some broken links in the documentation.
 
 ## [v0.7.15] - 2022-07-05
@@ -509,7 +518,8 @@ architecture.
 
 - Initial release
 
-[Unreleased]: https://github.com/japaric/heapless/compare/v0.7.15...HEAD
+[Unreleased]: https://github.com/japaric/heapless/compare/v0.7.16...HEAD
+[v0.7.16]: https://github.com/japaric/heapless/compare/v0.7.15...v0.7.16
 [v0.7.15]: https://github.com/japaric/heapless/compare/v0.7.14...v0.7.15
 [v0.7.14]: https://github.com/japaric/heapless/compare/v0.7.13...v0.7.14
 [v0.7.13]: https://github.com/japaric/heapless/compare/v0.7.12...v0.7.13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- add more `PartialEq` implementations to `Vec` where `Vec` is the RHS
+
 ### Changed
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- [breaking-change] `IndexMap` and `IndexSet` now require that keys implement the `core::hash::Hash`
+  trait instead of the `hash32::Hash` (v0.2.0) trait
+
 ### Fixed
+
+### Removed
+
+- [breaking-change] this crate no longer has a Minimum Supported Rust Version (MSRV) guarantee and
+  should be used with the latest stable version of the Rust toolchain.
 
 ## [v0.7.16] - 2022-08-09
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ atomic-polyfill = { version = "0.1.4" }
 atomic-polyfill = { version = "0.1.4" }
 
 [target.'cfg(target_arch = "avr")'.dependencies]
-atomic-polyfill = { version = "0.1.8", optional = true }
+atomic-polyfill = { version = "1.0.1", optional = true }
 
 [dependencies]
 hash32 = "0.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["static", "no-heap"]
 license = "MIT OR Apache-2.0"
 name = "heapless"
 repository = "https://github.com/japaric/heapless"
-version = "0.7.16"
+version = "0.8.0"
 
 [features]
 default = ["cas"]
@@ -40,7 +40,7 @@ atomic-polyfill = { version = "0.1.4" }
 atomic-polyfill = { version = "1.0.1", optional = true }
 
 [dependencies]
-hash32 = "0.2.1"
+hash32 = "0.3.0"
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 spin = "0.9.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["static", "no-heap"]
 license = "MIT OR Apache-2.0"
 name = "heapless"
 repository = "https://github.com/japaric/heapless"
-version = "0.7.15"
+version = "0.7.16"
 
 [features]
 default = ["cas"]

--- a/cfail/ui/freeze.stderr
+++ b/cfail/ui/freeze.stderr
@@ -1,9 +1,9 @@
 error[E0499]: cannot borrow `q` as mutable more than once at a time
- --> $DIR/freeze.rs:7:5
+ --> ui/freeze.rs:7:5
   |
 6 |     let (_p, mut _c) = q.split();
-  |                        - first mutable borrow occurs here
+  |                        --------- first mutable borrow occurs here
 7 |     q.enqueue(0).unwrap();
-  |     ^ second mutable borrow occurs here
+  |     ^^^^^^^^^^^^ second mutable borrow occurs here
 8 |     _c.dequeue();
-  |     -- first borrow later used here
+  |     ------------ first borrow later used here

--- a/cfail/ui/not-send.stderr
+++ b/cfail/ui/not-send.stderr
@@ -1,44 +1,42 @@
 error[E0277]: `*const ()` cannot be sent between threads safely
-  --> $DIR/not-send.rs:19:5
+  --> ui/not-send.rs:19:5
    |
-12 | fn is_send<T>()
-   |    ------- required by a bound in this
-13 | where
-14 |     T: Send,
-   |        ---- required by this bound in `is_send`
-...
 19 |     is_send::<Consumer<NotSend, 4>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `*const ()` cannot be sent between threads safely
    |
    = help: within `PhantomData<*const ()>`, the trait `Send` is not implemented for `*const ()`
    = note: required because it appears within the type `PhantomData<*const ()>`
    = note: required because of the requirements on the impl of `Send` for `Consumer<'_, PhantomData<*const ()>, 4_usize>`
-
-error[E0277]: `*const ()` cannot be sent between threads safely
-  --> $DIR/not-send.rs:20:5
+note: required by a bound in `is_send`
+  --> ui/not-send.rs:14:8
    |
 12 | fn is_send<T>()
    |    ------- required by a bound in this
 13 | where
 14 |     T: Send,
-   |        ---- required by this bound in `is_send`
-...
+   |        ^^^^ required by this bound in `is_send`
+
+error[E0277]: `*const ()` cannot be sent between threads safely
+  --> ui/not-send.rs:20:5
+   |
 20 |     is_send::<Producer<NotSend, 4>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `*const ()` cannot be sent between threads safely
    |
    = help: within `PhantomData<*const ()>`, the trait `Send` is not implemented for `*const ()`
    = note: required because it appears within the type `PhantomData<*const ()>`
    = note: required because of the requirements on the impl of `Send` for `Producer<'_, PhantomData<*const ()>, 4_usize>`
-
-error[E0277]: `*const ()` cannot be sent between threads safely
-  --> $DIR/not-send.rs:21:5
+note: required by a bound in `is_send`
+  --> ui/not-send.rs:14:8
    |
 12 | fn is_send<T>()
    |    ------- required by a bound in this
 13 | where
 14 |     T: Send,
-   |        ---- required by this bound in `is_send`
-...
+   |        ^^^^ required by this bound in `is_send`
+
+error[E0277]: `*const ()` cannot be sent between threads safely
+  --> ui/not-send.rs:21:5
+   |
 21 |     is_send::<Queue<NotSend, 4>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `*const ()` cannot be sent between threads safely
    |
@@ -49,16 +47,18 @@ error[E0277]: `*const ()` cannot be sent between threads safely
    = note: required because it appears within the type `UnsafeCell<MaybeUninit<PhantomData<*const ()>>>`
    = note: required because it appears within the type `[UnsafeCell<MaybeUninit<PhantomData<*const ()>>>; 4]`
    = note: required because it appears within the type `Queue<PhantomData<*const ()>, 4_usize>`
-
-error[E0277]: `*const ()` cannot be sent between threads safely
-  --> $DIR/not-send.rs:22:5
+note: required by a bound in `is_send`
+  --> ui/not-send.rs:14:8
    |
 12 | fn is_send<T>()
    |    ------- required by a bound in this
 13 | where
 14 |     T: Send,
-   |        ---- required by this bound in `is_send`
-...
+   |        ^^^^ required by this bound in `is_send`
+
+error[E0277]: `*const ()` cannot be sent between threads safely
+  --> ui/not-send.rs:22:5
+   |
 22 |     is_send::<Vec<NotSend, 4>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ `*const ()` cannot be sent between threads safely
    |
@@ -68,16 +68,18 @@ error[E0277]: `*const ()` cannot be sent between threads safely
    = note: required because it appears within the type `MaybeUninit<PhantomData<*const ()>>`
    = note: required because it appears within the type `[MaybeUninit<PhantomData<*const ()>>; 4]`
    = note: required because it appears within the type `heapless::Vec<PhantomData<*const ()>, 4_usize>`
-
-error[E0277]: `*const ()` cannot be sent between threads safely
-  --> $DIR/not-send.rs:23:5
+note: required by a bound in `is_send`
+  --> ui/not-send.rs:14:8
    |
 12 | fn is_send<T>()
    |    ------- required by a bound in this
 13 | where
 14 |     T: Send,
-   |        ---- required by this bound in `is_send`
-...
+   |        ^^^^ required by this bound in `is_send`
+
+error[E0277]: `*const ()` cannot be sent between threads safely
+  --> ui/not-send.rs:23:5
+   |
 23 |     is_send::<HistoryBuffer<NotSend, 4>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `*const ()` cannot be sent between threads safely
    |
@@ -87,3 +89,11 @@ error[E0277]: `*const ()` cannot be sent between threads safely
    = note: required because it appears within the type `MaybeUninit<PhantomData<*const ()>>`
    = note: required because it appears within the type `[MaybeUninit<PhantomData<*const ()>>; 4]`
    = note: required because it appears within the type `HistoryBuffer<PhantomData<*const ()>, 4_usize>`
+note: required by a bound in `is_send`
+  --> ui/not-send.rs:14:8
+   |
+12 | fn is_send<T>()
+   |    ------- required by a bound in this
+13 | where
+14 |     T: Send,
+   |        ^^^^ required by this bound in `is_send`

--- a/src/de.rs
+++ b/src/de.rs
@@ -1,8 +1,12 @@
 use crate::{
     binary_heap::Kind as BinaryHeapKind, BinaryHeap, IndexMap, IndexSet, LinearMap, String, Vec,
 };
-use core::{fmt, marker::PhantomData};
-use hash32::{BuildHasherDefault, Hash, Hasher};
+use core::{
+    fmt,
+    hash::{Hash, Hasher},
+    marker::PhantomData,
+};
+use hash32::BuildHasherDefault;
 use serde::de::{self, Deserialize, Deserializer, Error, MapAccess, SeqAccess};
 
 // Sequential containers

--- a/src/indexmap.rs
+++ b/src/indexmap.rs
@@ -1,6 +1,14 @@
-use core::{borrow::Borrow, fmt, iter::FromIterator, mem, num::NonZeroU32, ops, slice};
+use core::{
+    borrow::Borrow,
+    fmt,
+    hash::{BuildHasher, Hash, Hasher as _},
+    iter::FromIterator,
+    mem,
+    num::NonZeroU32,
+    ops, slice,
+};
 
-use hash32::{BuildHasher, BuildHasherDefault, FnvHasher, Hash, Hasher};
+use hash32::{BuildHasherDefault, FnvHasher};
 
 use crate::Vec;
 

--- a/src/indexset.rs
+++ b/src/indexset.rs
@@ -1,6 +1,11 @@
 use crate::indexmap::{self, IndexMap};
-use core::{borrow::Borrow, fmt, iter::FromIterator};
-use hash32::{BuildHasher, BuildHasherDefault, FnvHasher, Hash};
+use core::{
+    borrow::Borrow,
+    fmt,
+    hash::{BuildHasher, Hash},
+    iter::FromIterator,
+};
+use hash32::{BuildHasherDefault, FnvHasher};
 
 /// A [`heapless::IndexSet`](./struct.IndexSet.html) using the
 /// default FNV hasher.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,8 +64,11 @@
 //!
 //! # Minimum Supported Rust Version (MSRV)
 //!
-//! This crate is guaranteed to compile on stable Rust 1.51 and up with its default set of features.
-//! It *might* compile on older versions but that may change in any new patch release.
+//! This crate does *not* have a Minimum Supported Rust Version (MSRV) and may make use of language
+//! features and API in the standard library available in the latest stable Rust version.
+//!
+//! In other words, changes in the Rust version requirement of this crate are not considered semver
+//! breaking change and may occur in patch version releases.
 
 #![cfg_attr(not(test), no_std)]
 #![deny(missing_docs)]

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -1,7 +1,8 @@
+use core::hash::{BuildHasher, Hash};
+
 use crate::{
     binary_heap::Kind as BinaryHeapKind, BinaryHeap, IndexMap, IndexSet, LinearMap, String, Vec,
 };
-use hash32::{BuildHasher, Hash};
 use serde::ser::{Serialize, SerializeMap, SerializeSeq, Serializer};
 
 // Sequential containers

--- a/src/spsc.rs
+++ b/src/spsc.rs
@@ -451,18 +451,6 @@ where
     }
 }
 
-impl<T, const N: usize> hash32::Hash for Queue<T, N>
-where
-    T: hash32::Hash,
-{
-    fn hash<H: hash32::Hasher>(&self, state: &mut H) {
-        // iterate over self in order
-        for t in self.iter() {
-            hash32::Hash::hash(t, state);
-        }
-    }
-}
-
 impl<'a, T, const N: usize> IntoIterator for &'a Queue<T, N> {
     type Item = &'a T;
     type IntoIter = Iter<'a, T, N>;
@@ -590,8 +578,9 @@ impl<'a, T, const N: usize> Producer<'a, T, N> {
 
 #[cfg(test)]
 mod tests {
+    use std::hash::{Hash, Hasher};
+
     use crate::spsc::Queue;
-    use hash32::Hasher;
 
     #[test]
     fn full() {
@@ -892,13 +881,13 @@ mod tests {
         };
         let hash1 = {
             let mut hasher1 = hash32::FnvHasher::default();
-            hash32::Hash::hash(&rb1, &mut hasher1);
+            rb1.hash(&mut hasher1);
             let hash1 = hasher1.finish();
             hash1
         };
         let hash2 = {
             let mut hasher2 = hash32::FnvHasher::default();
-            hash32::Hash::hash(&rb2, &mut hasher2);
+            rb2.hash(&mut hasher2);
             let hash2 = hasher2.finish();
             hash2
         };

--- a/src/string.rs
+++ b/src/string.rs
@@ -1,7 +1,5 @@
 use core::{cmp::Ordering, fmt, fmt::Write, hash, iter, ops, str};
 
-use hash32;
-
 use crate::Vec;
 
 /// A fixed capacity [`String`](https://doc.rust-lang.org/std/string/struct.String.html)
@@ -361,13 +359,6 @@ impl<const N: usize> hash::Hash for String<N> {
     #[inline]
     fn hash<H: hash::Hasher>(&self, hasher: &mut H) {
         <str as hash::Hash>::hash(self, hasher)
-    }
-}
-
-impl<const N: usize> hash32::Hash for String<N> {
-    #[inline]
-    fn hash<H: hash32::Hasher>(&self, hasher: &mut H) {
-        <str as hash32::Hash>::hash(self, hasher)
     }
 }
 

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -2,7 +2,6 @@ use core::{
     cmp::Ordering, convert::TryFrom, fmt, hash, iter::FromIterator, mem::MaybeUninit, ops, ptr,
     slice,
 };
-use hash32;
 
 /// A fixed capacity [`Vec`](https://doc.rust-lang.org/std/vec/struct.Vec.html)
 ///
@@ -895,15 +894,6 @@ where
 {
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
         <[T] as hash::Hash>::hash(self, state)
-    }
-}
-
-impl<T, const N: usize> hash32::Hash for Vec<T, N>
-where
-    T: hash32::Hash,
-{
-    fn hash<H: hash32::Hasher>(&self, state: &mut H) {
-        <[T] as hash32::Hash>::hash(self, state)
     }
 }
 


### PR DESCRIPTION
Should fix https://github.com/japaric/heapless/issues/312