### PR TITLE
Add support for `into_raw` and `from_raw` for Box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added `truncate` to `Deque`
 - Added `retain` to `Deque`
 - Added `retain_mut` to `Deque`
+- Added `into_raw` to `Box`
+- Added `from_raw` to `Box`
 
 ## [v0.9.1] - 2025-08-19
 

--- a/src/pool/treiber/cas.rs
+++ b/src/pool/treiber/cas.rs
@@ -125,6 +125,12 @@ where
         unsafe { Self::new_unchecked(initial_tag(), NonNull::from(reference)) }
     }
 
+    #[inline]
+    pub unsafe fn from_ptr_unchecked(ptr: *mut N) -> Self {
+        debug_assert!(!ptr.is_null(), "Pointer must be non-null");
+        Self::new_unchecked(initial_tag(), NonNull::new_unchecked(ptr))
+    }
+
     /// # Safety
     ///
     /// - `ptr` must be a valid pointer.

--- a/src/pool/treiber/llsc.rs
+++ b/src/pool/treiber/llsc.rs
@@ -46,6 +46,14 @@ where
             inner: NonNull::from(ref_),
         }
     }
+
+    #[inline]
+    pub unsafe fn from_ptr_unchecked(ptr: *mut N) -> Self {
+        debug_assert!(!ptr.is_null(), "Pointer must be non-null");
+        Self {
+            inner: NonNull::new_unchecked(ptr),
+        }
+    }
 }
 
 impl<N> Clone for NonNullPtr<N>


### PR DESCRIPTION
Hi! This PR proposes adding `into_raw()` and `from_raw()` support for `Box` types, similar to what `std::boxed::Box` provides.

While implementing FFI bindings for a resource managed by a BoxPool (with create_resource() / destroy_resource() hooks), I ran into the need for APIs to obtain and reconstruct raw pointers.

I’ve been using this patch for a while in my own project, and it has worked well. It would be great if this functionality could be included upstream.