### PR TITLE
Don't panic in VecInner::extend and return a Result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added `from_bytes_truncating_at_nul` to `CString`
 - Added `CString::{into_bytes, into_bytes_with_nul, into_string}`
 - Added `pop_front_if` and `pop_back_if` to `Deque`
+- Replace panicking in `VecInner::extend` with returning a `Result`.
 
 ## [v0.9.2] 2025-11-12
 

--- a/src/linear_map.rs
+++ b/src/linear_map.rs
@@ -586,7 +586,9 @@ where
         I: IntoIterator<Item = (K, V)>,
     {
         let mut out = Self::new();
-        out.buffer.extend(iter);
+        out.buffer
+            .extend(iter)
+            .expect("LinearMap::from_iter overflow");
         out
     }
 }


### PR DESCRIPTION
Other methods for extending VecInner already return results instead of panicking. In case of VecInner::extend, avoiding a panic by checking that the actual amount of elements to extend with fits beforehand is not generally possible.

So attempt to add the elements from the iterator and restore the original length in case of an error.

This is a semver-breaking change.