### PR TITLE
Export Iter from IndexSet and IndexMap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [breaking-change] changed the target support of memory pool API to only support 32-bit x86 and a
   subset of ARM targets. See the module level documentation of the `pool` module for details
 - relax trait requirements on `IndexMap` and `IndexSet`.
+- export `IndexSet` and `IndexMap` iterator types.
 
 - [breaking-change] this crate now depends on `atomic-polyfill` v1.0.1, meaning that targets that
   require a polyfill need a `critical-section` **v1.x.x** implementation.

--- a/src/indexmap.rs
+++ b/src/indexmap.rs
@@ -1081,6 +1081,10 @@ impl<'a, K, V, S, const N: usize> IntoIterator for &'a mut IndexMap<K, V, S, N> 
     }
 }
 
+/// An iterator over the items of a [`IndexMap`].
+///
+/// This `struct` is created by the [`iter`](IndexMap::iter) method on [`IndexMap`]. See its
+/// documentation for more.
 pub struct Iter<'a, K, V> {
     iter: slice::Iter<'a, Bucket<K, V>>,
 }

--- a/src/indexset.rs
+++ b/src/indexset.rs
@@ -571,6 +571,10 @@ where
     }
 }
 
+/// An iterator over the items of a [`IndexSet`].
+///
+/// This `struct` is created by the [`iter`](IndexSet::iter) method on [`IndexSet`]. See its
+/// documentation for more.
 pub struct Iter<'a, T> {
     iter: indexmap::Iter<'a, T, ()>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,8 +82,10 @@
 pub use binary_heap::BinaryHeap;
 pub use deque::Deque;
 pub use histbuf::{HistoryBuffer, OldestOrdered};
-pub use indexmap::{Bucket, Entry, FnvIndexMap, IndexMap, OccupiedEntry, Pos, VacantEntry};
-pub use indexset::{FnvIndexSet, IndexSet};
+pub use indexmap::{
+    Bucket, Entry, FnvIndexMap, IndexMap, Iter as IndexMapIter, OccupiedEntry, Pos, VacantEntry,
+};
+pub use indexset::{FnvIndexSet, IndexSet, Iter as IndexSetIter};
 pub use linear_map::LinearMap;
 pub use string::String;
 pub use vec::Vec;


### PR DESCRIPTION
Exports the `Iter` types for `IndexSet` and `IndexMap`.

My use case is having a trait generic over a `BTreeSet` and `IndexSet` which has a `type Iter`.