### PR TITLE
Add `Vec::remove_insert()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 - Added `from_bytes_truncating_at_nul` to `CString`
+- Added `remove_insert` to `Vec`
 
 ## [v0.9.2] 2025-11-12
 


### PR DESCRIPTION
 In patterns where an insertion directly follows a removal, this serves
 as being more efficient, since it only shifts/copies values as needed
 for the combined operation.

 This also comes with the added bonus of not needing to check for
 fullness, and thus, a `Result` is not needed as a return type.