### PR TITLE
export all IndexMap iterators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   subset of ARM targets. See the module level documentation of the `pool` module for details
 - relax trait requirements on `IndexMap` and `IndexSet`.
 - export `IndexSet` and `IndexMap` iterator types.
+- [breaking-change] export `IndexMapKeys`, `IndexMapValues` and
+  `IndexMapValuesMut` iterator types.
 
 - [breaking-change] this crate now depends on `atomic-polyfill` v1.0.1, meaning that targets that
   require a polyfill need a `critical-section` **v1.x.x** implementation.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,9 @@ pub use binary_heap::BinaryHeap;
 pub use deque::Deque;
 pub use histbuf::{HistoryBuffer, OldestOrdered};
 pub use indexmap::{
-    Bucket, Entry, FnvIndexMap, IndexMap, Iter as IndexMapIter, OccupiedEntry, Pos, VacantEntry,
+    Bucket, Entry, FnvIndexMap, IndexMap, Iter as IndexMapIter, IterMut as IndexMapIterMut,
+    Keys as IndexMapKeys, OccupiedEntry, Pos, VacantEntry, Values as IndexMapValues,
+    ValuesMut as IndexMapValuesMut,
 };
 pub use indexset::{FnvIndexSet, IndexSet, Iter as IndexSetIter};
 pub use linear_map::LinearMap;


### PR DESCRIPTION
Exports all the iterator types of `IndexMap`.

I wonder if it'd make sense to have a module structure such as the one in `alloc::collections`, e.g.: `heapless::indexmap` and re-export `heapless::indexmap::IndexMap` on the crate root, to have all the iterator types inside the `indexmap` module but still public.