### PR TITLE
Switch from `serde` to `serde_core`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Minor fixes to module docs.
 - Make MSRV of 1.87.0 explicit.
-
 - Implement `Default` for `CapacityError`.
 - Implement `defmt::Format` for `CapacityError`.
 - Implement `TryFrom` for `Deque` from array.
+- Switch from `serde` to `serde_core` for enabling faster compilations.
 
 ## [v0.9.1] - 2025-08-19
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ portable-atomic-unsafe-assume-single-core = [
 ]
 
 # implement serde traits.
-serde = ["dep:serde"]
+serde = ["dep:serde_core"]
 
 # implement ufmt traits.
 ufmt = ["dep:ufmt", "dep:ufmt-write"]
@@ -59,7 +59,7 @@ nightly = []
 bytes = { version = "1", default-features = false, optional = true }
 portable-atomic = { version = "1.0", optional = true }
 hash32 = "0.3.0"
-serde = { version = "1", optional = true, default-features = false }
+serde_core = { version = "1", optional = true, default-features = false }
 ufmt = { version = "0.2", optional = true }
 ufmt-write = { version = "0.1", optional = true }
 defmt = { version = "1.0.1", optional = true }

--- a/src/de.rs
+++ b/src/de.rs
@@ -8,7 +8,7 @@ use core::{
     marker::PhantomData,
 };
 use hash32::BuildHasherDefault;
-use serde::de::{self, Deserialize, Deserializer, Error, MapAccess, SeqAccess};
+use serde_core::de::{self, Deserialize, Deserializer, Error, MapAccess, SeqAccess};
 
 // Sequential containers
 
@@ -105,7 +105,7 @@ where
     {
         struct ValueVisitor<'de, T, LenT: LenType, const N: usize>(PhantomData<(&'de (), T, LenT)>);
 
-        impl<'de, T, LenT, const N: usize> serde::de::Visitor<'de> for ValueVisitor<'de, T, LenT, N>
+        impl<'de, T, LenT, const N: usize> serde_core::de::Visitor<'de> for ValueVisitor<'de, T, LenT, N>
         where
             T: Deserialize<'de>,
             LenT: LenType,
@@ -145,7 +145,7 @@ where
     {
         struct ValueVisitor<'de, T, const N: usize>(PhantomData<(&'de (), T)>);
 
-        impl<'de, T, const N: usize> serde::de::Visitor<'de> for ValueVisitor<'de, T, N>
+        impl<'de, T, const N: usize> serde_core::de::Visitor<'de> for ValueVisitor<'de, T, N>
         where
             T: Deserialize<'de>,
         {
@@ -184,7 +184,7 @@ where
     {
         struct ValueVisitor<'de, T, const N: usize>(PhantomData<(&'de (), T)>);
 
-        impl<'de, T, const N: usize> serde::de::Visitor<'de> for ValueVisitor<'de, T, N>
+        impl<'de, T, const N: usize> serde_core::de::Visitor<'de> for ValueVisitor<'de, T, N>
         where
             T: Deserialize<'de>,
         {

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -10,7 +10,7 @@ use crate::{
     vec::{VecInner, VecStorage},
     IndexMap, IndexSet,
 };
-use serde::ser::{Serialize, SerializeMap, SerializeSeq, Serializer};
+use serde_core::ser::{Serialize, SerializeMap, SerializeSeq, Serializer};
 
 // Sequential containers
 


### PR DESCRIPTION
This new split of `serde` crate, enables faster compilation by allowing non-derive needing parts (such as this library) to be compiled in parallel to `serde_derive` crate.
