### PR TITLE
 Implements TryFrom for Deque from array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Implement `Default` for `CapacityError`.
 - Implement `defmt::Format` for `CapacityError`.
+- Implement `TryFrom` for `Deque` from array.
 
 ## [v0.9.1] - 2025-08-19
 


### PR DESCRIPTION
Previous reviews and comments can be found in [pull request 524](https://github.com/rust-embedded/heapless/pull/524).

Fixes https://github.com/rust-embedded/heapless/issues/522.

This PR implements the TryFrom trait for creating a Deque from a slice.

Note the use of unsafe for copying all bytes from the slice to the Deque buffer after ensuring that the Deque buffer has enough space.

Also note the use of ManuallyDrop to ensure that any heap memory referred to by the element contents is not dropped at the end of this method since the elements in the Deque buffer will be pointing to it.