### PR TITLE
Update spin dependency to newer version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ atomic-polyfill = { version = "1.0.1", optional = true }
 hash32 = "0.3.0"
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
-spin = "0.9.2"
+spin = "0.9.4"
 
 [dependencies.serde]
 version = "1"


### PR DESCRIPTION
This updates `spin` to the newest version, this change helps us in one of our repos.