### PR TITLE
Support rustup

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.87.0"


### PR DESCRIPTION
Add `rust-toolchain.toml` that allows users to install the required Rust version using `rustup`.