### PR TITLE
Backport xtensa cas polyfil and bump to 0.7.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+## [v0.7.17] - 2023-12-04
+
+### Added
+
+- Backported cas polyfil for the `xtensa-esp32s2-none-elf` target.
+
 ## [v0.7.16] - 2022-08-09
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["static", "no-heap"]
 license = "MIT OR Apache-2.0"
 name = "heapless"
 repository = "https://github.com/japaric/heapless"
-version = "0.7.16"
+version = "0.7.17"
 
 [features]
 default = ["cas"]
@@ -28,16 +28,19 @@ mpmc_large = []
 defmt-impl = ["defmt"]
 
 [target.thumbv6m-none-eabi.dependencies]
-atomic-polyfill = { version = "0.1.2", optional = true }
+atomic-polyfill = { version = "1", optional = true }
 
 [target.riscv32i-unknown-none-elf.dependencies]
-atomic-polyfill = { version = "0.1.4" }
+atomic-polyfill = { version = "1" }
 
 [target.riscv32imc-unknown-none-elf.dependencies]
-atomic-polyfill = { version = "0.1.4" }
+atomic-polyfill = { version = "1" }
+
+[target.xtensa-esp32s2-none-elf.dependencies]
+atomic-polyfill = { version = "1" }
 
 [target.'cfg(target_arch = "avr")'.dependencies]
-atomic-polyfill = { version = "0.1.8", optional = true }
+atomic-polyfill = { version = "1", optional = true }
 
 [dependencies]
 hash32 = "0.2.1"

--- a/build.rs
+++ b/build.rs
@@ -40,6 +40,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 // | "riscv32imc-unknown-none-elf"  // supported by atomic-polyfill
                 | "thumbv4t-none-eabi"
                 // | "thumbv6m-none-eabi"           // supported by atomic-polyfill
+                // | "xtensa-esp32s2-none-elf"      // supported by atomic-polyfill
                 => {}
 
             _ => {
@@ -55,6 +56,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         "msp430-none-elf"
         // | "riscv32i-unknown-none-elf"    // supported by atomic-polyfill
         // | "riscv32imc-unknown-none-elf"  // supported by atomic-polyfill
+        // | "xtensa-esp32s2-none-elf"  // supported by atomic-polyfill
         => {}
 
         _ => {
@@ -75,7 +77,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 println!("cargo:rustc-cfg=cas_atomic_polyfill");
             }
 
-            "thumbv6m-none-eabi" => {
+            "thumbv6m-none-eabi" | "xtensa-esp32s2-none-elf" => {
                 println!("cargo:rustc-cfg=cas_atomic_polyfill");
             }
             _ => {}


### PR DESCRIPTION
Which includes a backport, see https://github.com/rust-embedded/heapless/issues/422 for details.