### PR TITLE
Document #583 and deprecate `mpmc`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added `FusedIterator` to `vec::IntoIter`, `deque::IntoIter`, `index_map::IntoIter` and `linear_map::IntoIter`.
 - Added `ExactSizeIterator` to `vec::IntoIter`, `deque::IntoIter`, `index_map::IntoIter` and `linear_map::IntoIter`.
 - Added `DoubleEndedIterator` to `vec::IntoIter` and `deque::IntoIter`.
+- Deprecate `mpmc` (see [#583](https://github.com/rust-embedded/heapless/issues/583#issuecomment-3469297720))
 
 ## [v0.9.1] - 2025-08-19
 

--- a/tests/tsan.rs
+++ b/tests/tsan.rs
@@ -122,6 +122,7 @@ fn mpmc_contention() {
 
     const N: u32 = 64;
 
+    #[expect(deprecated)]
     static Q: Queue<u32, 64> = Queue::new();
 
     let (s, r) = mpsc::channel();


### PR DESCRIPTION
This follows the wg meeting conclusions of 28/10/2025