### PR TITLE
Add truncate and retain(_mut) to Deque

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Implement `TryFrom` for `Deque` from array.
 - Switch from `serde` to `serde_core` for enabling faster compilations.
 - Implement `Zeroize` trait for all data structures with the `zeroize` feature to securely clear sensitive data from memory.
+- Added `truncate` to `Deque`
+- Added `retain` to `Deque`
+- Added `retain_mut` to `Deque`
 
 ## [v0.9.1] - 2025-08-19
 


### PR DESCRIPTION
Howdy!

As I was working on simplifying a crate's logic to fit in a `no_std` context, I found that `Deque` didn't have some of the methods I was using from `alloc`'s implementation.

So I took the time to port them over! Apologies if the comments in `truncate` are a bit much, it was mostly to help me wrap my head around how the data structure itself used its private variables. 

If you spot an error in my logic or if I missed something, please let me know!