### PR TITLE
Remove release date.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-## [v0.9.3] 2025-04-15
+## [v0.9.3]
 
 - Fixed unsoundness in `Deque::clear`, `HistoryBuf::clear` and `IndexMap::clear` in the context
 of panicking drop implementations.


### PR DESCRIPTION
Maybe we should just remove the date, since this always requires the release PR to be up-to-date when merged.