### PR TITLE
Add `Vec::resize_with`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Added `resize_with` to `Vec`
+
 ## [v0.9.3] 2025-04-15
 
 - Fixed unsoundness in `Deque::clear`, `HistoryBuf::clear` and `IndexMap::clear` in the context

--- a/src/vec/mod.rs
+++ b/src/vec/mod.rs
@@ -814,7 +814,7 @@ impl<T, LenT: LenType, S: VecStorage<T> + ?Sized> VecInner<T, LenT, S> {
     ///
     /// # Examples
     ///
-    ///```
+    /// ```
     /// use heapless::Vec;
     ///
     /// let mut vec: Vec<usize, 8> = Vec::new();
@@ -823,7 +823,7 @@ impl<T, LenT: LenType, S: VecStorage<T> + ?Sized> VecInner<T, LenT, S> {
     /// let mut p = 1;
     /// vec.resize_with(7, || { p *= 2; p }).unwrap();
     /// assert_eq!(vec, [1, 2, 3, 2, 4, 8, 16]);
-    ///```
+    /// ```
     pub fn resize_with<F>(&mut self, new_len: usize, mut f: F) -> Result<(), CapacityError>
     where
         F: FnMut() -> T,

--- a/src/vec/mod.rs
+++ b/src/vec/mod.rs
@@ -796,7 +796,7 @@ impl<T, LenT: LenType, S: VecStorage<T> + ?Sized> VecInner<T, LenT, S> {
         self.resize(new_len, T::default())
     }
 
-    ///  Resizes the `Vec` in-place to that `len` is equal to `new_len`.
+    ///  Resizes the `Vec` in-place so that `len` is equal to `new_len`.
     ///
     ///  If `new_len` is greater than `len`, the `Vec` is extended by the
     ///  difference, with each additional slot filled with calling the closure

--- a/src/vec/mod.rs
+++ b/src/vec/mod.rs
@@ -762,7 +762,7 @@ impl<T, LenT: LenType, S: VecStorage<T> + ?Sized> VecInner<T, LenT, S> {
     /// difference, with each additional slot filled with value. If
     /// `new_len` is less than len, the Vec is simply truncated.
     ///
-    /// See also [`resize_default`](Self::resize_default).
+    /// See also [`resize_default`](Self::resize_default) and [`resize_with`](Self::resize_with).
     pub fn resize(&mut self, new_len: usize, value: T) -> Result<(), CapacityError>
     where
         T: Clone,
@@ -794,6 +794,58 @@ impl<T, LenT: LenType, S: VecStorage<T> + ?Sized> VecInner<T, LenT, S> {
         T: Clone + Default,
     {
         self.resize(new_len, T::default())
+    }
+
+    ///  Resizes the `Vec` in-place to that `len` is equal to `new_len`.
+    ///
+    ///  If `new_len` is greater than `len`, the `Vec` is extended by the
+    ///  difference, with each additional slot filled with calling the closure
+    ///  `f`. The return value from `f` will end up in the `Vec` in the order they
+    ///  have been generated.
+    ///
+    ///  If `new_len` is less than `len`, the `Vec` is simply truncated.
+    ///
+    /// The method uses a closure to create new values on every push. If you'd
+    /// rather [`Clone`] a given value, use [`Vec::resize`]. If you want to use the
+    /// [`Default`] trait to generate values, use [`Vec::resize_default`].
+    ///
+    /// [`resize`]: Self::resize
+    /// [`resize_default`]: Self::resize_default
+    ///
+    /// # Examples
+    ///
+    ///```
+    /// use heapless::Vec;
+    ///
+    /// let mut vec: Vec<usize, 8> = Vec::new();
+    /// vec.extend_from_slice(&[1, 2, 3]).unwrap();
+    ///
+    /// let mut p = 1;
+    /// vec.resize_with(7, || { p *= 2; p }).unwrap();
+    /// assert_eq!(vec, [1, 2, 3, 2, 4, 8, 16]);
+    ///```
+    pub fn resize_with<F>(&mut self, new_len: usize, mut f: F) -> Result<(), CapacityError>
+    where
+        F: FnMut() -> T,
+    {
+        if new_len > self.capacity() {
+            return Err(CapacityError);
+        }
+
+        if new_len > self.len() {
+            while self.len() < new_len {
+                // SAFETY: `new_len` <= capacity as checked above, and the loop condition
+                // ensures len() < new_len <= capacity, so there it is guaranteed to have
+                // room to push.
+                unsafe {
+                    self.push_unchecked(f());
+                }
+            }
+        } else {
+            self.truncate(new_len);
+        }
+
+        Ok(())
     }
 
     /// Forces the length of the vector to `new_len`.
@@ -2186,6 +2238,86 @@ mod tests {
         // correct value is being written.
         v.resize_default(1).unwrap();
         assert_eq!(v[0], 0);
+    }
+
+    #[test]
+    fn resize_with_size_limit() {
+        let mut v: Vec<u8, 4> = Vec::new();
+        let f = || 0;
+
+        v.resize_with(0, f).unwrap();
+        v.resize_with(4, f).unwrap();
+        v.resize_with(5, f).expect_err("full");
+    }
+
+    #[test]
+    fn resize_with_length_cases() {
+        let mut v: Vec<u8, 4> = Vec::new();
+        let f = || 0;
+
+        assert_eq!(v.len(), 0);
+
+        // Grow by 1
+        v.resize_with(1, f).unwrap();
+        assert_eq!(v.len(), 1);
+
+        // Grow by 2
+        v.resize_with(3, f).unwrap();
+        assert_eq!(v.len(), 3);
+
+        // Resize to current size
+        v.resize_with(3, f).unwrap();
+        assert_eq!(v.len(), 3);
+
+        // Shrink by 1
+        v.resize_with(2, f).unwrap();
+        assert_eq!(v.len(), 2);
+
+        // Shrink by 2
+        v.resize_with(0, f).unwrap();
+        assert_eq!(v.len(), 0);
+    }
+
+    #[test]
+    fn resize_with_contents() {
+        let mut v: Vec<u8, 4> = Vec::new();
+
+        // New entries take the closure's return value when growing
+        v.resize_with(1, || 17).unwrap();
+        assert_eq!(v[0], 17);
+
+        // Old values aren't changed when growing
+        v.resize_with(2, || 18).unwrap();
+        assert_eq!(v[0], 17);
+        assert_eq!(v[1], 18);
+
+        // Old values aren't changed when length unchanged
+        v.resize_with(2, || 0).unwrap();
+        assert_eq!(v[0], 17);
+        assert_eq!(v[1], 18);
+
+        // Old values aren't changed when shrinking
+        v.resize_with(1, || 0).unwrap();
+        assert_eq!(v[0], 17);
+    }
+
+    #[test]
+    fn resize_with_calls_closure_per_slot_in_order() {
+        let mut v: Vec<u8, 8> = Vec::new();
+        v.extend_from_slice(&[1, 2, 3]).unwrap();
+
+        // The closure is called exactly once per new slot, and the values
+        // end up in the Vec in the order they were generated.
+        let mut counter = 0;
+        v.resize_with(7, || {
+            counter += 1;
+            counter
+        })
+        .unwrap();
+
+        assert_eq!(v, [1, 2, 3, 1, 2, 3, 4]);
+        // 4 new slots => closure called exactly 4 times
+        assert_eq!(counter, 4);
     }
 
     #[test]


### PR DESCRIPTION
Closes https://github.com/rust-embedded/heapless/issues/648.

Adds `Vec::resize_with`, the closure-based counterpart to the existing `resize` method, in line with the `std` library `resize_with` method.

This method is valuable when you wish to resize the `Vec` and require some computation for each new element.

### Changes
- `resize_with` method added to `Vec` with documentation specifying when to use each of the `resize` functions.
- Test coverage matching the `resize` method's coverage, as well as coverage for per-slot closure invocation, to test the invariant mentioned in the documentation.