### PR TITLE
Remove implementing Deref<Target = [T]> for HistoryBuf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Added `resize_with` to `Vec`
 - Added `retain_back` (aka `truncate_front`) to `Deque`
+- Removed `impl Deref` for `HistoryBuf` to make accessing the raw backing array explicit (use `as_slice`).
 
 ## [v0.9.3] 2025-04-15
 

--- a/src/history_buf.rs
+++ b/src/history_buf.rs
@@ -31,7 +31,7 @@
 //! assert_eq!(avg, 4);
 //! ```
 
-use core::{fmt, marker::PhantomData, mem::MaybeUninit, ops::Deref, ptr, slice};
+use core::{fmt, marker::PhantomData, mem::MaybeUninit, ptr, slice};
 
 #[cfg(feature = "zeroize")]
 use zeroize::Zeroize;
@@ -586,18 +586,10 @@ impl<T, S: HistoryBufStorage<T> + ?Sized> Drop for HistoryBufInner<T, S> {
     }
 }
 
-impl<T, S: HistoryBufStorage<T> + ?Sized> Deref for HistoryBufInner<T, S> {
-    type Target = [T];
-
-    fn deref(&self) -> &[T] {
-        self.as_slice()
-    }
-}
-
 impl<T, S: HistoryBufStorage<T> + ?Sized> AsRef<[T]> for HistoryBufInner<T, S> {
     #[inline]
     fn as_ref(&self) -> &[T] {
-        self
+        self.as_slice()
     }
 }
 
@@ -606,7 +598,7 @@ where
     T: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        <[T] as fmt::Debug>::fmt(self, f)
+        <[T] as fmt::Debug>::fmt(self.as_slice(), f)
     }
 }
 
@@ -683,7 +675,6 @@ mod tests {
         let x: HistoryBuf<u8, 4> = HistoryBuf::new_with(1);
         assert_eq!(x.len(), 4);
         assert_eq!(x.as_slice(), [1; 4]);
-        assert_eq!(*x, [1; 4]);
         assert!(x.is_full());
 
         let x: HistoryBuf<u8, 4> = HistoryBuf::new();
@@ -933,8 +924,8 @@ mod tests {
                 x,
                 y,
                 "{:?} {:?}",
-                x.iter().collect::<Vec<_>>(),
-                y.iter().collect::<Vec<_>>()
+                x.as_slice().iter().collect::<Vec<_>>(),
+                y.as_slice().iter().collect::<Vec<_>>()
             );
         }
     }


### PR DESCRIPTION
There is already `as_slice()` which gives access to the underlying backing array where the elements are not in the order of writing.

With automatic dereferencing, functions like `iter()` or `windows()` are automatically available for `HistoryBuf` instances and are returning items in an order which does not reflect the write order and will likely surprise users which did not carefully read all the documentation for `HistoryBuf` like me.