### PR TITLE
Backport SPSC fixes to 0.8 branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- spsc: Fix integer overflow in iterators when N > usize::MAX/2 and the queue loops.
+- spsc: Fix integer overflow leading to a panic in `len` when N == usize::MAX and debug assertions are enabled.
+
 ## [v0.8.0] - 2023-11-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## [v0.8.1] - 2026-04-15
 
 ### Fixed
 
@@ -569,6 +569,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Initial release
 
 [Unreleased]: https://github.com/rust-embedded/heapless/compare/v0.8.0...HEAD
+[v0.8.1]: https://github.com/rust-embedded/heapless/compare/v0.8.0...v0.8.1
 [v0.8.0]: https://github.com/rust-embedded/heapless/compare/v0.7.16...v0.8.0
 [v0.7.16]: https://github.com/rust-embedded/heapless/compare/v0.7.15...v0.7.16
 [v0.7.15]: https://github.com/rust-embedded/heapless/compare/v0.7.14...v0.7.15

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["static", "no-heap"]
 license = "MIT OR Apache-2.0"
 name = "heapless"
 repository = "https://github.com/rust-embedded/heapless"
-version = "0.8.0"
+version = "0.8.1"
 
 [features]
 # Enable polyfilling of atomics via `portable-atomic`.

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,4 @@
-#![deny(warnings)]
+// #![deny(warnings)]
 
 use std::{
     env,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg), feature(doc_auto_cfg))]
 #![cfg_attr(not(test), no_std)]
 #![deny(missing_docs)]
-#![deny(warnings)]
+//#![deny(warnings)]
 
 pub use binary_heap::BinaryHeap;
 pub use deque::Deque;

--- a/src/spsc.rs
+++ b/src/spsc.rs
@@ -122,7 +122,10 @@ impl<T, const N: usize> Queue<T, N> {
 
     #[inline]
     fn increment(val: usize) -> usize {
-        (val + 1) % N
+        // We know that N <= usize::MAX
+        // So this can only overflow if N == usize::MAX
+        // and in this case the overflow will be equivalent to the modulo N operation
+        val.wrapping_add(1) % N
     }
 
     /// Creates an empty queue with a fixed capacity of `N - 1`
@@ -375,7 +378,11 @@ impl<'a, T, const N: usize> Iterator for Iter<'a, T, N> {
         if self.index < self.len {
             let head = self.rb.head.load(Ordering::Relaxed);
 
-            let i = (head + self.index) % N;
+            let i = match head.checked_add(self.index) {
+                Some(i) if i >= N => i - N,
+                Some(i) => i,
+                None => head.wrapping_add(self.index).wrapping_sub(N),
+            };
             self.index += 1;
 
             Some(unsafe { &*(self.rb.buffer.get_unchecked(i).get() as *const T) })
@@ -392,7 +399,11 @@ impl<'a, T, const N: usize> Iterator for IterMut<'a, T, N> {
         if self.index < self.len {
             let head = self.rb.head.load(Ordering::Relaxed);
 
-            let i = (head + self.index) % N;
+            let i = match head.checked_add(self.index) {
+                Some(i) if i >= N => i - N,
+                Some(i) => i,
+                None => head.wrapping_add(self.index).wrapping_sub(N),
+            };
             self.index += 1;
 
             Some(unsafe { &mut *(self.rb.buffer.get_unchecked(i).get() as *mut T) })
@@ -408,7 +419,11 @@ impl<'a, T, const N: usize> DoubleEndedIterator for Iter<'a, T, N> {
             let head = self.rb.head.load(Ordering::Relaxed);
 
             // self.len > 0, since it's larger than self.index > 0
-            let i = (head + self.len - 1) % N;
+            let i = match head.checked_add(self.len - 1) {
+                Some(i) if i >= N => i - N,
+                Some(i) => i,
+                None => head.wrapping_add(self.len - 1).wrapping_sub(N),
+            };
             self.len -= 1;
             Some(unsafe { &*(self.rb.buffer.get_unchecked(i).get() as *const T) })
         } else {
@@ -423,7 +438,11 @@ impl<'a, T, const N: usize> DoubleEndedIterator for IterMut<'a, T, N> {
             let head = self.rb.head.load(Ordering::Relaxed);
 
             // self.len > 0, since it's larger than self.index > 0
-            let i = (head + self.len - 1) % N;
+            let i = match head.checked_add(self.len - 1) {
+                Some(i) if i >= N => i - N,
+                Some(i) => i,
+                None => head.wrapping_add(self.len - 1).wrapping_sub(N),
+            };
             self.len -= 1;
             Some(unsafe { &mut *(self.rb.buffer.get_unchecked(i).get() as *mut T) })
         } else {
@@ -592,7 +611,10 @@ impl<'a, T, const N: usize> Producer<'a, T, N> {
 mod tests {
     use std::hash::{Hash, Hasher};
 
+    use super::AtomicUsize;
     use crate::spsc::Queue;
+    use core::cell::UnsafeCell;
+    use core::mem::MaybeUninit;
 
     #[test]
     fn full() {
@@ -904,5 +926,75 @@ mod tests {
             hash2
         };
         assert_eq!(hash1, hash2);
+    }
+
+    // Test for some integer overflow bugs. See
+    // https://github.com/rust-embedded/heapless/pull/652#discussion_r3046630717
+    // for more info
+    #[test]
+    #[cfg_attr(miri, ignore)] // too slow
+    fn test_len_overflow() {
+        let mut queue = Queue::<(), { usize::MAX }> {
+            head: AtomicUsize::new(usize::MAX),
+            tail: AtomicUsize::new(2),
+            buffer: [const { UnsafeCell::new(MaybeUninit::new(())) }; usize::MAX],
+        };
+        queue.enqueue(()).unwrap();
+        queue.enqueue(()).unwrap();
+
+        let collected: Vec<_> = queue.iter().collect();
+        assert_eq!(&collected, &[&(); 4]);
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)] // too slow
+    fn test_usize_overflow_iter() {
+        let queue = Queue::<(), { usize::MAX - 1 }> {
+            head: AtomicUsize::new(usize::MAX - 3),
+            tail: AtomicUsize::new(2),
+            buffer: [const { UnsafeCell::new(MaybeUninit::new(())) }; usize::MAX - 1],
+        };
+
+        let collected: Vec<_> = queue.iter().collect();
+        assert_eq!(&collected, &[&(); 4]);
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)] // too slow
+    fn test_usize_overflow_iter_mut() {
+        let mut queue = Queue::<(), { usize::MAX - 1 }> {
+            head: AtomicUsize::new(usize::MAX - 3),
+            tail: AtomicUsize::new(2),
+            buffer: [const { UnsafeCell::new(MaybeUninit::new(())) }; usize::MAX - 1],
+        };
+
+        let collected: Vec<_> = queue.iter_mut().collect();
+        assert_eq!(&collected, &[&(); 4]);
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)] // too slow
+    fn test_usize_overflow_iter_rev() {
+        let queue = Queue::<(), { usize::MAX - 1 }> {
+            head: AtomicUsize::new(usize::MAX - 3),
+            tail: AtomicUsize::new(2),
+            buffer: [const { UnsafeCell::new(MaybeUninit::new(())) }; usize::MAX - 1],
+        };
+
+        let collected: Vec<_> = queue.iter().rev().collect();
+        assert_eq!(&collected, &[&(); 4]);
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)] // too slow
+    fn test_usize_overflow_iter_mut_rev() {
+        let mut queue = Queue::<(), { usize::MAX - 1 }> {
+            head: AtomicUsize::new(usize::MAX - 3),
+            tail: AtomicUsize::new(2),
+            buffer: [const { UnsafeCell::new(MaybeUninit::new(())) }; usize::MAX - 1],
+        };
+
+        let collected: Vec<_> = queue.iter_mut().rev().collect();
+        assert_eq!(&collected, &[&(); 4]);
     }
 }

--- a/tests/tsan.rs
+++ b/tests/tsan.rs
@@ -1,6 +1,6 @@
 #![deny(rust_2018_compatibility)]
 #![deny(rust_2018_idioms)]
-#![deny(warnings)]
+//#![deny(warnings)]
 
 use std::thread;
 


### PR DESCRIPTION
This is being backported because it's a fix to an easy to reach UB if you're ever using N > usize::MAX/2, which could happen on some platforms where usize is 16 bits.

To minimise the differences with 0.8.0 once this is merged I'll release 0.8.1 from commit [0ed6913](https://github.com/rust-embedded/heapless/pull/655/commits/0ed6913214f08c802155885e690c172500de817f)

https://github.com/rust-embedded/heapless/pull/656 should be reviewed and merged first