### PR TITLE
Add HistoryBuffer::as_slices()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Add `Clone` and `PartialEq` implementations to `HistoryBuffer`.
 - Added an object pool API. see the `pool::object` module level doc for details
+- Add `HistoryBuffer::as_slices()`
 
 ### Changed
 


### PR DESCRIPTION
This method returns the contents of a HistoryBuffer as two ordered slices, similar to [Deque::as_slices()](https://docs.rs/heapless/0.7.16/heapless/struct.Deque.html#method.as_slices).