### PR TITLE
mpmc: Document #583 and add corresponding loom test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,6 +86,11 @@ jobs:
       - name: Run cargo test
         run: cargo test --features="alloc,defmt,mpmc_large,portable-atomic-critical-section,serde,ufmt,bytes,zeroize,embedded-io-v0.7"
 
+      - name: Run loom tests
+        run: cargo test -- loom
+        continue-on-error: true
+        env:
+          RUSTFLAGS: '--cfg loom'
   # Run cargo fmt --check
   style:
     name: style

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added `truncate` to `Deque`
 - Added `retain` to `Deque`
 - Added `retain_mut` to `Deque`
+- `mpmc::Queue`: document non-lock free behaviour, and add loom tests
 
 ## [v0.9.1] - 2025-08-19
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,9 @@ stable_deref_trait = { version = "1", default-features = false }
 critical-section = { version = "1.1", features = ["std"] }
 static_assertions = "1.1.0"
 
+[target.'cfg(loom)'.dependencies]
+loom = "0.7.2"
+
 [package.metadata.docs.rs]
 features = [
     "bytes",
@@ -93,3 +96,6 @@ features = [
 # for the pool module
 targets = ["i686-unknown-linux-gnu"]
 rustdoc-args = ["--cfg", "docsrs"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(loom)'] }

--- a/tests/tsan.rs
+++ b/tests/tsan.rs
@@ -1,5 +1,6 @@
 #![deny(rust_2018_compatibility)]
 #![deny(rust_2018_idioms)]
+#![cfg(not(loom))]
 
 use std::{ptr::addr_of_mut, thread};
 


### PR DESCRIPTION
This patch documents the issue reported in #583 and adds failing loom tests to exercise #583 hoping that a future algorithm change can make them pass.

The tests are ran in CI but their results is ignored for now as they fail.

Ideally the `loom` tests will cover more usage of `mpmc::Queue` in the future and also cover `spsc`.