### PR TITLE
add FromUtf8Error in sync with std

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 - Added `from_bytes_truncating_at_nul` to `CString`
+- Added `FromUtf8Error` to `heapless::string`
+- [breaking-change] Changed error type of `String::from_utf8` from `core::str::Utf8Error` to `heapless::string::FromUtf8Error`
 
 ## [v0.9.2] 2025-11-12
 


### PR DESCRIPTION
I'm proposing changing the error type of `String::from_utf8` form `core::str::Utf8Error` to `heapless::string::FromUtf8Error`. This would mirror the error type of `std::String::from_utf8` (which is `std::string::FromUtf8Error`). This is a breaking change.

`FromUtf8Error` has the advantage that you can regain ownership over the data that you want to convert to UTF-8 in case of an error, which you currently lose in that case.
The change would have made it possible for me in #639 to implement `into_string` without unsafe code.