### PR TITLE
impl {Clone, PartialEq} for HistoryBuffer {...}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - [breaking-change] `IndexMap` and `IndexSet` now require that keys implement the `core::hash::Hash`
   trait instead of the `hash32::Hash` (v0.2.0) trait
+- `HistoryBuffer` implements `Clone` and `PartialEq`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Add `Clone` and `PartialEq` implementations to `HistoryBuffer`.
+
 ### Changed
 
 - [breaking-change] `IndexMap` and `IndexSet` now require that keys implement the `core::hash::Hash`
   trait instead of the `hash32::Hash` (v0.2.0) trait
-- `HistoryBuffer` implements `Clone` and `PartialEq`.
 
 ### Fixed
 

--- a/src/histbuf.rs
+++ b/src/histbuf.rs
@@ -244,7 +244,11 @@ where
 {
     fn clone(&self) -> Self {
         let mut ret = Self::new();
-        ret.extend(self.iter().cloned());
+        for (new, old) in ret.data.iter_mut().zip(self.as_slice()) {
+            new.write(old.clone());
+        }
+        ret.filled = self.filled;
+        ret.write_at = self.write_at;
         ret
     }
 }


### PR DESCRIPTION
- `impl Clone for HistoryBuffer`
- `impl PartialEq for HistoryBuffer`

Both are tested fairly rigorously.

Motivation is to use this type in a `yew::Properties` struct, which requires both traits to be implemented.