### PR TITLE
deque: Add pop_front_if and pop_back_if

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 - Added `from_bytes_truncating_at_nul` to `CString`
 - Added `CString::{into_bytes, into_bytes_with_nul, into_string}`
+- Added `pop_front_if` and `pop_back_if` to `Deque`
 
 ## [v0.9.2] 2025-11-12
 


### PR DESCRIPTION
This follows the APIs added in today's 1.93 release of Rust. Implementation and tests come from Rust std.