### PR TITLE
Recover StableDeref trait for pool::object::Object and pool::boxed::Box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added an object pool API. see the `pool::object` module level doc for details
 - Add `HistoryBuffer::as_slices()`
 - Implemented `retain` for `IndexMap` and `IndexSet`.
+- Recover `StableDeref` trait for `pool::object::Object` and `pool::boxed::Box`.
 
 ### Changed
 

--- a/src/pool/boxed.rs
+++ b/src/pool/boxed.rs
@@ -84,6 +84,8 @@ use core::{
     ops, ptr,
 };
 
+use stable_deref_trait::StableDeref;
+
 use super::treiber::{NonNullPtr, Stack, UnionNode};
 
 /// Creates a new `BoxPool` singleton with the given `$name` that manages the specified `$data_type`
@@ -211,6 +213,8 @@ where
         unsafe { &mut *self.node_ptr.as_ptr().cast::<P::Data>() }
     }
 }
+
+unsafe impl<P> StableDeref for Box<P> where P: BoxPool {}
 
 impl<A> fmt::Display for Box<A>
 where

--- a/src/pool/object.rs
+++ b/src/pool/object.rs
@@ -71,6 +71,8 @@ use core::{
     ops, ptr,
 };
 
+use stable_deref_trait::StableDeref;
+
 use super::treiber::{AtomicPtr, NonNullPtr, Stack, StructNode};
 
 /// Creates a new `ObjectPool` singleton with the given `$name` that manages the specified
@@ -219,6 +221,8 @@ where
         unsafe { &mut *ptr::addr_of_mut!((*self.node_ptr.as_ptr()).data) }
     }
 }
+
+unsafe impl<A> StableDeref for Object<A> where A: ObjectPool {}
 
 impl<A> fmt::Display for Object<A>
 where


### PR DESCRIPTION
I add ReadBuffer and WriteBuffer to pool::object::Object and pool::box::Box.
It allows to use embedded DMA of HAL crates, such as [stm32f4xx_hal::dma::Transfer](https://docs.rs/stm32f4xx-hal/latest/stm32f4xx_hal/dma/struct.Transfer.html).