### PR TITLE
removed doc_auto_cfg feature, was merged into doc_cfg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Removed `sorted_linked_list::Iter` and `sorted_linked_list::IterInner`.
 - Removed `sorted_linked_list::FindMut` and `sorted_linked_list::FindMutInner`.
 - The `Q2`, `Q4`, `Q8`, `Q16`, `Q32` and `Q64` aliases for `MpMcQueue` have been removed.
+- `doc_auto_cfg` feature which was merged into `doc_cfg`. Presence of the feature led to doc
+  build failures on nightly.
 
 ## [v0.8.0] - 2023-11-07
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,7 +123,7 @@
 //!
 //! In other words, changes in the Rust version requirement of this crate are not considered semver
 //! breaking change and may occur in patch version releases.
-#![cfg_attr(docsrs, feature(doc_cfg), feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(not(test), no_std)]
 #![deny(missing_docs)]
 #![cfg_attr(


### PR DESCRIPTION
The `doc_auto_cfg` feature was merged into `doc_cfg` by this PR: https://github.com/rust-lang/rust/pull/138907

This leads to doc build failures with nightly compilers.