### PR TITLE
Pin nightly in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly
+          toolchain: nightly-2025-10-11
           components: miri
 
       - name: Run miri
@@ -95,8 +95,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: nightly
           components: rustfmt
 
       - name: cargo fmt --check
@@ -225,8 +226,9 @@ jobs:
           echo "targets=${targets[*]}" >> "${GITHUB_OUTPUT}"
 
       - name: Install nightly Rust with targets (${{ steps.metadata.outputs.targets }})
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: nightly-2025-10-11
           targets: ${{ steps.metadata.outputs.targets }}
 
       - name: cargo rustdoc
@@ -330,7 +332,7 @@ jobs:
       - name: Install Rust nightly with target (${{ matrix.target }})
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly
+          toolchain: nightly-2025-10-11
           target: ${{ matrix.target }}
           components: rust-src
 


### PR DESCRIPTION
Needs to be done until https://github.com/rust-lang/rust/issues/147648 is resolved.

Example of failed workflow: https://github.com/rust-embedded/heapless/actions/runs/18805787053/job/53659693297?pr=617