### PR TITLE
Queue: implement QueueView on top of #486

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added `LinearMapView`, the `!Sized` version of `LinearMap`.
 - Added `HistoryBufferView`, the `!Sized` version of `HistoryBuffer`.
 - Added `DequeView`, the `!Sized` version of `Deque`.
+- Added `QueueView`, the `!Sized` version of `Queue`.
 
 ### Changed
 

--- a/tests/cpass.rs
+++ b/tests/cpass.rs
@@ -1,8 +1,9 @@
 //! Collections of `Send`-able things are `Send`
 
 use heapless::{
-    spsc::{Consumer, Producer, Queue},
-    HistoryBuffer, Vec,
+    histbuf::HistoryBufferView,
+    spsc::{Consumer, ConsumerView, Producer, ProducerView, Queue, QueueView},
+    HistoryBuffer, Vec, VecView,
 };
 
 #[test]
@@ -13,13 +14,18 @@ fn send() {
 
     fn is_send<T>()
     where
-        T: Send,
+        T: Send + ?Sized,
     {
     }
 
     is_send::<Consumer<IsSend, 4>>();
+    is_send::<ConsumerView<IsSend>>();
     is_send::<Producer<IsSend, 4>>();
+    is_send::<ProducerView<IsSend>>();
     is_send::<Queue<IsSend, 4>>();
+    is_send::<QueueView<IsSend>>();
     is_send::<Vec<IsSend, 4>>();
+    is_send::<VecView<IsSend>>();
     is_send::<HistoryBuffer<IsSend, 4>>();
+    is_send::<HistoryBufferView<IsSend>>();
 }


### PR DESCRIPTION
Like the others, this will maintains backwards compatibility with:

- `capacity` was const so the non-const, generic version is `storage_capacity`,
- `Iter`, `IterMut`, `Consumer`, Producer` were public, so now they are made generic, but they should be made to always use the `View` version in a breaking release

TODO: Add this to #494 when merging