### PR TITLE
Allow setting visibility of the pool struct in the `box_pool!` macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 - Make MSRV of 1.87.0 explicit.
+- Allow setting visibility for the pool struct in the `box_pool!` macro.
 
 ## [v0.9.1] - 2025-08-19
 

--- a/src/pool/boxed.rs
+++ b/src/pool/boxed.rs
@@ -64,7 +64,8 @@
 //! use core::ptr::addr_of_mut;
 //! use heapless::{box_pool, pool::boxed::BoxBlock};
 //!
-//! box_pool!(MyBoxPool: u128);
+//! // You can optionally set visibility for the pool struct.
+//! box_pool!(pub MyBoxPool: u128);
 //!
 //! const POOL_CAPACITY: usize = 8;
 //!
@@ -96,8 +97,8 @@ use super::treiber::{NonNullPtr, Stack, UnionNode};
 /// For more extensive documentation see the [module level documentation](crate::pool::boxed)
 #[macro_export]
 macro_rules! box_pool {
-    ($name:ident: $data_type:ty) => {
-        pub struct $name;
+    ($visibility:vis $name:ident: $data_type:ty) => {
+        $visibility struct $name;
 
         impl $crate::pool::boxed::BoxPool for $name {
             type Data = $data_type;


### PR DESCRIPTION
While I think this is a good change, unfortunately it's a breaking change and hence keeping it in draft for now until the next API break (perhaps 1.0).
