### PR TITLE
Deque::make_contiguous: don't let `back` become equal to `N`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 - Fixed `IndexMap::truncate` leading to an inconsistent state.
+- Fixed `Deque::make_contigous` leading to an inconsistent state.
 - Added `resize_with` to `Vec`
 - Added `retain_back` (aka `truncate_front`) to `Deque`
 - Fixed unsoundness in `Vec::IntoIter::drop` and `HistoryBuf::write`in the context of panicking drop implementations.

--- a/src/deque.rs
+++ b/src/deque.rs
@@ -504,7 +504,7 @@ impl<T, S: VecStorage<T> + ?Sized> DequeInner<T, S> {
                     // the used part of the buffer now is `0..self.len`, so set
                     // `head` to the beginning of that range.
                     self.front = 0;
-                    self.back = len;
+                    self.back = if free == 0 { 0 } else { len };
                 }
             }
         }
@@ -1807,6 +1807,20 @@ mod tests {
 
         // Deque contains: 5, 6, 7, 8
         assert_eq!(q.as_slices(), ([5, 6, 7, 8].as_slice(), [].as_slice()));
+
+        // Test `make_contiguous` failing to reset back index properly.
+        // See https://github.com/rust-embedded/heapless/issues/676
+        q.clear();
+        for i in 0..4 {
+            q.push_back(i).unwrap();
+        }
+        for i in 4..7 {
+            q.pop_front();
+            q.push_back(i).unwrap();
+        }
+        q.make_contiguous();
+        q.pop_front();
+        q.push_back(99).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
In one branch of `make_contiguous`, `back` was given the value of `len`, which is incorrect and should be `0` when the `Deque` is full

Closes #676 